### PR TITLE
cleanup/docs-truth: normalize maintained docs and repo boundaries

### DIFF
--- a/.agents/skills/qwenvoice-doc-sync/SKILL.md
+++ b/.agents/skills/qwenvoice-doc-sync/SKILL.md
@@ -44,6 +44,7 @@ Use these pairings as defaults:
 - **Runtime or vendoring behavior**: `docs/reference/vendoring-runtime.md`
 - **Versioned release messaging**: `docs/releases/vX.Y.md`
 - **Repo-local agent guidance**: `.agents/skills/*.md`
+- **Supplemental prose**: `qwen_tone.md` and similar non-reference guides that should follow, not redefine, the maintained docs
 
 If a doc is intentionally user-facing, keep the wording concise and benefit-led. If it is maintainer-facing, keep the wording factual and operational.
 If signing or notarization behavior changed, explicitly re-check the public install path in `README.md` so official releases are described as signed/notarized/stapled and unsigned-build workarounds stay out of the normal install steps.

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@ xcuserdata/
 *.swp
 *~
 
+# Python cache leftovers
+__pycache__/
+*.pyc
+*.pyo
+
 # Dependencies
 Packages/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ The maintained repo docs in this checkout are:
 
 Do not point contributors at missing supplementary docs. Use the maintained files above instead.
 
+Supplemental prose such as `qwen_tone.md` may still be useful, but it is not part of the maintained reference set.
+
 ## Source Of Truth
 
 When repo facts disagree, trust sources in this order:

--- a/README.md
+++ b/README.md
@@ -162,10 +162,12 @@ Use GitHub workflow artifacts for authoritative shipped release validation.
 
 Custom Voice and Voice Design are guided by natural-language instructions rather than SSML-style sliders or markup.
 
-See [`qwen_tone.md`](qwen_tone.md) for the current app-oriented guidance on:
+See [`qwen_tone.md`](qwen_tone.md) for supplemental app- and CLI-oriented guidance on:
 
 - what the shipped app exposes
 - what broader Qwen3-TTS ecosystem notes are informational only
+
+For current repo truth about shipped behavior, trust this README plus [`docs/reference/current-state.md`](docs/reference/current-state.md) over supplemental prose.
 
 ## Architecture
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,21 +2,29 @@
 
 This folder contains the current, repo-authored documentation for QwenVoice.
 
-## Public Docs
-
-- [`../README.md`](../README.md) — GitHub landing page and end-user overview
-- [`../qwen_tone.md`](../qwen_tone.md) — practical guide to tone, emotion, and instruction writing in the shipped app and CLI
-
-## Contributor And Agent Docs
+## Maintained Reference Docs
 
 - [`../AGENTS.md`](../AGENTS.md) — primary repository operating guide for coding agents and maintainers
 - [`reference/current-state.md`](reference/current-state.md) — shared current repo facts reused by the other docs
 - [`reference/engineering-status.md`](reference/engineering-status.md) — current engineering status, cleanup outcomes, and live caveats
 - [`reference/vendoring-runtime.md`](reference/vendoring-runtime.md) — source/debug Python compatibility, backend helper overlay, native packaging, and runtime notes
 
-## CLI Docs
+These are the maintained source-of-truth documents for contributor and repository behavior. When prose disagrees, trust the repo code, manifests, scripts, and then these reference docs in that order.
 
+## Product And Public Docs
+
+- [`../README.md`](../README.md) — GitHub landing page and end-user overview
 - [`../cli/README.md`](../cli/README.md) — standalone CLI usage and setup
+
+## Supplemental Guides
+
+- [`../qwen_tone.md`](../qwen_tone.md) — supplemental tone and prompt-writing guidance for the app and CLI
+
+Supplemental guides are useful, but they are not the primary source of truth for current repo structure or shipped-product behavior.
+
+## Historical Docs
+
+- [`releases/`](releases/) — checked-in release notes for past published versions
 
 ## Repo-Local Skills
 
@@ -24,6 +32,6 @@ This folder contains the current, repo-authored documentation for QwenVoice.
 
 ## Notes
 
-- Maintained contributor guidance in this checkout lives in the files listed above. Do not assume missing supplementary docs still exist.
+- Maintained contributor guidance in this checkout lives in the maintained reference docs listed above. Do not assume missing supplementary docs still exist.
 - Generated and vendor documentation under `Sources/Resources/python/`, `cli/.venv/`, and dependency package directories is intentionally out of scope for the repo docs.
-- Historical notes may still appear in git history or external references, but the maintained repo docs live in the files listed above.
+- Historical notes may still appear in git history or external references, but the maintained repo facts live in the reference docs listed above.

