### PR TITLE
Fix 10 bugs: concurrency, error handling, security, UX

### DIFF
--- a/Sources/Views/Generate/VoiceCloningView.swift
+++ b/Sources/Views/Generate/VoiceCloningView.swift
@@ -336,11 +336,22 @@ struct VoiceCloningView: View {
         }
     }
 
+    private static let allowedAudioExtensions: Set<String> = [
+        "wav", "mp3", "aiff", "aif", "m4a", "flac", "ogg"
+    ]
+
     private func handleDrop(_ providers: [NSItemProvider]) -> Bool {
         guard let provider = providers.first else { return false }
         provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { data, _ in
             guard let data = data as? Data,
                   let url = URL(dataRepresentation: data, relativeTo: nil) else { return }
+            let ext = url.pathExtension.lowercased()
+            guard Self.allowedAudioExtensions.contains(ext) else {
+                Task { @MainActor in
+                    errorMessage = "Unsupported file type '.\(ext)'. Drop an audio file (WAV, MP3, AIFF, M4A, FLAC, or OGG)."
+                }
+                return
+            }
             Task { @MainActor in
                 referenceAudioPath = url.path
                 selectedVoice = nil


### PR DESCRIPTION
## Summary

Fixes 10 real bugs identified during a comprehensive codebase audit across Python backend, Swift services, and UI.

### Concurrency (Tier 1)
- **HuggingFaceDownloader data races**: Added `NSLock` protecting `continuations`, `destinations`, `currentTaskBytesWritten`, and `currentProgressHandler` from concurrent access between caller thread and URLSession delegate queue

### Error Handling (Tier 2)
- **DatabaseService silent failure**: `saveGeneration` now throws `DatabaseServiceError.notInitialized` when `dbQueue` is nil instead of silently dropping data; added `initError` property and warnings on read methods
- **PythonBridge RPC timeout**: `call()` races continuation against a timeout (300s for generation, 10s for ping) using `withThrowingTaskGroup`; added `PythonBridgeError.timeout` case
- **server.py whitespace strip**: `text = (params.get("text") or "").strip()` rejects whitespace-only input before GPU processing

### Security & Correctness (Tier 2-3)
- **delete_voice path traversal**: Applied same `re.sub` sanitization as `enroll_voice` to prevent `../../` attacks
- **clear_cache guard**: Moved `_mx.metal.clear_cache()` to `finally` block with `if _mx is not None:` guard — frees GPU memory even after failures
- **makedirs empty dirname**: Guard `os.makedirs` call when `os.path.dirname(output_path)` returns empty string

### Process Lifecycle & UX (Tier 3)
- **PythonBridge.stop() race**: Captures process reference before nilling, terminates, and waits in a detached task to prevent zombie processes during rapid restart
- **VoiceCloningView drop validation**: `handleDrop()` now validates file extension against allowed audio types (wav, mp3, aiff, m4a, flac, ogg); rejects non-audio with error message
- **LIKE metacharacter escape**: Escapes `%`, `_`, `\` in search queries so they're treated as literals

## Test plan
- [x] `xcodebuild build` succeeds
- [x] App launches, backend shows "Ready"
- [x] All 6 sidebar tabs navigate and render correctly
- [x] Voice Cloning shows REFERENCE AUDIO, drop zone, TRANSCRIPT sections
- [x] History tab loads without crash (database service functional)
- [x] Voices tab accessible (delete_voice path works)
- [x] Models tab renders model listings
- [x] Preferences tab loads settings
- [x] App stable throughout full navigation cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)