### PR TITLE
Remove opaque list background in HistoryView

### DIFF
--- a/Sources/Views/Library/HistoryView.swift
+++ b/Sources/Views/Library/HistoryView.swift
@@ -79,6 +79,7 @@ struct HistoryView: View {
                     }
                 }
                 .listStyle(.inset)
+                .scrollContentBackground(.hidden)
             }
 
         }


### PR DESCRIPTION
## Summary
- Add `.scrollContentBackground(.hidden)` to the `List` in `HistoryView.swift` so it blends with the dark glassmorphism theme instead of showing a default opaque lighter rectangle behind history rows.

## Test plan
- [ ] Build succeeds (`xcodebuild build`)
- [ ] Open History tab and verify the list background is transparent, matching the app's dark glass theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)