--- a/docs/reference/current-state.md
+++ b/docs/reference/current-state.md
@@ -167,5 +167,6 @@ On the maintainer machine, validation is intentionally low-RAM and serialized: r
 - `docs/reference/current-state.md`, `docs/reference/engineering-status.md`, and `docs/reference/vendoring-runtime.md` are the maintained reference docs.
 - `README.md` is the public GitHub landing page.
 - `cli/README.md` documents the standalone CLI, which has a broader speaker map than the shipped GUI.
+- `qwen_tone.md` is a supplemental guidance doc, not a maintained reference doc.
 
-The maintained docs in this checkout are the files listed above. Do not assume older supplementary docs still exist.
+The maintained docs in this checkout are the files listed above. Do not assume older supplementary docs still exist, and do not treat supplemental prose as equal to the maintained reference set.

--- a/docs/reference/vendoring-runtime.md
+++ b/docs/reference/vendoring-runtime.md
@@ -6,6 +6,17 @@ QwenVoice has three maintained vendoring/runtime stories:
 2. **Packaged release builds**
 3. **Native backend source vendoring**
 
+## Tracked Surface Boundaries
+
+Treat tracked surfaces in this repo as four different classes:
+
+- **Repo-owned source**: `Sources/`, `QwenVoiceTests/`, maintained docs, workflows, and repo-local skills
+- **Repo-owned vendored source**: `third_party_patches/`, where QwenVoice intentionally carries patched upstream code as maintained source
+- **Generated or bundled compatibility assets**: `Sources/Resources/python/`, `Sources/Resources/ffmpeg/`, most of `Sources/Resources/vendor/`, and similar script-produced payloads
+- **Local-only state**: `build/`, `.worktrees/`, `DerivedData/`, app-support data, local virtualenvs, and other machine-specific outputs
+
+Only the first three classes belong in tracked cleanup conversations. Local-only state should be managed through ignore rules, maintainer docs, or machine cleanup, not treated as repo source.
+
 ## Development Mode
 
 In a clean source checkout, `Sources/Resources/python/` is usually absent. The app then:

--- a/qwen_tone.md
+++ b/qwen_tone.md
@@ -1,6 +1,12 @@
 # Tone and Emotion in QwenVoice
 
-This guide focuses on what QwenVoice currently exposes, then calls out where the standalone CLI or broader Qwen3-TTS ecosystem goes beyond the shipped macOS app.
+This guide is a supplemental prompt-writing reference. It focuses on what QwenVoice currently exposes, then calls out where the standalone CLI or broader Qwen3-TTS ecosystem goes beyond the shipped macOS app.
+
+For current repo truth about app structure, workflow names, or shipped behavior, trust:
+
+1. `README.md`
+2. `docs/reference/current-state.md`
+3. `AGENTS.md`
 
 ## What the Shipped App Exposes
 
@@ -9,8 +15,8 @@ The shipped GUI controls tone and emotion through natural-language instructions,
 Current app behavior:
 
 - **Custom Voice** uses one of the shipped English speakers plus an instruction prompt
-- **Voice Design** is reached inside the Custom Voice screen by switching to the `Custom` speaker chip
-- **Voice Cloning** clones from reference audio and does not expose a separate instruction-style tone control surface
+- **Voice Design** is its own main-window destination with a separate screen and prompt flow
+- **Voice Cloning** clones from reference audio and can optionally use a transcript for better preparation quality, but it does not expose a separate instruction-style tone control surface
 - the shipping GUI exposes live streaming preview for single generations, but not temperature or max-token controls
 
 Useful instruction patterns in the shipped app:
@@ -44,7 +50,7 @@ Those are informational for power users and benchmark tooling, but they are not 
 - Be specific: combine voice character, emotional state, and pacing in one instruction.
 - Keep requests concrete: `calm middle-aged narrator with steady pacing` works better than `make it better`.
 - Iterate wording: instruction following is probabilistic, so small prompt changes can materially change the result.
-- For consistent stylized production, design a voice first and then clone from a reference workflow rather than trying to rediscover the exact same tone every run.
+- For consistent stylized production, use Voice Design when you want a reusable prompt-driven voice shape, then use Voice Cloning when you want a specific reference identity rather than trying to rediscover the same tone every run.
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- classify maintained reference docs vs supplemental prose
- fix the stale Voice Design guidance in qwen_tone.md
- document the tracked-source vs local-only boundary and tighten Python cache ignores
- sync the repo-local doc-sync skill with the new doc classification

## Tracking
- closes #14
- advances #15
- part of #20

## Verification
- ./scripts/check_project_inputs.sh
- python3 scripts/harness.py validate
- rg -n "run(_backend)?_tests\.sh|docs/reference/te(sting)\.md|Voice Design is reached inside the Custom Voice screen|tracked junk exists" README.md docs AGENTS.md .agents qwen_tone.md
