### PR TITLE
Add macOS 15 manual release workflow

### DIFF
--- a/.github/workflows/release-macos15.yml
+++ b/.github/workflows/release-macos15.yml
@@ -1,0 +1,114 @@
+name: Release macOS 15
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Branch, tag, or commit to build"
+        required: false
+        default: "main"
+        type: string
+      artifact_label:
+        description: "Optional artifact suffix (appended to artifact name)"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build-release:
+    name: Build Release DMG (macOS 15)
+    runs-on: macos-15
+    timeout-minutes: 120
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_ref }}
+          fetch-depth: 0
+
+      - name: Print build context
+        run: |
+          echo "git_ref input: ${{ inputs.git_ref }}"
+          echo "resolved SHA: $GITHUB_SHA"
+          echo "run ID: $GITHUB_RUN_ID"
+          echo "run number: $GITHUB_RUN_NUMBER"
+
+      - name: Ensure XcodeGen is installed
+        run: |
+          if command -v xcodegen >/dev/null 2>&1; then
+            echo "xcodegen already installed: $(xcodegen --version)"
+          else
+            brew install xcodegen
+            echo "xcodegen installed: $(xcodegen --version)"
+          fi
+
+      - name: Ensure scripts are executable
+        run: chmod +x scripts/*.sh
+
+      - name: Build release pipeline
+        run: ./scripts/release.sh
+
+      - name: Verify bundled dependencies in final app
+        run: |
+          APP_PATH="build/QwenVoice.app"
+          RESOURCES_PATH="$APP_PATH/Contents/Resources"
+
+          test -d "$APP_PATH"
+          test -d "$RESOURCES_PATH"
+          test -x "$RESOURCES_PATH/ffmpeg"
+          test -d "$RESOURCES_PATH/python"
+          test -f "$RESOURCES_PATH/python/.qwenvoice-runtime-manifest.json"
+          test -x "$RESOURCES_PATH/python/bin/python3" || test -x "$RESOURCES_PATH/python/bin/python3.13"
+          test -f "$RESOURCES_PATH/server.py" || test -f "$RESOURCES_PATH/backend/server.py"
+
+          if find "$RESOURCES_PATH" -name "*.whl" -print -quit | grep -q .; then
+            echo "Error: .whl files leaked into app resources"
+            exit 1
+          fi
+          if find "$RESOURCES_PATH" \( -name "*.pyc" -o -type d -name "__pycache__" \) -print -quit | grep -q .; then
+            echo "Error: compiled Python artifacts leaked into app resources"
+            exit 1
+          fi
+
+          ./scripts/verify_release_bundle.sh "$APP_PATH"
+
+      - name: Assert outputs and generate release metadata
+        run: |
+          test -d build/QwenVoice.app
+          test -f build/QwenVoice.dmg
+          shasum -a 256 build/QwenVoice.dmg > build/QwenVoice.dmg.sha256
+
+          {
+            echo "commit_sha=$GITHUB_SHA"
+            echo "git_ref_input=${{ inputs.git_ref }}"
+            echo "run_id=$GITHUB_RUN_ID"
+            echo "run_number=$GITHUB_RUN_NUMBER"
+            echo "built_at_utc=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          } > build/release-metadata.txt
+
+      - name: Compute artifact name
+        run: |
+          name="qwenvoice-macos15-${GITHUB_RUN_NUMBER}"
+          label="${{ inputs.artifact_label }}"
+          if [ -n "$label" ]; then
+            safe_label="$(printf '%s' "$label" | tr -cs 'A-Za-z0-9._-' '-' | sed 's/^-*//; s/-*$//')"
+            if [ -n "$safe_label" ]; then
+              name="${name}-${safe_label}"
+            fi
+          fi
+          echo "ARTIFACT_NAME=$name" >> "$GITHUB_ENV"
+          echo "artifact name: $name"
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          if-no-files-found: error
+          path: |
+            build/QwenVoice.dmg
+            build/QwenVoice.dmg.sha256
+            build/release-metadata.txt


### PR DESCRIPTION
## Summary\nAdds a manual GitHub Actions workflow to build release artifacts on macOS 15 and upload a self-contained DMG artifact.\n\n## What it does\n- workflow_dispatch inputs:  and \n- Runs on \n- Runs === QwenVoice: Release Build ===


[1/8] Bundling Python...
=== QwenVoice: Bundle Python ===

[1/5] Using cached Python download
[2/5] Extracting Python...
    Extracted: Python 3.13.12
[3/5] Installing pip packages...
    Validating core imports...\n- Verifies bundled dependencies in final app (, , manifest, backend script, no leaked wheels/pyc/cache)\n- Runs \n- Produces , checksum, and release metadata\n- Uploads artifacts for manual publishing\n\n## Notes\n cannot be executed until this workflow file exists on the default branch (GitHub API behavior).