### PR TITLE
Rebrand macOS UI around the iOS Vocello design system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ build/
 # Git worktrees
 .worktrees/
 
+# Brainstorming/visual-companion session state
+.superpowers/
+
 # CLI user data
 cli/models/
 cli/outputs/

--- a/QwenVoice.xcodeproj/project.pbxproj
+++ b/QwenVoice.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		CE9FB73376B49D81E5BEFAF3 /* StartupDiagnosticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21943A54ED34AAA37626A252 /* StartupDiagnosticsView.swift */; };
 		D27D60A56143986204A2D592 /* Voice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623B6EAE78F8B7100D4675F4 /* Voice.swift */; };
 		D2DD8D5683671707CF6C06AA /* XPCNativeEngineCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895C57D89AE37AAB30A6D08E /* XPCNativeEngineCoordinatorTests.swift */; };
+		D69B889EAFAF2B5E77BD7CE0 /* VocelloTypography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4EF8C66F9816E558165977 /* VocelloTypography.swift */; };
 		D9CD489105C5ADCF38E6EE96 /* IOSModelDeliverySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC061E247067EDDB99401F09 /* IOSModelDeliverySupport.swift */; };
 		DAD34C5A369EE8338E586DDC /* NativeTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B33472B5B6CE711BEEF3244 /* NativeTelemetry.swift */; };
 		DB901031F858C01ECCED4DA4 /* IOSGenerationSetupCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10CE8FC9B1A2B580ED62408D /* IOSGenerationSetupCards.swift */; };
@@ -567,6 +568,7 @@
 		890E011F57EAC237416DDF0F /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		89331D74C7D33B5E0DF54415 /* LivePreviewDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivePreviewDiagnostics.swift; sourceTree = "<group>"; };
 		895C57D89AE37AAB30A6D08E /* XPCNativeEngineCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XPCNativeEngineCoordinatorTests.swift; sourceTree = "<group>"; };
+		8A4EF8C66F9816E558165977 /* VocelloTypography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocelloTypography.swift; sourceTree = "<group>"; };
 		8C15A84833CBBA98512F16C5 /* LivePreviewSmokeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivePreviewSmokeTests.swift; sourceTree = "<group>"; };
 		8C2C23800F44C1E0900C9F8D /* VocelloUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VocelloUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8C465AE879E2D9F601EC26DB /* DocumentIO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentIO.swift; sourceTree = "<group>"; };
@@ -1217,6 +1219,7 @@
 				F4F9D906B9BDE4A6978A5650 /* TextInputView.swift */,
 				5BB08FF07316ED61BB3A9F5D /* VocelloSegmentedControl.swift */,
 				C52189346EE3842A95A7FA18 /* VocelloStatusChip.swift */,
+				8A4EF8C66F9816E558165977 /* VocelloTypography.swift */,
 				F8D158D7F133942E02D828FC /* VocelloVMark.swift */,
 				652CF3434A19FF8823B9CCA2 /* WaveformView.swift */,
 				D4ED24544C9C26510DFCFE5C /* WindowChromeConfigurator.swift */,
@@ -1814,6 +1817,7 @@
 				712EF5135E17F9CE4052CCE8 /* UITestWindowCoordinator.swift in Sources */,
 				260D78EB3B7D5D7335C1B1FF /* VocelloSegmentedControl.swift in Sources */,
 				87E399C7E2DA92DDD6C53C95 /* VocelloStatusChip.swift in Sources */,
+				D69B889EAFAF2B5E77BD7CE0 /* VocelloTypography.swift in Sources */,
 				694F44654893F3B2D8D3AE58 /* VocelloVMark.swift in Sources */,
 				FDC2379CA4DB15F84DB80A3C /* Voice.swift in Sources */,
 				5FE8611FB168684BB5A832C1 /* VoiceCloningCoordinator.swift in Sources */,

--- a/QwenVoice.xcodeproj/project.pbxproj
+++ b/QwenVoice.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		019E5164FDE5AFD5FE86CBC9 /* TTSModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802B55E1EAC5684CDE4BBE03 /* TTSModel.swift */; };
 		04B2BA5833A1482EE9886202 /* QwenVoiceNativeRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025AB362CF3511ED784AE0B3 /* QwenVoiceNativeRuntime.swift */; };
 		04CBC254ECD926FEEB63E082 /* DatabaseServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3518DFCBACC3D1A7F5893B4 /* DatabaseServiceTests.swift */; };
+		051CB6D99E17B73E0AC37544 /* SidebarSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99235BBACC54954879498193 /* SidebarSection.swift */; };
+		056DD437FF7D41A65CDE2FDA /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9857BFB390C9E4401ED0FD /* SettingsView.swift */; };
 		057B63F15E495358760D4967 /* AudioPlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE335D1E032508F0E9B7614 /* AudioPlayerViewModel.swift */; };
 		05C45E2D020CE3D0E46AB49E /* AppStateRestorationPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24F04C92F11D3A7A98A0244 /* AppStateRestorationPolicyTests.swift */; };
 		06445A839283CCD0ADBFF1C7 /* NativeCloneSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05AE04FC3819262A8952F8FB /* NativeCloneSupport.swift */; };
@@ -39,7 +41,9 @@
 		1F607713C38054A7FA7F1D6E /* Generation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1BA97E899E616829A78233A /* Generation.swift */; };
 		204995EE6E17D7F1DDFA02FB /* HuggingFace in Frameworks */ = {isa = PBXBuildFile; productRef = 357F5CA9E28DE9CA8F48905E /* HuggingFace */; };
 		21012A67D1700D60D741FCBC /* QwenVoiceNative.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 405DF32499EDF28E20D73FEA /* QwenVoiceNative.framework */; };
+		21668141B7258138535595C6 /* TopGlassBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D6B63D0FE110CB888A5178 /* TopGlassBar.swift */; };
 		25AA6B68605F58DB9EE09EE6 /* RuntimeReleaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43033F9668B23257EDC8EEE3 /* RuntimeReleaseCoordinator.swift */; };
+		260D78EB3B7D5D7335C1B1FF /* VocelloSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB08FF07316ED61BB3A9F5D /* VocelloSegmentedControl.swift */; };
 		2652AA780375CA68D2A076C9 /* IOSShellPrimitives.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA28E2DF284402995B080598 /* IOSShellPrimitives.swift */; };
 		266EAA8391784BAB3CD80459 /* HuggingFace in Frameworks */ = {isa = PBXBuildFile; productRef = B79005899075F7467222FEA4 /* HuggingFace */; };
 		280A67A391CE1EE6F93C3BC4 /* UnsafeSpeechGenerationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC0AAA8033470C310E11EA6 /* UnsafeSpeechGenerationModel.swift */; };
@@ -103,8 +107,10 @@
 		63688213A368E98006CB5813 /* IOSAppBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E06F182E0D06AC11E44161D /* IOSAppBootstrap.swift */; };
 		64632D36BB7D5B179743C1C5 /* VocelloEngineExtensionHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981847F3339656A6F41E95FA /* VocelloEngineExtensionHost.swift */; };
 		64DBE2E5558AB9BCEBD09D2E /* ContractBackedModelRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75ED7320DEC606B571AB6E14 /* ContractBackedModelRegistry.swift */; };
+		65981D77E5B30F95BE51ED4F /* VoiceOrb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F295A3DBFFFA841C6D86E7 /* VoiceOrb.swift */; };
 		66148521A6C41374A9E58509 /* MLXAudioTTS in Frameworks */ = {isa = PBXBuildFile; productRef = 08357FFBB93AA79A98397B4B /* MLXAudioTTS */; };
 		6911F6DF40E40078CDE91DA0 /* TTSEngineStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E7AE4ADBE28C15D463E8CC /* TTSEngineStore.swift */; };
+		694F44654893F3B2D8D3AE58 /* VocelloVMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D158D7F133942E02D828FC /* VocelloVMark.swift */; };
 		6C329D9AE8AC56F1C930D32A /* DatabaseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8174C5EB5C39242E7EF445 /* DatabaseService.swift */; };
 		6C73192903DFFED166DD93FB /* EmotionPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A9B0840026EFF26202877BF /* EmotionPickerView.swift */; };
 		6CCE745C787CC14B0193FD48 /* NativeMLXMacEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CED27360BBBEA5D0A0A7AA /* NativeMLXMacEngine.swift */; };
@@ -132,13 +138,17 @@
 		82477C8375221067B1B85F6B /* BatchGenerationRunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B012C93D8AC77A60ED5A790 /* BatchGenerationRunnerTests.swift */; };
 		82B95BB3F61F41F3BB882283 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2EC6F0D89B4220E1F3A6CA71 /* LaunchScreen.storyboard */; };
 		850CDA13E23723B8A92F7D9C /* ModelRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5814A0DF5264DE6671474C8 /* ModelRegistry.swift */; };
+		85554E9AD164D26E3E95DC5F /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4E59FD97C3B29B5684242DD /* HomeView.swift */; };
 		8612AA28117CF2FDD46D401A /* AppPerformanceSignposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C8C4331104AAE56B2B7047 /* AppPerformanceSignposts.swift */; };
+		87E399C7E2DA92DDD6C53C95 /* VocelloStatusChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C52189346EE3842A95A7FA18 /* VocelloStatusChip.swift */; };
 		881B6A72F8BD0FAEC1E291D8 /* NativeMemoryPolicyResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AEE16398D08C10B333F02D3 /* NativeMemoryPolicyResolver.swift */; };
 		8C368E980B5C4B59C1179736 /* IOSMemoryMetricsBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 04959460DEEFC35448B5F9F7 /* IOSMemoryMetricsBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8C675B0590E4A89594D8FE33 /* QwenVoiceCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1CD42CBFA3E0E68EDA48DEA /* QwenVoiceCore.framework */; };
+		8C677230BFF77831D9A83756 /* CormorantTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4ED032C7C1B7D8EFA09C406 /* CormorantTitle.swift */; };
 		8E58BE1E09A9430CD949DF6D /* ExtensionEngineTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0C75B51B150DAD46318887D /* ExtensionEngineTransport.swift */; };
 		8FBF7D34C853874E60A1AA9F /* Waiting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5F92C27C5DBA1F0452F3A60 /* Waiting.swift */; };
 		905A10A270A279A00E700D37 /* TimingExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F87CB9B9415D7556595B20 /* TimingExtensions.swift */; };
+		90B091B4FD4CDEA12A0496C9 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29DE536D0985C3228AF6FB79 /* LibraryView.swift */; };
 		92671248BD664D9F6371CEA2 /* MLX in Frameworks */ = {isa = PBXBuildFile; productRef = 8F0F57EE1787C0627AD36CC7 /* MLX */; };
 		9314A3EA67AF59D9B361DD97 /* MLXAudioTTS in Frameworks */ = {isa = PBXBuildFile; productRef = 11FDE2EFFA7EC79F899F3714 /* MLXAudioTTS */; };
 		940F6E64A6613D0A4F1CD843 /* IOSGenerateFlowViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8D4D8DFF4CFC912BE52FF1E /* IOSGenerateFlowViews.swift */; };
@@ -216,6 +226,8 @@
 		DB901031F858C01ECCED4DA4 /* IOSGenerationSetupCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10CE8FC9B1A2B580ED62408D /* IOSGenerationSetupCards.swift */; };
 		DC82C53833745F1993CB460B /* NativeModelRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17D220A87B118CDAB8682AA /* NativeModelRegistryTests.swift */; };
 		DCEF09940749A14DEB062D04 /* IOSGenerationTextLimitPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9213D3C53B12F841327ACCF /* IOSGenerationTextLimitPolicy.swift */; };
+		DD68C31CF65CB917F7090D6C /* WindowFooterPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77C4CC2A9F96F65881C063D7 /* WindowFooterPlayer.swift */; };
+		DE9272AD046912D27A75FD62 /* GenerateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12640FB7FDB49BAF1544A4B2 /* GenerateView.swift */; };
 		DF7559613420E7F6199BAB41 /* BackendPerformanceContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4A9DBBACF0224EDE712E31 /* BackendPerformanceContractTests.swift */; };
 		DFDC2DB9B267DB938A862746 /* NativeStreamingSynthesisSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 066A78E7232A89C203BE60A3 /* NativeStreamingSynthesisSession.swift */; };
 		DFF41A112585ADC31484F16C /* IOSMemorySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8AF8C5F67A18A2A6790A33 /* IOSMemorySnapshot.swift */; };
@@ -443,6 +455,7 @@
 		05AE04FC3819262A8952F8FB /* NativeCloneSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeCloneSupport.swift; sourceTree = "<group>"; };
 		066A78E7232A89C203BE60A3 /* NativeStreamingSynthesisSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeStreamingSynthesisSession.swift; sourceTree = "<group>"; };
 		06720D555739C2E8AE36A913 /* NativeStreamingSynthesisSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeStreamingSynthesisSession.swift; sourceTree = "<group>"; };
+		06D6B63D0FE110CB888A5178 /* TopGlassBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopGlassBar.swift; sourceTree = "<group>"; };
 		06F87CB9B9415D7556595B20 /* TimingExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimingExtensions.swift; sourceTree = "<group>"; };
 		08A7E4D67B06F288693FEAC2 /* GenerationScreenPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationScreenPresentation.swift; sourceTree = "<group>"; };
 		0AEC31C6C5F1978398C647E5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -455,6 +468,7 @@
 		101AFE7CFE754BDF26AD5CD4 /* GenerationDrafts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationDrafts.swift; sourceTree = "<group>"; };
 		10CE8FC9B1A2B580ED62408D /* IOSGenerationSetupCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSGenerationSetupCards.swift; sourceTree = "<group>"; };
 		111F1F71B7CC59C9C1AD4038 /* ExtensionEngineIPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionEngineIPC.swift; sourceTree = "<group>"; };
+		12640FB7FDB49BAF1544A4B2 /* GenerateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateView.swift; sourceTree = "<group>"; };
 		14202A5EA4A0355319DF2F34 /* AppLaunchDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppLaunchDiagnostics.swift; sourceTree = "<group>"; };
 		16357673B0524D933999409E /* SidebarStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarStatusView.swift; sourceTree = "<group>"; };
 		169416ABF9E023B87DCE932D /* TTSContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSContract.swift; sourceTree = "<group>"; };
@@ -473,6 +487,7 @@
 		23BE17D8F4587716FB24641C /* AppGenerationTelemetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGenerationTelemetry.swift; sourceTree = "<group>"; };
 		281629E0EE8593C8F69031A6 /* ModelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelsView.swift; sourceTree = "<group>"; };
 		297CA448BB4837C19346ECC7 /* BatchGenerationRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchGenerationRunner.swift; sourceTree = "<group>"; };
+		29DE536D0985C3228AF6FB79 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
 		2CE335D1E032508F0E9B7614 /* AudioPlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayerViewModel.swift; sourceTree = "<group>"; };
 		2EC6F0D89B4220E1F3A6CA71 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		30217C0DF571FAC613EA347F /* EngineServiceCodecTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineServiceCodecTests.swift; sourceTree = "<group>"; };
@@ -494,6 +509,7 @@
 		4377E3144E68AF1ECE1ABCDC /* EmotionPreset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmotionPreset.swift; sourceTree = "<group>"; };
 		44E29A8F18ADF5E5C68E11E1 /* ModelManagerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManagerViewModel.swift; sourceTree = "<group>"; };
 		452CA311723F50EB66FFBC4D /* mlx-audio-swift */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "mlx-audio-swift"; path = "third_party_patches/mlx-audio-swift"; sourceTree = SOURCE_ROOT; };
+		45F295A3DBFFFA841C6D86E7 /* VoiceOrb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOrb.swift; sourceTree = "<group>"; };
 		47AF7FDD09D2508B2D02F5A6 /* NativeModelLoadCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeModelLoadCoordinator.swift; sourceTree = "<group>"; };
 		4A367AAE25201E301F646DCA /* ModelManagerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManagerViewModel.swift; sourceTree = "<group>"; };
 		4B012C93D8AC77A60ED5A790 /* BatchGenerationRunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchGenerationRunnerTests.swift; sourceTree = "<group>"; };
@@ -515,6 +531,7 @@
 		5A9B0840026EFF26202877BF /* EmotionPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmotionPickerView.swift; sourceTree = "<group>"; };
 		5ADD468538B8CB0B6E629FB7 /* GenerationWorkflowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationWorkflowView.swift; sourceTree = "<group>"; };
 		5B7F58AC8D59F087073797F7 /* IOSModelDeliveryBackgroundEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSModelDeliveryBackgroundEvents.swift; sourceTree = "<group>"; };
+		5BB08FF07316ED61BB3A9F5D /* VocelloSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocelloSegmentedControl.swift; sourceTree = "<group>"; };
 		617BE72142511CD5043C341E /* qwenvoice_contract.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = qwenvoice_contract.json; sourceTree = "<group>"; };
 		623B6EAE78F8B7100D4675F4 /* Voice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Voice.swift; sourceTree = "<group>"; };
 		637866C95AC607A5E0509956 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
@@ -539,6 +556,7 @@
 		75ED7320DEC606B571AB6E14 /* ContractBackedModelRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContractBackedModelRegistry.swift; sourceTree = "<group>"; };
 		760B43D401DD225A7DAF45B1 /* IOSFoundationPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSFoundationPolicyTests.swift; sourceTree = "<group>"; };
 		7658FC7786FF12AFB1D10CB4 /* SavedVoicesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedVoicesViewModelTests.swift; sourceTree = "<group>"; };
+		77C4CC2A9F96F65881C063D7 /* WindowFooterPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowFooterPlayer.swift; sourceTree = "<group>"; };
 		786E4C195547351A7BAD7CF6 /* GenerationDraftsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationDraftsTests.swift; sourceTree = "<group>"; };
 		7A3736EA57DD8B4B60EF1883 /* AppCommandRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCommandRouter.swift; sourceTree = "<group>"; };
 		802B55E1EAC5684CDE4BBE03 /* TTSModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSModel.swift; sourceTree = "<group>"; };
@@ -560,11 +578,13 @@
 		958B08B9790BD411BEE24FA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		981847F3339656A6F41E95FA /* VocelloEngineExtensionHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocelloEngineExtensionHost.swift; sourceTree = "<group>"; };
 		98C65FFC6BA471E3A19EA0C2 /* TTSEngineStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSEngineStoreTests.swift; sourceTree = "<group>"; };
+		99235BBACC54954879498193 /* SidebarSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSection.swift; sourceTree = "<group>"; };
 		9AC0AAA8033470C310E11EA6 /* UnsafeSpeechGenerationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsafeSpeechGenerationModel.swift; sourceTree = "<group>"; };
 		9B899A22B7619F15A40FC99C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9E06F182E0D06AC11E44161D /* IOSAppBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSAppBootstrap.swift; sourceTree = "<group>"; };
 		9E54014942862A03DA9ABA13 /* ExtensionEngineCommand+Transport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ExtensionEngineCommand+Transport.swift"; sourceTree = "<group>"; };
 		A014ECB4F32BED1D8FE49B68 /* IOSAccessibilityIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSAccessibilityIdentifiers.swift; sourceTree = "<group>"; };
+		A4ED032C7C1B7D8EFA09C406 /* CormorantTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CormorantTitle.swift; sourceTree = "<group>"; };
 		A6B73109FDA26E5BE216F042 /* VocelloiOSTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = VocelloiOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9213D3C53B12F841327ACCF /* IOSGenerationTextLimitPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSGenerationTextLimitPolicy.swift; sourceTree = "<group>"; };
 		A986C0809EC0CC034DB5666C /* NativeAudioPreparationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAudioPreparationTests.swift; sourceTree = "<group>"; };
@@ -590,6 +610,8 @@
 		C2DFCE926BEA571377795E61 /* NativeCloneSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeCloneSupport.swift; sourceTree = "<group>"; };
 		C317D7467D26FD09704CFD81 /* SidebarPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPlayerView.swift; sourceTree = "<group>"; };
 		C4A51A054EBF03C0D4E010A6 /* IOSRootNavigationModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSRootNavigationModels.swift; sourceTree = "<group>"; };
+		C4E59FD97C3B29B5684242DD /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		C52189346EE3842A95A7FA18 /* VocelloStatusChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocelloStatusChip.swift; sourceTree = "<group>"; };
 		C5814A0DF5264DE6671474C8 /* ModelRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelRegistry.swift; sourceTree = "<group>"; };
 		C5D4F51C8BBABFB4246536FD /* GenerationLibraryEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationLibraryEvents.swift; sourceTree = "<group>"; };
 		C5F92C27C5DBA1F0452F3A60 /* Waiting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Waiting.swift; sourceTree = "<group>"; };
@@ -599,6 +621,7 @@
 		C9DFF46140E21950EEDD4721 /* MLXModelLoadCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLXModelLoadCoordinator.swift; sourceTree = "<group>"; };
 		CA69FF9D2F8980B6EECA2831 /* StreamingChunkFinalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingChunkFinalizationTests.swift; sourceTree = "<group>"; };
 		CBFD195E3C3F6CFC29D83EC1 /* Generation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Generation.swift; sourceTree = "<group>"; };
+		CC9857BFB390C9E4401ED0FD /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		CD14EA7079C5160A638BE0D4 /* GenerationSemantics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationSemantics.swift; sourceTree = "<group>"; };
 		CE621138D32607BE4CF4FDE5 /* NativeRuntimeTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeRuntimeTestSupport.swift; sourceTree = "<group>"; };
 		D2A539A647083CC4810F72FE /* WaveformService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformService.swift; sourceTree = "<group>"; };
@@ -634,6 +657,7 @@
 		F3D8ACB81CF073C1688E259F /* ExtensionBackedTTSEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionBackedTTSEngine.swift; sourceTree = "<group>"; };
 		F4F9D906B9BDE4A6978A5650 /* TextInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextInputView.swift; sourceTree = "<group>"; };
 		F84E19D8BAEB03195166A26A /* IOSMemoryMetricsBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IOSMemoryMetricsBridge.m; sourceTree = "<group>"; };
+		F8D158D7F133942E02D828FC /* VocelloVMark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocelloVMark.swift; sourceTree = "<group>"; };
 		F8D4D8DFF4CFC912BE52FF1E /* IOSGenerateFlowViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSGenerateFlowViews.swift; sourceTree = "<group>"; };
 		F9F88D3A405265D7B25F2E3B /* LivePreviewIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivePreviewIntegrationTests.swift; sourceTree = "<group>"; };
 		FA28E2DF284402995B080598 /* IOSShellPrimitives.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSShellPrimitives.swift; sourceTree = "<group>"; };
@@ -808,6 +832,7 @@
 			children = (
 				281629E0EE8593C8F69031A6 /* ModelsView.swift */,
 				7282AD0029C4CFDAEF69F9DB /* PreferencesView.swift */,
+				CC9857BFB390C9E4401ED0FD /* SettingsView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -870,6 +895,15 @@
 			name = Packages;
 			sourceTree = "<group>";
 		};
+		2FA4E5E04FD9FF7FDD5C9074 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				C4E59FD97C3B29B5684242DD /* HomeView.swift */,
+				45F295A3DBFFFA841C6D86E7 /* VoiceOrb.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
 		3335A2C55708EA04625018B2 /* QwenVoiceTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -924,6 +958,7 @@
 				21943A54ED34AAA37626A252 /* StartupDiagnosticsView.swift */,
 				9EF4E551B79B35D60032C17C /* Components */,
 				5923E35865DE1169584028DD /* Generate */,
+				2FA4E5E04FD9FF7FDD5C9074 /* Home */,
 				C1C590053F5326D33AD9D8A7 /* Library */,
 				0DAC412D2DCB346EB874A3C6 /* Settings */,
 				D04B5DF95506C7083D60178B /* Sidebar */,
@@ -974,6 +1009,7 @@
 			isa = PBXGroup;
 			children = (
 				B84E7EAC8760A09DC87915DD /* CustomVoiceView.swift */,
+				12640FB7FDB49BAF1544A4B2 /* GenerateView.swift */,
 				53F47C4B97AF4841FDEEB907 /* VoiceCloningView.swift */,
 				F1FFAA967392EE269CF32328 /* VoiceDesignView.swift */,
 			);
@@ -1042,6 +1078,7 @@
 				7220613AFFBB1E9C0C9AB52F /* GenerationDrafts.swift */,
 				08A7E4D67B06F288693FEAC2 /* GenerationScreenPresentation.swift */,
 				72B703DF8A07FC4F83D3202F /* ModelInfo.swift */,
+				99235BBACC54954879498193 /* SidebarSection.swift */,
 				4F84F3D2B1CF22DA6148705D /* SidebarStatus.swift */,
 				E56DB3F2A6729473A3816C4C /* TTSContract.swift */,
 				802B55E1EAC5684CDE4BBE03 /* TTSModel.swift */,
@@ -1170,6 +1207,7 @@
 				890E011F57EAC237416DDF0F /* AppTheme.swift */,
 				E2C37F7C548405565C230BF8 /* BatchGenerationSheet.swift */,
 				70E509E03D5758CB0D6C0388 /* ContinuousVoiceDescriptionField.swift */,
+				A4ED032C7C1B7D8EFA09C406 /* CormorantTitle.swift */,
 				5A9B0840026EFF26202877BF /* EmotionPickerView.swift */,
 				D8C22183F1D9A8DC478C8B8B /* FlowLayout.swift */,
 				5ADD468538B8CB0B6E629FB7 /* GenerationWorkflowView.swift */,
@@ -1177,8 +1215,12 @@
 				C317D7467D26FD09704CFD81 /* SidebarPlayerView.swift */,
 				16357673B0524D933999409E /* SidebarStatusView.swift */,
 				F4F9D906B9BDE4A6978A5650 /* TextInputView.swift */,
+				5BB08FF07316ED61BB3A9F5D /* VocelloSegmentedControl.swift */,
+				C52189346EE3842A95A7FA18 /* VocelloStatusChip.swift */,
+				F8D158D7F133942E02D828FC /* VocelloVMark.swift */,
 				652CF3434A19FF8823B9CCA2 /* WaveformView.swift */,
 				D4ED24544C9C26510DFCFE5C /* WindowChromeConfigurator.swift */,
+				77C4CC2A9F96F65881C063D7 /* WindowFooterPlayer.swift */,
 				C1FC88E299FA8685AA781D8D /* V2 */,
 			);
 			path = Components;
@@ -1188,6 +1230,7 @@
 			isa = PBXGroup;
 			children = (
 				E4D22F70AB025CF59B428113 /* HistoryView.swift */,
+				29DE536D0985C3228AF6FB79 /* LibraryView.swift */,
 				6CFE0839E5278349D1087CB9 /* SavedVoiceSheet.swift */,
 				0D3C6777F2ABFE603D026E0D /* VoicesView.swift */,
 			);
@@ -1205,6 +1248,7 @@
 			isa = PBXGroup;
 			children = (
 				637866C95AC607A5E0509956 /* SidebarView.swift */,
+				06D6B63D0FE110CB888A5178 /* TopGlassBar.swift */,
 			);
 			path = Sidebar;
 			sourceTree = "<group>";
@@ -1725,12 +1769,14 @@
 				9D252B7945375066E6E70CAC /* BatchGenerationSheet.swift in Sources */,
 				BC702680E0058355A5DDDC81 /* ContentView.swift in Sources */,
 				59EF7FDB9556E1860DC2FF67 /* ContinuousVoiceDescriptionField.swift in Sources */,
+				8C677230BFF77831D9A83756 /* CormorantTitle.swift in Sources */,
 				AD4BB14FA57891024AF706D2 /* CustomVoiceCoordinator.swift in Sources */,
 				369B39A3B4D6D2C2FE6B956F /* CustomVoiceView.swift in Sources */,
 				6C329D9AE8AC56F1C930D32A /* DatabaseService.swift in Sources */,
 				6C73192903DFFED166DD93FB /* EmotionPickerView.swift in Sources */,
 				EEFE4FE49F13B576053735F5 /* EmotionPreset.swift in Sources */,
 				5E975521FC8B355333145278 /* FlowLayout.swift in Sources */,
+				DE9272AD046912D27A75FD62 /* GenerateView.swift in Sources */,
 				1F607713C38054A7FA7F1D6E /* Generation.swift in Sources */,
 				9C596C12FF2FAF4901655F51 /* GenerationDrafts.swift in Sources */,
 				ECEE4AE6F2D1AF6BA9EFECAA /* GenerationLibraryEvents.swift in Sources */,
@@ -1738,8 +1784,10 @@
 				7197E0B1B11DA77FF707BB2B /* GenerationScreenPresentation.swift in Sources */,
 				B6824C9F4B35990C52CCDDB8 /* GenerationWorkflowView.swift in Sources */,
 				4B578A4D21A7CC18003BBA14 /* HistoryView.swift in Sources */,
+				85554E9AD164D26E3E95DC5F /* HomeView.swift in Sources */,
 				102B2746352B5032F9F34A31 /* HuggingFaceDownloader.swift in Sources */,
 				2E6A0B30C35D6D082403D964 /* LayoutConstants.swift in Sources */,
+				90B091B4FD4CDEA12A0496C9 /* LibraryView.swift in Sources */,
 				40A94D5A75E9D1F5FB41023C /* LivePreviewDiagnostics.swift in Sources */,
 				0D54E198EE173129C4A2B771 /* ModelInfo.swift in Sources */,
 				0C938FCAEB2BB9E2356C4326 /* ModelManagerViewModel.swift in Sources */,
@@ -1748,7 +1796,9 @@
 				A4391A1D525E6177F26A23F1 /* QwenVoiceApp.swift in Sources */,
 				4E143AC96C8ABA269C3929AE /* SavedVoiceSheet.swift in Sources */,
 				9AD93240195D2474CD96EB6B /* SavedVoicesViewModel.swift in Sources */,
+				056DD437FF7D41A65CDE2FDA /* SettingsView.swift in Sources */,
 				C838C6E3E59717F67F49C45C /* SidebarPlayerView.swift in Sources */,
+				051CB6D99E17B73E0AC37544 /* SidebarSection.swift in Sources */,
 				39AA20C20D7E3716C7F67116 /* SidebarStatus.swift in Sources */,
 				5D23FDB4CC008D1E909414A8 /* SidebarStatusView.swift in Sources */,
 				7A4C342B51D60AB71AC61E0C /* SidebarView.swift in Sources */,
@@ -1757,19 +1807,25 @@
 				9C7F54D72E62B1918F56298B /* TTSContract.swift in Sources */,
 				019E5164FDE5AFD5FE86CBC9 /* TTSModel.swift in Sources */,
 				1BA11424A101CD274AFE9727 /* TextInputView.swift in Sources */,
+				21668141B7258138535595C6 /* TopGlassBar.swift in Sources */,
 				9F33BE2BD7E13711926ED9B8 /* UITestAutomationSupport.swift in Sources */,
 				E5E94AD88F173238332FECF7 /* UITestFaultInjection.swift in Sources */,
 				C80870F3585538BACB90AD65 /* UITestStubMacEngine.swift in Sources */,
 				712EF5135E17F9CE4052CCE8 /* UITestWindowCoordinator.swift in Sources */,
+				260D78EB3B7D5D7335C1B1FF /* VocelloSegmentedControl.swift in Sources */,
+				87E399C7E2DA92DDD6C53C95 /* VocelloStatusChip.swift in Sources */,
+				694F44654893F3B2D8D3AE58 /* VocelloVMark.swift in Sources */,
 				FDC2379CA4DB15F84DB80A3C /* Voice.swift in Sources */,
 				5FE8611FB168684BB5A832C1 /* VoiceCloningCoordinator.swift in Sources */,
 				9506A9366B29D225A10210E7 /* VoiceCloningView.swift in Sources */,
 				42996C0B65F1C9A87A19101D /* VoiceDesignCoordinator.swift in Sources */,
 				AC562D9EF3EB6A8A3452FC8F /* VoiceDesignView.swift in Sources */,
+				65981D77E5B30F95BE51ED4F /* VoiceOrb.swift in Sources */,
 				B005B34A94873FF7C4D80A7E /* VoicesView.swift in Sources */,
 				13462F046FE8C8196DE2BD97 /* WaveformService.swift in Sources */,
 				BFB9538DB6144B9BD8E227DE /* WaveformView.swift in Sources */,
 				FB7787825792B2182031F43C /* WindowChromeConfigurator.swift in Sources */,
+				DD68C31CF65CB917F7090D6C /* WindowFooterPlayer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/QwenVoice.xcodeproj/xcshareddata/xcschemes/QwenVoice Foundation.xcscheme
+++ b/QwenVoice.xcodeproj/xcshareddata/xcschemes/QwenVoice Foundation.xcscheme
@@ -4,7 +4,8 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -15,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "939725D6CC844653EA90F39E"
-               BuildableName = "Vocello.app"
+               BuildableName = "QwenVoice.app"
                BlueprintName = "QwenVoice"
                ReferencedContainer = "container:QwenVoice.xcodeproj">
             </BuildableReference>
@@ -26,25 +27,30 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "939725D6CC844653EA90F39E"
-            BuildableName = "Vocello.app"
-            BlueprintName = "QwenVoice"
-            ReferencedContainer = "container:QwenVoice.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <TestPlans>
          <TestPlanReference
-            reference = "container:tests/Plans/QwenVoiceSource.xctestplan"
-            default = "YES">
+            default = "YES"
+            reference = "container:tests/Plans/QwenVoiceSource.xctestplan">
          </TestPlanReference>
          <TestPlanReference
             reference = "container:tests/Plans/QwenVoiceRuntime.xctestplan">
          </TestPlanReference>
       </TestPlans>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "939725D6CC844653EA90F39E"
+            BuildableName = "QwenVoice.app"
+            BlueprintName = "QwenVoice"
+            ReferencedContainer = "container:QwenVoice.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,11 +67,13 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "939725D6CC844653EA90F39E"
-            BuildableName = "Vocello.app"
+            BuildableName = "QwenVoice.app"
             BlueprintName = "QwenVoice"
             ReferencedContainer = "container:QwenVoice.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -78,7 +86,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "939725D6CC844653EA90F39E"
-            BuildableName = "Vocello.app"
+            BuildableName = "QwenVoice.app"
             BlueprintName = "QwenVoice"
             ReferencedContainer = "container:QwenVoice.xcodeproj">
          </BuildableReference>

--- a/QwenVoice.xcodeproj/xcshareddata/xcschemes/QwenVoice.xcscheme
+++ b/QwenVoice.xcodeproj/xcshareddata/xcschemes/QwenVoice.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2600"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -15,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "939725D6CC844653EA90F39E"
-               BuildableName = "Vocello.app"
+               BuildableName = "QwenVoice.app"
                BlueprintName = "QwenVoice"
                ReferencedContainer = "container:QwenVoice.xcodeproj">
             </BuildableReference>
@@ -26,12 +27,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "939725D6CC844653EA90F39E"
-            BuildableName = "Vocello.app"
+            BuildableName = "QwenVoice.app"
             BlueprintName = "QwenVoice"
             ReferencedContainer = "container:QwenVoice.xcodeproj">
          </BuildableReference>
@@ -54,11 +56,13 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "939725D6CC844653EA90F39E"
-            BuildableName = "Vocello.app"
+            BuildableName = "QwenVoice.app"
             BlueprintName = "QwenVoice"
             ReferencedContainer = "container:QwenVoice.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -71,7 +75,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "939725D6CC844653EA90F39E"
-            BuildableName = "Vocello.app"
+            BuildableName = "QwenVoice.app"
             BlueprintName = "QwenVoice"
             ReferencedContainer = "container:QwenVoice.xcodeproj">
          </BuildableReference>

--- a/QwenVoice.xcodeproj/xcshareddata/xcschemes/Vocello UI.xcscheme
+++ b/QwenVoice.xcodeproj/xcshareddata/xcschemes/Vocello UI.xcscheme
@@ -4,7 +4,8 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -15,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "939725D6CC844653EA90F39E"
-               BuildableName = "Vocello.app"
+               BuildableName = "QwenVoice.app"
                BlueprintName = "QwenVoice"
                ReferencedContainer = "container:QwenVoice.xcodeproj">
             </BuildableReference>
@@ -40,22 +41,27 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <TestPlans>
+         <TestPlanReference
+            default = "YES"
+            reference = "container:tests/Plans/VocelloUISmoke.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "939725D6CC844653EA90F39E"
-            BuildableName = "Vocello.app"
+            BuildableName = "QwenVoice.app"
             BlueprintName = "QwenVoice"
             ReferencedContainer = "container:QwenVoice.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <TestPlans>
-         <TestPlanReference
-            reference = "container:tests/Plans/VocelloUISmoke.xctestplan"
-            default = "YES">
-         </TestPlanReference>
-      </TestPlans>
+      <Testables>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -72,11 +78,13 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "939725D6CC844653EA90F39E"
-            BuildableName = "Vocello.app"
+            BuildableName = "QwenVoice.app"
             BlueprintName = "QwenVoice"
             ReferencedContainer = "container:QwenVoice.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -89,7 +97,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "939725D6CC844653EA90F39E"
-            BuildableName = "Vocello.app"
+            BuildableName = "QwenVoice.app"
             BlueprintName = "QwenVoice"
             ReferencedContainer = "container:QwenVoice.xcodeproj">
          </BuildableReference>

--- a/QwenVoice.xcodeproj/xcshareddata/xcschemes/VocelloiOS Foundation.xcscheme
+++ b/QwenVoice.xcodeproj/xcshareddata/xcschemes/VocelloiOS Foundation.xcscheme
@@ -4,7 +4,8 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -15,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8E4346491ECB9C6C678CD73F"
-               BuildableName = "Vocello.app"
+               BuildableName = "VocelloiOS.app"
                BlueprintName = "VocelloiOS"
                ReferencedContainer = "container:QwenVoice.xcodeproj">
             </BuildableReference>
@@ -26,22 +27,27 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <TestPlans>
+         <TestPlanReference
+            default = "YES"
+            reference = "container:tests/Plans/VocelloiOSFoundation.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8E4346491ECB9C6C678CD73F"
-            BuildableName = "Vocello.app"
+            BuildableName = "VocelloiOS.app"
             BlueprintName = "VocelloiOS"
             ReferencedContainer = "container:QwenVoice.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <TestPlans>
-         <TestPlanReference
-            reference = "container:tests/Plans/VocelloiOSFoundation.xctestplan"
-            default = "YES">
-         </TestPlanReference>
-      </TestPlans>
+      <Testables>
+      </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -58,11 +64,13 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8E4346491ECB9C6C678CD73F"
-            BuildableName = "Vocello.app"
+            BuildableName = "VocelloiOS.app"
             BlueprintName = "VocelloiOS"
             ReferencedContainer = "container:QwenVoice.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -75,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8E4346491ECB9C6C678CD73F"
-            BuildableName = "Vocello.app"
+            BuildableName = "VocelloiOS.app"
             BlueprintName = "VocelloiOS"
             ReferencedContainer = "container:QwenVoice.xcodeproj">
          </BuildableReference>

--- a/QwenVoice.xcodeproj/xcshareddata/xcschemes/VocelloiOS.xcscheme
+++ b/QwenVoice.xcodeproj/xcshareddata/xcschemes/VocelloiOS.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2600"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -15,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8E4346491ECB9C6C678CD73F"
-               BuildableName = "Vocello.app"
+               BuildableName = "VocelloiOS.app"
                BlueprintName = "VocelloiOS"
                ReferencedContainer = "container:QwenVoice.xcodeproj">
             </BuildableReference>
@@ -26,12 +27,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8E4346491ECB9C6C678CD73F"
-            BuildableName = "Vocello.app"
+            BuildableName = "VocelloiOS.app"
             BlueprintName = "VocelloiOS"
             ReferencedContainer = "container:QwenVoice.xcodeproj">
          </BuildableReference>
@@ -54,11 +56,13 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8E4346491ECB9C6C678CD73F"
-            BuildableName = "Vocello.app"
+            BuildableName = "VocelloiOS.app"
             BlueprintName = "VocelloiOS"
             ReferencedContainer = "container:QwenVoice.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -71,7 +75,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "8E4346491ECB9C6C678CD73F"
-            BuildableName = "Vocello.app"
+            BuildableName = "VocelloiOS.app"
             BlueprintName = "VocelloiOS"
             ReferencedContainer = "container:QwenVoice.xcodeproj">
          </BuildableReference>

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -136,7 +136,11 @@ struct ContentView: View {
 
     private let launchSidebarOverride: SidebarItem?
 
-    @State private var selectedItem: SidebarItem?
+    @State private var selectedSection: SidebarSection?
+    @State private var generateMode: GenerationMode = .custom
+    @State private var libraryTab: LibraryTab = .history
+    @State private var settingsTab: SettingsTab = .models
+
     @State private var protectedLaunchOverride: SidebarItem?
     @State private var pendingHighlightedModelID: String?
     @State private var historySearchText = ""
@@ -151,16 +155,53 @@ struct ContentView: View {
     @State private var voiceDesignActivationID: Int
     @State private var voiceCloningActivationID: Int
 
+    private var derivedSidebarItem: SidebarItem? {
+        switch selectedSection {
+        case .home, .none:
+            return nil
+        case .generate:
+            switch generateMode {
+            case .custom: return .customVoice
+            case .design: return .voiceDesign
+            case .clone:  return .voiceCloning
+            }
+        case .library:
+            return libraryTab.sidebarItem
+        case .settings:
+            return settingsTab.sidebarItem
+        }
+    }
+
     private var currentWindowTitle: String {
-        selectedItem?.rawValue ?? "Vocello"
+        derivedSidebarItem?.rawValue ?? selectedSection?.rawValue ?? "Vocello"
     }
 
     private var currentActiveScreenID: String {
-        selectedItem?.screenAccessibilityID ?? "screen_customVoice"
+        if let derivedSidebarItem {
+            return derivedSidebarItem.screenAccessibilityID
+        }
+        switch selectedSection {
+        case .home: return "screen_home"
+        case .generate: return "screen_generate"
+        case .library: return "screen_library"
+        case .settings: return "screen_settings"
+        case .none: return "screen_home"
+        }
     }
 
-    private var disabledSidebarItems: Set<SidebarItem> {
+    private var disabledGenerationItems: Set<SidebarItem> {
         Set(SidebarItem.generationItems.filter { !$0.isAvailable(using: modelManager) })
+    }
+
+    private var disabledSidebarSections: Set<SidebarSection> {
+        var disabled: Set<SidebarSection> = []
+        let allModesDisabled = SidebarItem.generationItems.allSatisfy {
+            disabledGenerationItems.contains($0)
+        }
+        if allModesDisabled {
+            disabled.insert(.generate)
+        }
+        return disabled
     }
 
     private var canUseSavedVoicesInVoiceCloning: Bool {
@@ -169,21 +210,21 @@ struct ContentView: View {
     }
 
     private var currentDisabledSidebarIdentifiers: String {
-        let identifiers = disabledSidebarItems.map(\.accessibilityID).sorted()
+        let identifiers = disabledGenerationItems.map(\.accessibilityID).sorted()
         return identifiers.isEmpty ? "none" : identifiers.joined(separator: ",")
     }
 
     private var isPreservingLaunchOverrideSelection: Bool {
         guard let protectedLaunchOverride else { return false }
-        return selectedItem == protectedLaunchOverride
+        return derivedSidebarItem == protectedLaunchOverride
     }
 
-    private var sidebarSelectionBinding: Binding<SidebarItem?> {
+    private var sidebarSelectionBinding: Binding<SidebarSection?> {
         Binding(
-            get: { selectedItem },
+            get: { selectedSection },
             set: { newValue in
                 guard let newValue else { return }
-                selectSidebarItemIfEnabled(newValue)
+                selectSectionIfEnabled(newValue)
             }
         )
     }
@@ -195,11 +236,33 @@ struct ContentView: View {
         let initialSelection = SidebarItem.defaultInitialSelection(
             launchOverride: launchSidebarOverride
         )
-        _selectedItem = State(initialValue: initialSelection)
+
+        let sectionFromItem = ContentView.section(for: initialSelection)
+        let initialSection = AppLaunchConfiguration.current.initialSidebarSectionOverride ?? sectionFromItem
+        _selectedSection = State(initialValue: initialSection)
+
+        if let mode = initialSelection.generationMode {
+            _generateMode = State(initialValue: mode)
+        }
+        if let libraryTab = initialSelection.libraryTab {
+            _libraryTab = State(initialValue: libraryTab)
+        }
+        if let settingsTab = initialSelection.settingsTab {
+            _settingsTab = State(initialValue: settingsTab)
+        }
+
         _protectedLaunchOverride = State(initialValue: launchSidebarOverride)
         _customVoiceActivationID = State(initialValue: initialSelection == .customVoice ? 1 : 0)
         _voiceDesignActivationID = State(initialValue: initialSelection == .voiceDesign ? 1 : 0)
         _voiceCloningActivationID = State(initialValue: initialSelection == .voiceCloning ? 1 : 0)
+    }
+
+    static func section(for item: SidebarItem) -> SidebarSection {
+        switch item {
+        case .customVoice, .voiceDesign, .voiceCloning: return .generate
+        case .history, .voices: return .library
+        case .models: return .settings
+        }
     }
 
     static func savedVoiceCloneHandoffPlan(
@@ -233,44 +296,56 @@ struct ContentView: View {
         )
     }
 
+    private var activePlayerTint: Color {
+        switch selectedSection ?? .home {
+        case .home:     return AppTheme.accent
+        case .generate: return AppTheme.modeColor(for: generateMode)
+        case .library:  return AppTheme.library
+        case .settings: return AppTheme.settings
+        }
+    }
+
     var body: some View {
         NavigationSplitView {
             SidebarView(
-                selection: sidebarSelectionBinding,
-                disabledItems: disabledSidebarItems
+                selectedSection: sidebarSelectionBinding,
+                disabledSections: disabledSidebarSections
             )
-                .navigationSplitViewColumnWidth(min: 220, ideal: 250, max: 300)
+                .navigationSplitViewColumnWidth(min: 240, ideal: 280, max: 320)
         } detail: {
             detailContent
         }
         .navigationTitle(currentWindowTitle)
         .toolbar {
             MainWindowToolbar(
-                selectedItem: selectedItem,
+                derivedSidebarItem: derivedSidebarItem,
                 historySortOrder: $historySortOrder,
                 historySearchText: $historySearchText,
                 voicesEnrollRequestID: $voicesEnrollRequestID
             )
         }
         .navigationSplitViewStyle(.balanced)
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            WindowFooterPlayer(modeTint: activePlayerTint)
+                .environmentObject(audioPlayer)
+        }
         .onAppear(perform: handleAppear)
         .task { await handleInitialLoad() }
-        .onChange(of: selectedItem) { _, newValue in handleSelectionChange(newValue) }
+        .onChange(of: selectedSection) { _, _ in handleSelectionChange() }
+        .onChange(of: generateMode) { _, _ in handleSelectionChange() }
+        .onChange(of: libraryTab) { _, _ in handleSelectionChange() }
+        .onChange(of: settingsTab) { _, _ in handleSelectionChange() }
         .onChange(of: modelManager.statuses) { _, _ in handleStatusesChange() }
         .onReceive(appCommandRouter.sidebarSelection) { item in
-            selectSidebarItemIfEnabled(item)
+            navigateToSidebarItem(item)
         }
     }
 
     @ViewBuilder
     private var detailContent: some View {
         Group {
-            if let selectedItem {
-                screenView(for: selectedItem)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            } else {
-                Color.clear
-            }
+            sectionHostView
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .profileBackground(Color(nsColor: .windowBackgroundColor))
@@ -284,47 +359,35 @@ struct ContentView: View {
     }
 
     @ViewBuilder
-    private func screenView(for item: SidebarItem) -> some View {
-        switch item {
-        case .customVoice:
-            CustomVoiceView(
-                draft: $customVoiceDraft,
-                activationID: customVoiceActivationID,
-                ttsEngineStore: ttsEngineStore,
-                audioPlayer: audioPlayer,
-                modelManager: modelManager,
-                appCommandRouter: appCommandRouter
-            )
-        case .voiceDesign:
-            VoiceDesignView(
-                draft: $voiceDesignDraft,
-                activationID: voiceDesignActivationID,
-                ttsEngineStore: ttsEngineStore,
-                audioPlayer: audioPlayer,
-                modelManager: modelManager,
-                savedVoicesViewModel: savedVoicesViewModel,
-                appCommandRouter: appCommandRouter
-            )
-        case .voiceCloning:
-            VoiceCloningView(
-                draft: $voiceCloningDraft,
-                pendingSavedVoiceHandoff: $pendingVoiceCloningHandoff,
-                activationID: voiceCloningActivationID,
+    private var sectionHostView: some View {
+        switch selectedSection ?? .home {
+        case .home:
+            HomeView { mode in
+                navigateToSidebarItem(SidebarItem.item(for: mode))
+            }
+        case .generate:
+            GenerateView(
+                mode: $generateMode,
+                customVoiceDraft: $customVoiceDraft,
+                voiceDesignDraft: $voiceDesignDraft,
+                voiceCloningDraft: $voiceCloningDraft,
+                pendingVoiceCloningHandoff: $pendingVoiceCloningHandoff,
+                customVoiceActivationID: customVoiceActivationID,
+                voiceDesignActivationID: voiceDesignActivationID,
+                voiceCloningActivationID: voiceCloningActivationID,
                 ttsEngineStore: ttsEngineStore,
                 audioPlayer: audioPlayer,
                 modelManager: modelManager,
                 savedVoicesViewModel: savedVoicesViewModel,
                 appCommandRouter: appCommandRouter
             )
-        case .history:
-            HistoryView(
-                searchText: $historySearchText,
-                sortOrder: $historySortOrder
-            )
-        case .voices:
-            VoicesView(
-                enrollRequestID: voicesEnrollRequestID,
-                canUseInVoiceCloning: canUseSavedVoicesInVoiceCloning,
+        case .library:
+            LibraryView(
+                tab: $libraryTab,
+                historySearchText: $historySearchText,
+                historySortOrder: $historySortOrder,
+                voicesEnrollRequestID: voicesEnrollRequestID,
+                canUseSavedVoicesInVoiceCloning: canUseSavedVoicesInVoiceCloning,
                 onUseInVoiceCloning: { voice in
                     let plan = Self.savedVoiceCloneHandoffPlan(
                         for: voice,
@@ -333,8 +396,11 @@ struct ContentView: View {
                     startSavedVoiceCloningHandoff(plan)
                 }
             )
-        case .models:
-            ModelsView(highlightedModelID: $pendingHighlightedModelID)
+        case .settings:
+            SettingsView(
+                tab: $settingsTab,
+                pendingHighlightedModelID: $pendingHighlightedModelID
+            )
         }
     }
 
@@ -351,10 +417,7 @@ struct ContentView: View {
                 engineStore: ttsEngineStore
             )
         }
-        selectSidebarItemIfEnabled(
-            .voiceCloning,
-            bypassDisabledCheck: true
-        )
+        navigateToSidebarItem(.voiceCloning, bypassDisabledCheck: true)
     }
 
     static func beginSavedVoiceClonePreloadIfPossible(
@@ -377,11 +440,13 @@ struct ContentView: View {
         }
     }
 
-    private func handleSelectionChange(_ newValue: SidebarItem?) {
-        if let protectedLaunchOverride, newValue != protectedLaunchOverride {
+    private func handleSelectionChange() {
+        if let protectedLaunchOverride, derivedSidebarItem != protectedLaunchOverride {
             self.protectedLaunchOverride = nil
         }
-        bumpGenerationActivationCounter(for: newValue)
+        if selectedSection == .generate {
+            bumpGenerationActivationCounter(for: generateMode)
+        }
     }
 
     private func handleStatusesChange() {
@@ -392,37 +457,61 @@ struct ContentView: View {
 
     // MARK: - Helper methods
 
-    private func selectSidebarItemIfEnabled(_ item: SidebarItem, bypassDisabledCheck: Bool = false) {
-        guard bypassDisabledCheck || !disabledSidebarItems.contains(item) else { return }
+    private func selectSectionIfEnabled(_ section: SidebarSection) {
+        guard !disabledSidebarSections.contains(section) else { return }
         AppPerformanceSignposts.emit("Sidebar Selection")
-        if selectedItem == item {
+        if selectedSection == section {
             return
         }
-        selectedItem = item
+        selectedSection = section
+    }
+
+    private func navigateToSidebarItem(_ item: SidebarItem, bypassDisabledCheck: Bool = false) {
+        if !bypassDisabledCheck, disabledGenerationItems.contains(item) {
+            return
+        }
+        let targetSection = ContentView.section(for: item)
+        if let mode = item.generationMode {
+            generateMode = mode
+        }
+        if let libraryTab = item.libraryTab {
+            self.libraryTab = libraryTab
+        }
+        if let settingsTab = item.settingsTab {
+            self.settingsTab = settingsTab
+        }
+        if selectedSection != targetSection {
+            selectedSection = targetSection
+        }
     }
 
     private func reconcileSelectionWithAvailability() {
-        guard let selectedItem, disabledSidebarItems.contains(selectedItem) else {
-            return
-        }
+        guard selectedSection == .generate else { return }
+        let currentItem = derivedSidebarItem
+        guard let currentItem, disabledGenerationItems.contains(currentItem) else { return }
 
-        if let modelID = selectedItem.requiredModel?.id {
+        if let modelID = currentItem.requiredModel?.id {
             pendingHighlightedModelID = modelID
         }
 
-        self.selectedItem = .models
+        // Find an available mode; fall back to Settings/Models if none.
+        if let firstAvailable = SidebarItem.generationItems.first(where: { !disabledGenerationItems.contains($0) }),
+           let availableMode = firstAvailable.generationMode {
+            generateMode = availableMode
+        } else {
+            settingsTab = .models
+            selectedSection = .settings
+        }
     }
 
-    private func bumpGenerationActivationCounter(for item: SidebarItem?) {
-        switch item {
-        case .customVoice:
+    private func bumpGenerationActivationCounter(for mode: GenerationMode) {
+        switch mode {
+        case .custom:
             customVoiceActivationID += 1
-        case .voiceDesign:
+        case .design:
             voiceDesignActivationID += 1
-        case .voiceCloning:
+        case .clone:
             voiceCloningActivationID += 1
-        case .history, .voices, .models, .none:
-            break
         }
     }
 }
@@ -472,13 +561,13 @@ private struct HiddenWindowMarkers: View {
 // MARK: - MainWindowToolbar
 
 private struct MainWindowToolbar: ToolbarContent {
-    let selectedItem: SidebarItem?
+    let derivedSidebarItem: SidebarItem?
     @Binding var historySortOrder: HistorySortOrder
     @Binding var historySearchText: String
     @Binding var voicesEnrollRequestID: UUID?
 
     var body: some ToolbarContent {
-        if selectedItem == .history {
+        if derivedSidebarItem == .history {
             ToolbarItem {
                 HStack(spacing: 10) {
                     Menu {
@@ -503,7 +592,7 @@ private struct MainWindowToolbar: ToolbarContent {
             }
         }
 
-        if selectedItem == .voices {
+        if derivedSidebarItem == .voices {
             ToolbarItem {
                 Button("Add Voice Sample") {
                     voicesEnrollRequestID = UUID()

--- a/Sources/Models/SidebarSection.swift
+++ b/Sources/Models/SidebarSection.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+/// Top-level sidebar navigation in the brand-refresh shell.
+/// Sub-screens (modes inside Generate, tabs inside Library/Settings) are
+/// owned by the per-section host views and don't appear in the sidebar.
+enum SidebarSection: String, CaseIterable, Identifiable, Hashable {
+    case home = "Home"
+    case generate = "Generate"
+    case library = "Library"
+    case settings = "Settings"
+
+    var id: String { rawValue }
+
+    var iconName: String {
+        switch self {
+        case .home:     return "sparkles"
+        case .generate: return "waveform"
+        case .library:  return "rectangle.stack"
+        case .settings: return "gearshape"
+        }
+    }
+
+    /// Per-section brand tint (champagne for Home/Generate, silver-gold for
+    /// Library, silver for Settings). Generate's per-mode tint lives one
+    /// level deeper inside the segmented control.
+    var sidebarTint: Color {
+        switch self {
+        case .home, .generate: return AppTheme.accent
+        case .library:         return AppTheme.library
+        case .settings:        return AppTheme.settings
+        }
+    }
+
+    var accessibilityID: String {
+        "sidebarSection_\(rawValue.lowercased())"
+    }
+}
+
+/// Sub-tabs that live inside `SidebarSection.library`.
+enum LibraryTab: String, CaseIterable, Identifiable, Hashable {
+    case history = "History"
+    case voices = "Saved Voices"
+
+    var id: String { rawValue }
+
+    var sidebarItem: SidebarItem {
+        switch self {
+        case .history: return .history
+        case .voices:  return .voices
+        }
+    }
+}
+
+/// Sub-tabs that live inside `SidebarSection.settings`. Preferences keeps
+/// resolving through the existing `Settings` scene wrapper for now —
+/// `models` is the only sub-tab embedded in the main window.
+enum SettingsTab: String, CaseIterable, Identifiable, Hashable {
+    case models = "Models"
+    case preferences = "Preferences"
+
+    var id: String { rawValue }
+
+    var sidebarItem: SidebarItem? {
+        switch self {
+        case .models:      return .models
+        case .preferences: return nil
+        }
+    }
+}
+
+extension GenerationMode: Identifiable {
+    public var id: String { rawValue }
+}
+
+extension SidebarItem {
+    /// The top-level sidebar section that contains this screen.
+    var section: SidebarSection {
+        switch self {
+        case .customVoice, .voiceDesign, .voiceCloning: return .generate
+        case .history, .voices:                          return .library
+        case .models:                                    return .settings
+        }
+    }
+
+    /// The Generate mode this item maps to, when applicable.
+    var libraryTab: LibraryTab? {
+        switch self {
+        case .history: return .history
+        case .voices:  return .voices
+        default:       return nil
+        }
+    }
+
+    var settingsTab: SettingsTab? {
+        switch self {
+        case .models: return .models
+        default:      return nil
+        }
+    }
+}

--- a/Sources/Services/AppLaunchConfiguration.swift
+++ b/Sources/Services/AppLaunchConfiguration.swift
@@ -42,6 +42,19 @@ struct AppLaunchConfiguration {
         return SidebarItem(testScreenID: initialScreenID)
     }
 
+    /// `--uitest-screen=home` lands directly on the Home section, which has
+    /// no `SidebarItem` mapping (it lives one level above the per-screen
+    /// `SidebarItem` cases). Returns `nil` for any other screen ID so the
+    /// regular `initialSidebarItem` path keeps owning Generate/Library/Settings.
+    var initialSidebarSectionOverride: SidebarSection? {
+        guard let initialScreenID,
+              initialScreenID.replacingOccurrences(of: "screen_", with: "") == "home"
+        else {
+            return nil
+        }
+        return .home
+    }
+
     var shouldOpenSettingsOnLaunch: Bool {
         initialScreenID == "preferences"
     }
@@ -59,6 +72,10 @@ struct AppLaunchConfiguration {
     }
 
     var initialSidebarItem: SidebarItem? {
+        nil
+    }
+
+    var initialSidebarSectionOverride: SidebarSection? {
         nil
     }
 

--- a/Sources/Views/Components/AppTheme.swift
+++ b/Sources/Views/Components/AppTheme.swift
@@ -80,12 +80,49 @@ enum AppTheme {
         light: Color(red: 0.70, green: 0.43, blue: 0.24),  // deeper terracotta
         dark:  Color(red: 0.86, green: 0.66, blue: 0.53)   // warm terracotta
     )
-    // Library + Settings continue to resolve to the primary accent (golden) so
-    // non-generation surfaces read as one coherent app chrome.
-    static let history = accent
-    static let voices = accent
-    static let models = accent
-    static let preferences = accent
+    // Per-section tints (silver-gold for Library, silver for Settings) — the
+    // non-generation halves of the app each get their own muted brand color so
+    // chrome stops reading as a single uniform gold while still feeling Vocello.
+    // Dark values match Sources/iOS/IOSShellPrimitives.swift:IOSBrandTheme; light
+    // values are darkened variants for usable WCAG contrast.
+    static let library = Color(
+        light: Color(red: 0.45, green: 0.43, blue: 0.36),
+        dark:  Color(red: 0.75, green: 0.74, blue: 0.71)   // silver-gold
+    )
+    static let settings = Color(
+        light: Color(red: 0.36, green: 0.40, blue: 0.46),
+        dark:  Color(red: 0.68, green: 0.71, blue: 0.76)   // silver
+    )
+    static let history = library
+    static let voices = library
+    static let models = settings
+    static let preferences = settings
+
+    // V mark / wordmark gradient stops.
+    static let brandPurple = Color(
+        light: Color(red: 0.45, green: 0.38, blue: 0.62),
+        dark:  Color(red: 0.73, green: 0.66, blue: 0.84)
+    )
+    static let brandLavender = Color(
+        light: Color(red: 0.62, green: 0.55, blue: 0.74),
+        dark:  Color(red: 0.87, green: 0.82, blue: 0.93)
+    )
+
+    // Status chip dot colors (memory/healthy indicator). Match the iOS
+    // IOSBrandTheme memory* tokens exactly so cross-platform telemetry chips
+    // read identical.
+    static let statusHealthy = Color(
+        light: Color(red: 0.34, green: 0.49, blue: 0.34),
+        dark:  Color(red: 0.55, green: 0.70, blue: 0.55)
+    )
+    static let statusGuarded = Color(
+        light: Color(red: 0.62, green: 0.46, blue: 0.20),
+        dark:  Color(red: 0.85, green: 0.70, blue: 0.45)
+    )
+    static let statusCritical = Color(
+        light: Color(red: 0.62, green: 0.28, blue: 0.28),
+        dark:  Color(red: 0.85, green: 0.50, blue: 0.50)
+    )
 
     static let canvasBackground = Color(
         light: Color(red: 0.952, green: 0.943, blue: 0.920),

--- a/Sources/Views/Components/CormorantTitle.swift
+++ b/Sources/Views/Components/CormorantTitle.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+/// Cormorant Garamond is the Vocello brand serif, used for the wordmark and
+/// the H1 screen title at the top of each detail pane. macOS does not ship
+/// Cormorant in its system font catalog; `Font.custom` silently falls back
+/// to the system serif (Charter) when the font isn't installed. Bundling
+/// the font as an app resource is a planned follow-up.
+enum VocelloTitleStyle {
+    /// Sidebar brand-header wordmark size.
+    static let wordmarkSize: CGFloat = 23
+    /// Detail-pane H1 screen-title size.
+    static let h1Size: CGFloat = 32
+}
+
+extension Font {
+    static func vocelloSerif(_ size: CGFloat, weight: Font.Weight = .bold) -> Font {
+        Font.custom("Cormorant Garamond", size: size).weight(weight)
+    }
+
+    static var vocelloWordmark: Font {
+        vocelloSerif(VocelloTitleStyle.wordmarkSize, weight: .bold)
+    }
+
+    static var vocelloH1: Font {
+        vocelloSerif(VocelloTitleStyle.h1Size, weight: .bold)
+    }
+}
+
+private struct VocelloH1Modifier: ViewModifier {
+    @ScaledMetric private var scaledSize: CGFloat = VocelloTitleStyle.h1Size
+
+    func body(content: Content) -> some View {
+        content
+            .font(.vocelloSerif(scaledSize, weight: .bold))
+            .tracking(-0.6)
+            .foregroundStyle(AppTheme.textPrimary)
+    }
+}
+
+private struct VocelloWordmarkModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .font(.vocelloWordmark)
+            .tracking(-0.5)
+            .foregroundStyle(AppTheme.textPrimary)
+    }
+}
+
+extension View {
+    func vocelloH1() -> some View {
+        modifier(VocelloH1Modifier())
+    }
+
+    func vocelloWordmark() -> some View {
+        modifier(VocelloWordmarkModifier())
+    }
+}

--- a/Sources/Views/Components/LayoutConstants.swift
+++ b/Sources/Views/Components/LayoutConstants.swift
@@ -33,6 +33,55 @@ enum LayoutConstants {
     static let stageRadius: CGFloat = 22
     static let cardBorderWidth: CGFloat = 0.75
     static let controlHeight: CGFloat = 41
+
+    // MARK: - Vocello brand-refresh constants
+    //
+    // Added during the macOS UI ground-up refactor (spec at
+    // docs/superpowers/specs/2026-04-24-vocello-macos-redesign-design.md).
+    // Lives alongside the legacy constants above so existing call sites stay
+    // green; new chrome wires through these instead. Old names are migrated
+    // off in later steps of the refactor.
+
+    /// Card radius matching the iOS reference (replaces the legacy 12pt
+    /// cardRadius once all callers have been switched).
+    static let brandCardRadius: CGFloat = 22
+    /// Recessed in-card sub-surface radius (e.g., editor inside a stage card).
+    static let brandInlinePanelRadius: CGFloat = 16
+    /// Solid editor surface radius (text editors, file drops).
+    static let brandEditorRadius: CGFloat = 18
+    /// Primary-CTA radius (Generate button).
+    static let brandPrimaryCTARadius: CGFloat = 32
+
+    /// Hidden-titlebar glass top bar that holds traffic-light inset +
+    /// contextual toolbar items.
+    static let topGlassBarHeight: CGFloat = 44
+    /// Default-height window-footer player.
+    static let footerPlayerHeight: CGFloat = 76
+    /// Compact-height footer player below 900pt window height.
+    static let footerPlayerCompactHeight: CGFloat = 64
+    /// Maximum width of the footer player's center waveform region (caps it
+    /// at 4K windows so it doesn't stretch into a thin line).
+    static let footerPlayerCenterMaxWidth: CGFloat = 1200
+
+    /// Sidebar brand-header height (V mark + Cormorant wordmark).
+    static let sidebarBrandHeaderHeight: CGFloat = 64
+
+    /// Comfortable centered-form column width — used for text editors and
+    /// other form-shaped content so they don't stretch at 4K. Grids and
+    /// galleries continue to fill available width.
+    static let formContentMaxWidth: CGFloat = 720
+
+    // MARK: - Responsive breakpoints
+
+    /// Below this width the sidebar collapses out of view (toolbar toggle).
+    static let sidebarHideBreakpoint: CGFloat = 900
+    /// Below this width the sidebar uses a compact-rail presentation.
+    static let sidebarCompactBreakpoint: CGFloat = 1100
+    /// Below this width the sidebar uses its `min` column width.
+    static let sidebarIdealBreakpoint: CGFloat = 1400
+    /// Below this width the sidebar uses its `ideal` column width;
+    /// above it, the `max` column width.
+    static let sidebarMaxBreakpoint: CGFloat = 1920
     static let composerDefaultMinHeight: CGFloat = 252
     static let composerEmbeddedMinHeight: CGFloat = 268
     static let composerEmbeddedSpacing: CGFloat = 14

--- a/Sources/Views/Components/VocelloSegmentedControl.swift
+++ b/Sources/Views/Components/VocelloSegmentedControl.swift
@@ -77,14 +77,17 @@ private struct SegmentLabel: View {
     let tint: Color
     let isActive: Bool
 
+    @ScaledMetric private var verticalPadding: CGFloat = 10
+    @ScaledMetric private var horizontalPadding: CGFloat = 14
+
     var body: some View {
         Text(text)
-            .font(.system(size: 14, weight: .semibold))
+            .font(.vocelloFooterTitle)
             .tracking(-0.1)
             .foregroundStyle(isActive ? AppTheme.warmIvory : AppTheme.textSecondary)
             .frame(maxWidth: .infinity)
-            .padding(.vertical, 10)
-            .padding(.horizontal, 14)
+            .padding(.vertical, verticalPadding)
+            .padding(.horizontal, horizontalPadding)
             .background(activeFillBackground)
     }
 

--- a/Sources/Views/Components/VocelloSegmentedControl.swift
+++ b/Sources/Views/Components/VocelloSegmentedControl.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+/// Capsule segmented control for in-pane sub-section navigation
+/// (Generate's Custom/Design/Clone tabs, Library's History/Voices,
+/// Settings' Models/Preferences). Each segment can declare its own tint,
+/// so the active pill picks up the right brand color per section.
+struct VocelloSegmentedControl<Value: Hashable & Identifiable>: View {
+    struct Segment {
+        let value: Value
+        let label: String
+        let tint: Color
+        let accessibilityIdentifier: String?
+
+        init(
+            value: Value,
+            label: String,
+            tint: Color,
+            accessibilityIdentifier: String? = nil
+        ) {
+            self.value = value
+            self.label = label
+            self.tint = tint
+            self.accessibilityIdentifier = accessibilityIdentifier
+        }
+    }
+
+    let segments: [Segment]
+    @Binding var selection: Value
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(segments, id: \.value.id) { segment in
+                segmentButton(segment, isActive: selection == segment.value)
+            }
+        }
+        .padding(4)
+        .background(trackBackground)
+    }
+
+    @ViewBuilder
+    private func segmentButton(_ segment: Segment, isActive: Bool) -> some View {
+        Button {
+            AppLaunchConfiguration.performAnimated(.easeInOut(duration: 0.2)) {
+                selection = segment.value
+            }
+        } label: {
+            SegmentLabel(
+                text: segment.label,
+                tint: segment.tint,
+                isActive: isActive
+            )
+        }
+        .buttonStyle(.plain)
+        .contentShape(Capsule())
+        .accessibilityLabel(segment.label)
+        .accessibilityValue(isActive ? "selected" : "not selected")
+        .ifLet(segment.accessibilityIdentifier) { view, id in
+            view.accessibilityIdentifier(id)
+        }
+    }
+
+    @ViewBuilder
+    private var trackBackground: some View {
+        Capsule(style: .continuous)
+            .fill(AppTheme.cardFill.opacity(colorScheme == .dark ? 0.74 : 0.86))
+            .overlay(
+                Capsule(style: .continuous)
+                    .stroke(AppTheme.cardStroke.opacity(colorScheme == .dark ? 0.18 : 0.40), lineWidth: 0.5)
+            )
+    }
+}
+
+private struct SegmentLabel: View {
+    let text: String
+    let tint: Color
+    let isActive: Bool
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 14, weight: .semibold))
+            .tracking(-0.1)
+            .foregroundStyle(isActive ? AppTheme.warmIvory : AppTheme.textSecondary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+            .padding(.horizontal, 14)
+            .background(activeFillBackground)
+    }
+
+    @ViewBuilder
+    private var activeFillBackground: some View {
+        if isActive {
+            Capsule(style: .continuous)
+                .fill(tint.opacity(0.22))
+                .overlay(
+                    Capsule(style: .continuous)
+                        .stroke(tint.opacity(0.42), lineWidth: 0.75)
+                )
+        } else {
+            Color.clear
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func ifLet<Value, Transform: View>(
+        _ value: Value?,
+        transform: (Self, Value) -> Transform
+    ) -> some View {
+        if let value {
+            transform(self, value)
+        } else {
+            self
+        }
+    }
+}

--- a/Sources/Views/Components/VocelloStatusChip.swift
+++ b/Sources/Views/Components/VocelloStatusChip.swift
@@ -25,40 +25,50 @@ struct VocelloStatusChip: View {
 
     var body: some View {
         HStack(spacing: 6) {
-            Circle()
-                .fill(state.color)
-                .frame(width: 6, height: 6)
-
-            if let memoryMB {
-                Text(memoryFormatted(memoryMB))
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(AppTheme.textSecondary)
-                    .monospacedDigit()
-            }
-
-            if memoryMB != nil {
-                Text("·")
-                    .font(.system(size: 9))
-                    .foregroundStyle(AppTheme.textSecondary.opacity(0.65))
-            }
-
-            Text(state.rawValue)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(state.color)
+            statusDot
+            memoryGroup
+            stateLabel
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 5)
-        .background {
-            Capsule(style: .continuous)
-                .fill(AppTheme.inlineFill.opacity(colorScheme == .dark ? 0.74 : 0.85))
-                .overlay(
-                    Capsule(style: .continuous)
-                        .stroke(AppTheme.inlineStroke.opacity(colorScheme == .dark ? 0.22 : 0.45), lineWidth: 0.5)
-                )
-        }
+        .background(chipBackground)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Runtime status \(state.rawValue)")
         .accessibilityValue(memoryMB.map { "\(Int($0)) megabytes" } ?? "")
+    }
+
+    private var statusDot: some View {
+        Circle()
+            .fill(state.color)
+            .frame(width: 6, height: 6)
+    }
+
+    @ViewBuilder
+    private var memoryGroup: some View {
+        if let memoryMB {
+            Text(memoryFormatted(memoryMB))
+                .font(.vocelloCaption)
+                .foregroundStyle(AppTheme.textSecondary)
+                .monospacedDigit()
+            Text("·")
+                .font(.caption2)
+                .foregroundStyle(AppTheme.textSecondary.opacity(0.65))
+        }
+    }
+
+    private var stateLabel: some View {
+        Text(state.rawValue)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(state.color)
+    }
+
+    private var chipBackground: some View {
+        Capsule(style: .continuous)
+            .fill(AppTheme.inlineFill.opacity(colorScheme == .dark ? 0.74 : 0.85))
+            .overlay(
+                Capsule(style: .continuous)
+                    .stroke(AppTheme.inlineStroke.opacity(colorScheme == .dark ? 0.22 : 0.45), lineWidth: 0.5)
+            )
     }
 
     private func memoryFormatted(_ mb: Double) -> String {

--- a/Sources/Views/Components/VocelloStatusChip.swift
+++ b/Sources/Views/Components/VocelloStatusChip.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+/// Memory / runtime health indicator chip — a colored dot + memory reading +
+/// state label. Mirrors the iOS reference's `VHeader` chip. Uses
+/// `AppTheme.statusHealthy/Guarded/Critical` for the dot tone.
+struct VocelloStatusChip: View {
+    enum State: String {
+        case healthy = "Healthy"
+        case guarded = "Guarded"
+        case critical = "Critical"
+
+        var color: Color {
+            switch self {
+            case .healthy: return AppTheme.statusHealthy
+            case .guarded: return AppTheme.statusGuarded
+            case .critical: return AppTheme.statusCritical
+            }
+        }
+    }
+
+    let memoryMB: Double?
+    let state: State
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(state.color)
+                .frame(width: 6, height: 6)
+
+            if let memoryMB {
+                Text(memoryFormatted(memoryMB))
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(AppTheme.textSecondary)
+                    .monospacedDigit()
+            }
+
+            if memoryMB != nil {
+                Text("·")
+                    .font(.system(size: 9))
+                    .foregroundStyle(AppTheme.textSecondary.opacity(0.65))
+            }
+
+            Text(state.rawValue)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(state.color)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .background {
+            Capsule(style: .continuous)
+                .fill(AppTheme.inlineFill.opacity(colorScheme == .dark ? 0.74 : 0.85))
+                .overlay(
+                    Capsule(style: .continuous)
+                        .stroke(AppTheme.inlineStroke.opacity(colorScheme == .dark ? 0.22 : 0.45), lineWidth: 0.5)
+                )
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Runtime status \(state.rawValue)")
+        .accessibilityValue(memoryMB.map { "\(Int($0)) megabytes" } ?? "")
+    }
+
+    private func memoryFormatted(_ mb: Double) -> String {
+        if mb >= 1024 {
+            return String(format: "%.1f GB", mb / 1024.0)
+        }
+        return String(format: "%.1f MB", mb)
+    }
+}

--- a/Sources/Views/Components/VocelloTypography.swift
+++ b/Sources/Views/Components/VocelloTypography.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// Named Dynamic-Type-backed font roles for the Vocello brand-refresh chrome.
+/// Every font in the new sidebar / footer player / Home / segmented / status
+/// chip surfaces resolves through this enum so a single change here updates
+/// the whole app, and so every label honors the user's macOS Display scale
+/// and Accessibility text-size preference.
+///
+/// Roles:
+///   - `.vocelloMicroLabel`  uppercase wordmark tag, "RECENT TAKES"
+///   - `.vocelloCaption`     status-chip text, footer-player subtitle, mode-launcher sublabel
+///   - `.vocelloMonoTime`    footer-player monospaced time readout
+///   - `.vocelloFooterTitle` footer-player title, segmented-control label
+///   - `.vocelloLauncherTitle` Home mode-launcher card title
+///   - `.vocelloSidebarRow`  sidebar row label
+///
+/// The H1 and wordmark roles live in `CormorantTitle.swift` because they
+/// also carry the brand serif.
+extension Font {
+    static var vocelloMicroLabel: Font { .caption2.weight(.semibold) }
+
+    static var vocelloCaption: Font { .caption.weight(.medium) }
+
+    static var vocelloMonoTime: Font { .caption.weight(.medium).monospacedDigit() }
+
+    static var vocelloFooterTitle: Font { .subheadline.weight(.semibold) }
+
+    static var vocelloLauncherTitle: Font { .callout.weight(.semibold) }
+
+    static func vocelloSidebarRow(active: Bool) -> Font {
+        active ? .body.weight(.semibold) : .body
+    }
+}

--- a/Sources/Views/Components/VocelloVMark.swift
+++ b/Sources/Views/Components/VocelloVMark.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+/// Vocello "V" monogram — Swift port of the SVG used in the iOS reference
+/// (`refs/vocello_mark.png`, traced from `lib/vocello-chrome.jsx:VMark`).
+/// Two overlapping V shapes with a back/front gradient pair.
+///
+/// Default size renders at 28pt × ~24.6pt to match the iOS chrome's wordmark
+/// pairing. Pass an explicit `size` to scale.
+struct VocelloVMark: View {
+    var size: CGFloat = 28
+
+    var body: some View {
+        Canvas { context, canvasSize in
+            let scale = canvasSize.width / 32
+            let backPath = Path { path in
+                path.move(to: CGPoint(x: 2 * scale, y: 2 * scale))
+                path.addLine(to: CGPoint(x: 16 * scale, y: 26 * scale))
+                path.addLine(to: CGPoint(x: 30 * scale, y: 2 * scale))
+                path.addLine(to: CGPoint(x: 23 * scale, y: 2 * scale))
+                path.addLine(to: CGPoint(x: 16 * scale, y: 15 * scale))
+                path.addLine(to: CGPoint(x: 9 * scale, y: 2 * scale))
+                path.closeSubpath()
+            }
+            let frontPath = Path { path in
+                path.move(to: CGPoint(x: 10 * scale, y: 2 * scale))
+                path.addLine(to: CGPoint(x: 16 * scale, y: 13 * scale))
+                path.addLine(to: CGPoint(x: 22 * scale, y: 2 * scale))
+                path.addLine(to: CGPoint(x: 19 * scale, y: 2 * scale))
+                path.addLine(to: CGPoint(x: 16 * scale, y: 8 * scale))
+                path.addLine(to: CGPoint(x: 13 * scale, y: 2 * scale))
+                path.closeSubpath()
+            }
+
+            let backGradient = GraphicsContext.Shading.linearGradient(
+                Gradient(colors: [AppTheme.brandPurple, AppTheme.voiceDesign]),
+                startPoint: .zero,
+                endPoint: CGPoint(x: canvasSize.width, y: canvasSize.height)
+            )
+            context.fill(backPath, with: backGradient)
+
+            // 92% opacity baked into the gradient stops — Canvas shading
+            // doesn't expose a per-fill opacity helper, so we apply it via
+            // the colors themselves to match the iOS reference's frontV alpha.
+            let frontGradient = GraphicsContext.Shading.linearGradient(
+                Gradient(colors: [
+                    Color.white.opacity(0.96 * 0.92),
+                    AppTheme.brandLavender.opacity(0.92),
+                ]),
+                startPoint: CGPoint(x: canvasSize.width / 2, y: 0),
+                endPoint: CGPoint(x: canvasSize.width / 2, y: canvasSize.height)
+            )
+            context.fill(frontPath, with: frontGradient)
+        }
+        .frame(width: size, height: size * 0.875)
+        .accessibilityHidden(true)
+    }
+}

--- a/Sources/Views/Components/VocelloVMark.swift
+++ b/Sources/Views/Components/VocelloVMark.swift
@@ -4,10 +4,19 @@ import SwiftUI
 /// (`refs/vocello_mark.png`, traced from `lib/vocello-chrome.jsx:VMark`).
 /// Two overlapping V shapes with a back/front gradient pair.
 ///
-/// Default size renders at 28pt × ~24.6pt to match the iOS chrome's wordmark
-/// pairing. Pass an explicit `size` to scale.
+/// Default size renders at ~28pt × ~24.6pt to match the iOS chrome's wordmark
+/// pairing, scaled via `@ScaledMetric(relativeTo: .title)` so the mark grows
+/// in lockstep with the Cormorant wordmark when Dynamic Type is enlarged.
+/// Pass an explicit `size` to override and lock the size.
 struct VocelloVMark: View {
-    var size: CGFloat = 28
+    @ScaledMetric(relativeTo: .title) private var scaledSize: CGFloat = 28
+    private let overrideSize: CGFloat?
+
+    init(size: CGFloat? = nil) {
+        self.overrideSize = size
+    }
+
+    private var resolvedSize: CGFloat { overrideSize ?? scaledSize }
 
     var body: some View {
         Canvas { context, canvasSize in
@@ -51,7 +60,7 @@ struct VocelloVMark: View {
             )
             context.fill(frontPath, with: frontGradient)
         }
-        .frame(width: size, height: size * 0.875)
+        .frame(width: resolvedSize, height: resolvedSize * 0.875)
         .accessibilityHidden(true)
     }
 }

--- a/Sources/Views/Components/WindowChromeConfigurator.swift
+++ b/Sources/Views/Components/WindowChromeConfigurator.swift
@@ -45,6 +45,8 @@ struct WindowChromeConfigurator: NSViewRepresentable {
             window.titlebarAppearsTransparent = true
             window.styleMask.insert(.fullSizeContentView)
             window.toolbarStyle = .unified
+            window.isMovableByWindowBackground = true
+            window.minSize = NSSize(width: 1100, height: 720)
             window.identifier = WindowChromeState.configuredWindowIdentifier
         }
 

--- a/Sources/Views/Components/WindowFooterPlayer.swift
+++ b/Sources/Views/Components/WindowFooterPlayer.swift
@@ -23,17 +23,16 @@ struct WindowFooterPlayer: View {
     var modeTint: Color = AppTheme.accent
 
     @Environment(\.colorScheme) private var colorScheme
-
-    private var resolvedHeight: CGFloat {
-        LayoutConstants.footerPlayerHeight
-    }
+    @ScaledMetric private var scaledHeight: CGFloat = LayoutConstants.footerPlayerHeight
+    @ScaledMetric private var scaledCompactHeight: CGFloat = LayoutConstants.footerPlayerCompactHeight
+    @ScaledMetric private var horizontalPadding: CGFloat = 18
 
     var body: some View {
         GeometryReader { geo in
             let isCompact = geo.size.width < LayoutConstants.sidebarHideBreakpoint
             HStack(spacing: 16) {
                 leftRegion
-                    .frame(width: isCompact ? nil : 240, alignment: .leading)
+                    .frame(minWidth: isCompact ? 0 : 240, alignment: .leading)
                     .layoutPriority(2)
 
                 centerRegion
@@ -42,14 +41,14 @@ struct WindowFooterPlayer: View {
 
                 if !isCompact {
                     rightRegion
-                        .frame(width: 180, alignment: .trailing)
+                        .frame(minWidth: 160, alignment: .trailing)
                 }
             }
-            .padding(.horizontal, 18)
-            .frame(width: geo.size.width, height: isCompact ? LayoutConstants.footerPlayerCompactHeight : LayoutConstants.footerPlayerHeight)
+            .padding(.horizontal, horizontalPadding)
+            .frame(width: geo.size.width, height: isCompact ? scaledCompactHeight : scaledHeight)
             .background(footerMaterial)
         }
-        .frame(height: resolvedHeight)
+        .frame(height: scaledHeight)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("windowFooterPlayer")
     }
@@ -74,12 +73,12 @@ struct WindowFooterPlayer: View {
             playDisc
             VStack(alignment: .leading, spacing: 2) {
                 Text(titleText)
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.vocelloFooterTitle)
                     .foregroundStyle(audioPlayer.hasAudio ? AppTheme.textPrimary : AppTheme.textSecondary)
                     .tracking(-0.1)
                     .lineLimit(1)
                 Text(subtitleText)
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.vocelloCaption)
                     .foregroundStyle(AppTheme.textSecondary.opacity(0.85))
                     .lineLimit(1)
             }
@@ -127,7 +126,7 @@ struct WindowFooterPlayer: View {
             Spacer(minLength: 0)
             if audioPlayer.hasAudio {
                 Text(timeReadout)
-                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .font(.vocelloMonoTime)
                     .foregroundStyle(AppTheme.textSecondary)
                     .accessibilityIdentifier("windowFooterPlayer_time")
 
@@ -135,9 +134,9 @@ struct WindowFooterPlayer: View {
                     audioPlayer.dismiss()
                 } label: {
                     Image(systemName: "xmark")
-                        .font(.system(size: 12, weight: .semibold))
+                        .font(.caption.weight(.semibold))
                         .foregroundStyle(AppTheme.textSecondary)
-                        .frame(width: 28, height: 28)
+                        .frame(width: dismissButtonSize, height: dismissButtonSize)
                         .background(
                             Circle().fill(AppTheme.inlineFill.opacity(0.6))
                         )
@@ -150,6 +149,9 @@ struct WindowFooterPlayer: View {
     }
 
     // MARK: - Play disc
+
+    @ScaledMetric private var playDiscSize: CGFloat = 44
+    @ScaledMetric private var dismissButtonSize: CGFloat = 28
 
     @ViewBuilder
     private var playDisc: some View {
@@ -174,7 +176,7 @@ struct WindowFooterPlayer: View {
                                 endPoint: .bottom
                             )
                     )
-                    .frame(width: 44, height: 44)
+                    .frame(width: playDiscSize, height: playDiscSize)
                     .shadow(
                         color: audioPlayer.hasAudio ? modeTint.opacity(0.32) : .clear,
                         radius: 8, y: 4
@@ -187,7 +189,7 @@ struct WindowFooterPlayer: View {
                         .tint(Color.black.opacity(0.78))
                 } else {
                     Image(systemName: audioPlayer.isPlaying ? "pause.fill" : "play.fill")
-                        .font(.system(size: 14, weight: .bold))
+                        .font(.body.weight(.bold))
                         .foregroundStyle(audioPlayer.hasAudio ? Color.black.opacity(0.78) : AppTheme.textSecondary)
                 }
             }

--- a/Sources/Views/Components/WindowFooterPlayer.swift
+++ b/Sources/Views/Components/WindowFooterPlayer.swift
@@ -1,0 +1,224 @@
+import SwiftUI
+
+/// Persistent take player pinned to the bottom of the entire window —
+/// spans full window width across sidebar + detail. Replaces the
+/// sidebar-bottom `SidebarPlayerView` from the previous chrome.
+///
+/// Three regions left-to-right:
+///   • Left (240pt): play/pause disc + take title + subtitle metadata
+///   • Center (flex, capped at 1200pt): scrubable animated waveform
+///   • Right (180pt): take number badge + Download + ellipsis actions
+///
+/// At narrow widths (<900pt) the row collapses to compact mode: the
+/// right region hides and the player height drops to 64pt.
+///
+/// Visual states are derived from `AudioPlayerViewModel`:
+///   • idle:       no audio (`hasAudio == false`) — muted disc, tagline
+///   • generating: live stream in progress — orbit spinner
+///   • ready:      audio loaded, not playing — play button on tinted disc
+///   • playing:    audio playing — pause button on tinted disc
+struct WindowFooterPlayer: View {
+    @EnvironmentObject var audioPlayer: AudioPlayerViewModel
+    @EnvironmentObject var playbackProgress: AudioPlayerViewModel.PlaybackProgress
+    var modeTint: Color = AppTheme.accent
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var resolvedHeight: CGFloat {
+        LayoutConstants.footerPlayerHeight
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            let isCompact = geo.size.width < LayoutConstants.sidebarHideBreakpoint
+            HStack(spacing: 16) {
+                leftRegion
+                    .frame(width: isCompact ? nil : 240, alignment: .leading)
+                    .layoutPriority(2)
+
+                centerRegion
+                    .frame(maxWidth: LayoutConstants.footerPlayerCenterMaxWidth)
+                    .layoutPriority(1)
+
+                if !isCompact {
+                    rightRegion
+                        .frame(width: 180, alignment: .trailing)
+                }
+            }
+            .padding(.horizontal, 18)
+            .frame(width: geo.size.width, height: isCompact ? LayoutConstants.footerPlayerCompactHeight : LayoutConstants.footerPlayerHeight)
+            .background(footerMaterial)
+        }
+        .frame(height: resolvedHeight)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("windowFooterPlayer")
+    }
+
+    @ViewBuilder
+    private var footerMaterial: some View {
+        Rectangle()
+            .fill(Color(red: 0.078, green: 0.086, blue: 0.110).opacity(colorScheme == .dark ? 0.93 : 0.86))
+            .background(.ultraThinMaterial)
+            .overlay(alignment: .top) {
+                Rectangle()
+                    .fill(AppTheme.railStroke.opacity(colorScheme == .dark ? 0.85 : 0.30))
+                    .frame(height: 0.5)
+            }
+    }
+
+    // MARK: - Regions
+
+    @ViewBuilder
+    private var leftRegion: some View {
+        HStack(spacing: 12) {
+            playDisc
+            VStack(alignment: .leading, spacing: 2) {
+                Text(titleText)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(audioPlayer.hasAudio ? AppTheme.textPrimary : AppTheme.textSecondary)
+                    .tracking(-0.1)
+                    .lineLimit(1)
+                Text(subtitleText)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(AppTheme.textSecondary.opacity(0.85))
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var centerRegion: some View {
+        if audioPlayer.hasAudio {
+            GeometryReader { geo in
+                WaveformView(
+                    samples: audioPlayer.waveformSamples,
+                    progress: playbackProgress.progress
+                )
+                .contentShape(Rectangle())
+                .onTapGesture { location in
+                    guard audioPlayer.canSeek else { return }
+                    let fraction = max(0, min(1, location.x / geo.size.width))
+                    audioPlayer.seek(to: fraction)
+                }
+            }
+            .frame(height: 28)
+            .opacity(audioPlayer.canSeek ? 1.0 : 0.7)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Take waveform")
+            .accessibilityValue(audioPlayer.canSeek ? "seek enabled" : "seek disabled")
+        } else {
+            // Idle decoration: a faint static waveform silhouette.
+            HStack(spacing: 2) {
+                ForEach(0..<48, id: \.self) { i in
+                    let h: CGFloat = 4 + CGFloat((i * 37) % 17)
+                    RoundedRectangle(cornerRadius: 1.5)
+                        .fill(AppTheme.textSecondary.opacity(0.18))
+                        .frame(width: 3, height: h)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .accessibilityHidden(true)
+        }
+    }
+
+    @ViewBuilder
+    private var rightRegion: some View {
+        HStack(spacing: 8) {
+            Spacer(minLength: 0)
+            if audioPlayer.hasAudio {
+                Text(timeReadout)
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(AppTheme.textSecondary)
+                    .accessibilityIdentifier("windowFooterPlayer_time")
+
+                Button {
+                    audioPlayer.dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(AppTheme.textSecondary)
+                        .frame(width: 28, height: 28)
+                        .background(
+                            Circle().fill(AppTheme.inlineFill.opacity(0.6))
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss take")
+                .accessibilityIdentifier("windowFooterPlayer_dismiss")
+            }
+        }
+    }
+
+    // MARK: - Play disc
+
+    @ViewBuilder
+    private var playDisc: some View {
+        Button {
+            guard audioPlayer.hasAudio else { return }
+            AppLaunchConfiguration.performAnimated(.spring(response: 0.3, dampingFraction: 0.7)) {
+                audioPlayer.togglePlayPause()
+            }
+        } label: {
+            ZStack {
+                Circle()
+                    .fill(
+                        audioPlayer.hasAudio
+                            ? LinearGradient(
+                                colors: [modeTint, modeTint.opacity(0.86)],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                            : LinearGradient(
+                                colors: [AppTheme.inlineFill.opacity(0.85), AppTheme.inlineFill.opacity(0.70)],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                    )
+                    .frame(width: 44, height: 44)
+                    .shadow(
+                        color: audioPlayer.hasAudio ? modeTint.opacity(0.32) : .clear,
+                        radius: 8, y: 4
+                    )
+
+                if audioPlayer.isLiveStream {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .controlSize(.small)
+                        .tint(Color.black.opacity(0.78))
+                } else {
+                    Image(systemName: audioPlayer.isPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundStyle(audioPlayer.hasAudio ? Color.black.opacity(0.78) : AppTheme.textSecondary)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(!audioPlayer.hasAudio)
+        .accessibilityLabel(audioPlayer.isPlaying ? "Pause" : "Play")
+        .accessibilityIdentifier("windowFooterPlayer_playPause")
+        .accessibilityValue(audioPlayer.isPlaying ? "playing" : "paused")
+    }
+
+    // MARK: - Text
+
+    private var titleText: String {
+        if audioPlayer.hasAudio {
+            return audioPlayer.currentTitle.isEmpty ? "Untitled take" : audioPlayer.currentTitle
+        }
+        return "Latest take will appear here"
+    }
+
+    private var subtitleText: String {
+        if audioPlayer.isLiveStream {
+            return "Generating · synthesizing on-device"
+        }
+        if audioPlayer.hasAudio {
+            return "\(playbackProgress.formattedCurrentTime) of \(audioPlayer.durationDisplayText)"
+        }
+        return "Tap Generate to create one"
+    }
+
+    private var timeReadout: String {
+        "\(playbackProgress.formattedCurrentTime) / \(audioPlayer.durationDisplayText)"
+    }
+}

--- a/Sources/Views/Generate/GenerateView.swift
+++ b/Sources/Views/Generate/GenerateView.swift
@@ -26,6 +26,9 @@ struct GenerateView: View {
     let savedVoicesViewModel: SavedVoicesViewModel
     let appCommandRouter: AppCommandRouter
 
+    @ScaledMetric private var horizontalInset: CGFloat = 28
+    @ScaledMetric private var topInset: CGFloat = 24
+
     private var modeSegments: [VocelloSegmentedControl<GenerationMode>.Segment] {
         [
             .init(value: .custom, label: "Custom", tint: AppTheme.customVoice, accessibilityIdentifier: "generate_tab_custom"),
@@ -44,11 +47,11 @@ struct GenerateView: View {
                     segments: modeSegments,
                     selection: $mode
                 )
-                .frame(maxWidth: 540, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
                 .accessibilityIdentifier("generate_modeSegmented")
             }
-            .padding(.horizontal, 28)
-            .padding(.top, 24)
+            .padding(.horizontal, horizontalInset)
+            .padding(.top, topInset)
 
             modeContent
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/Views/Generate/GenerateView.swift
+++ b/Sources/Views/Generate/GenerateView.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+import QwenVoiceNative
+
+/// Host view for the Generate section. Owns the brand H1, the mode
+/// segmented control, and the routing into the per-mode views
+/// (CustomVoice / VoiceDesign / VoiceCloning).
+///
+/// State is passed through from `ContentView` so generation drafts,
+/// activation counters, and pending handoffs persist across mode swaps.
+@MainActor
+struct GenerateView: View {
+    @Binding var mode: GenerationMode
+
+    @Binding var customVoiceDraft: CustomVoiceDraft
+    @Binding var voiceDesignDraft: VoiceDesignDraft
+    @Binding var voiceCloningDraft: VoiceCloningDraft
+    @Binding var pendingVoiceCloningHandoff: PendingVoiceCloningHandoff?
+
+    let customVoiceActivationID: Int
+    let voiceDesignActivationID: Int
+    let voiceCloningActivationID: Int
+
+    let ttsEngineStore: TTSEngineStore
+    let audioPlayer: AudioPlayerViewModel
+    let modelManager: ModelManagerViewModel
+    let savedVoicesViewModel: SavedVoicesViewModel
+    let appCommandRouter: AppCommandRouter
+
+    private var modeSegments: [VocelloSegmentedControl<GenerationMode>.Segment] {
+        [
+            .init(value: .custom, label: "Custom", tint: AppTheme.customVoice, accessibilityIdentifier: "generate_tab_custom"),
+            .init(value: .design, label: "Design", tint: AppTheme.voiceDesign, accessibilityIdentifier: "generate_tab_design"),
+            .init(value: .clone,  label: "Clone",  tint: AppTheme.voiceCloning, accessibilityIdentifier: "generate_tab_clone"),
+        ]
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 14) {
+                Text("Generate")
+                    .vocelloH1()
+
+                VocelloSegmentedControl(
+                    segments: modeSegments,
+                    selection: $mode
+                )
+                .frame(maxWidth: 540, alignment: .leading)
+                .accessibilityIdentifier("generate_modeSegmented")
+            }
+            .padding(.horizontal, 28)
+            .padding(.top, 24)
+
+            modeContent
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .accessibilityIdentifier("screen_generate")
+    }
+
+    @ViewBuilder
+    private var modeContent: some View {
+        switch mode {
+        case .custom:
+            CustomVoiceView(
+                draft: $customVoiceDraft,
+                activationID: customVoiceActivationID,
+                ttsEngineStore: ttsEngineStore,
+                audioPlayer: audioPlayer,
+                modelManager: modelManager,
+                appCommandRouter: appCommandRouter
+            )
+            .accessibilityIdentifier("screen_customVoice")
+        case .design:
+            VoiceDesignView(
+                draft: $voiceDesignDraft,
+                activationID: voiceDesignActivationID,
+                ttsEngineStore: ttsEngineStore,
+                audioPlayer: audioPlayer,
+                modelManager: modelManager,
+                savedVoicesViewModel: savedVoicesViewModel,
+                appCommandRouter: appCommandRouter
+            )
+            .accessibilityIdentifier("screen_voiceDesign")
+        case .clone:
+            VoiceCloningView(
+                draft: $voiceCloningDraft,
+                pendingSavedVoiceHandoff: $pendingVoiceCloningHandoff,
+                activationID: voiceCloningActivationID,
+                ttsEngineStore: ttsEngineStore,
+                audioPlayer: audioPlayer,
+                modelManager: modelManager,
+                savedVoicesViewModel: savedVoicesViewModel,
+                appCommandRouter: appCommandRouter
+            )
+            .accessibilityIdentifier("screen_voiceCloning")
+        }
+    }
+}

--- a/Sources/Views/Home/HomeView.swift
+++ b/Sources/Views/Home/HomeView.swift
@@ -1,0 +1,200 @@
+import SwiftUI
+
+/// Landing screen — greeting, voice-orb hero, three mode launchers.
+/// Recent-takes integration with the history database is a planned
+/// follow-up; the placeholder card surfaces the slot today.
+@MainActor
+struct HomeView: View {
+    let onSelectMode: (GenerationMode) -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 28) {
+                heroBlock
+                launchersGrid
+                recentTakesPlaceholder
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 32)
+            .padding(.top, 32)
+            .padding(.bottom, 24)
+            .frame(maxWidth: 1040, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .accessibilityIdentifier("screen_home")
+    }
+
+    private var heroBlock: some View {
+        HStack(alignment: .center, spacing: 22) {
+            VoiceOrb(size: 96)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(greeting)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(AppTheme.textSecondary)
+                    .tracking(0.2)
+
+                Text("What should we voice today?")
+                    .vocelloH1()
+            }
+        }
+    }
+
+    private var launchersGrid: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 240, maximum: 360), spacing: 14, alignment: .topLeading)],
+            spacing: 14
+        ) {
+            ForEach(GenerationMode.allCases, id: \.self) { mode in
+                HomeModeLauncher(mode: mode) {
+                    onSelectMode(mode)
+                }
+            }
+        }
+    }
+
+    private var recentTakesPlaceholder: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("RECENT TAKES")
+                .font(.system(size: 11, weight: .semibold))
+                .tracking(1.4)
+                .foregroundStyle(AppTheme.textSecondary)
+
+            HStack(spacing: 12) {
+                Image(systemName: "clock.arrow.circlepath")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(AppTheme.library)
+                    .frame(width: 36, height: 36)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .fill(AppTheme.library.opacity(0.18))
+                    )
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Your recent takes will appear here")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(AppTheme.textPrimary)
+                    Text("Generate something to start your library.")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(AppTheme.textSecondary)
+                }
+                Spacer()
+            }
+            .padding(18)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(placeholderBackground)
+        }
+    }
+
+    private var placeholderBackground: some View {
+        let shape = RoundedRectangle(cornerRadius: LayoutConstants.brandCardRadius, style: .continuous)
+        return shape
+            .fill(AppTheme.cardFill.opacity(0.74))
+            .overlay(shape.stroke(AppTheme.cardStroke.opacity(0.4), lineWidth: 0.5))
+    }
+
+    private var greeting: String {
+        let hour = Calendar.current.component(.hour, from: Date())
+        switch hour {
+        case 5..<12:  return "Good morning"
+        case 12..<17: return "Good afternoon"
+        case 17..<22: return "Good evening"
+        default:      return "Good night"
+        }
+    }
+}
+
+private struct HomeModeLauncher: View {
+    let mode: GenerationMode
+    let action: () -> Void
+
+    private var tint: Color {
+        AppTheme.modeColor(for: mode)
+    }
+
+    private var label: String {
+        switch mode {
+        case .custom: return "Choose Voice"
+        case .design: return "Describe Voice"
+        case .clone:  return "Use Reference"
+        }
+    }
+
+    private var sublabel: String {
+        switch mode {
+        case .custom: return "Built-in speakers"
+        case .design: return "Natural-language tone"
+        case .clone:  return "From a short audio clip"
+        }
+    }
+
+    private var iconName: String {
+        switch mode {
+        case .custom: return "person.wave.2"
+        case .design: return "text.bubble"
+        case .clone:  return "waveform.badge.plus"
+        }
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HomeModeLauncherCard(
+                tint: tint,
+                iconName: iconName,
+                label: label,
+                sublabel: sublabel
+            )
+        }
+        .buttonStyle(.plain)
+        .contentShape(RoundedRectangle(cornerRadius: LayoutConstants.brandCardRadius, style: .continuous))
+        .accessibilityLabel(label)
+        .accessibilityHint(sublabel)
+    }
+}
+
+private struct HomeModeLauncherCard: View {
+    let tint: Color
+    let iconName: String
+    let label: String
+    let sublabel: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            iconBadge
+            textBlock
+            Spacer(minLength: 0)
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, minHeight: 132, alignment: .topLeading)
+        .background(cardBackground)
+    }
+
+    private var iconBadge: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(tint.opacity(0.20))
+                .frame(width: 40, height: 40)
+            Image(systemName: iconName)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(tint)
+        }
+    }
+
+    private var textBlock: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(AppTheme.textPrimary)
+            Text(sublabel)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(AppTheme.textSecondary)
+        }
+    }
+
+    private var cardBackground: some View {
+        let shape = RoundedRectangle(cornerRadius: LayoutConstants.brandCardRadius, style: .continuous)
+        return shape
+            .fill(tint.opacity(0.10))
+            .overlay(shape.stroke(tint.opacity(0.28), lineWidth: 0.75))
+    }
+}

--- a/Sources/Views/Home/HomeView.swift
+++ b/Sources/Views/Home/HomeView.swift
@@ -7,16 +7,20 @@ import SwiftUI
 struct HomeView: View {
     let onSelectMode: (GenerationMode) -> Void
 
+    @ScaledMetric private var horizontalPadding: CGFloat = 32
+    @ScaledMetric private var topPadding: CGFloat = 32
+    @ScaledMetric private var verticalSpacing: CGFloat = 28
+
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 28) {
+            VStack(alignment: .leading, spacing: verticalSpacing) {
                 heroBlock
                 launchersGrid
                 recentTakesPlaceholder
                 Spacer(minLength: 0)
             }
-            .padding(.horizontal, 32)
-            .padding(.top, 32)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.top, topPadding)
             .padding(.bottom, 24)
             .frame(maxWidth: 1040, alignment: .leading)
             .frame(maxWidth: .infinity, alignment: .center)
@@ -27,11 +31,11 @@ struct HomeView: View {
 
     private var heroBlock: some View {
         HStack(alignment: .center, spacing: 22) {
-            VoiceOrb(size: 96)
+            VoiceOrb()
 
             VStack(alignment: .leading, spacing: 6) {
                 Text(greeting)
-                    .font(.system(size: 13, weight: .medium))
+                    .font(.subheadline.weight(.medium))
                     .foregroundStyle(AppTheme.textSecondary)
                     .tracking(0.2)
 
@@ -57,25 +61,25 @@ struct HomeView: View {
     private var recentTakesPlaceholder: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("RECENT TAKES")
-                .font(.system(size: 11, weight: .semibold))
+                .font(.vocelloMicroLabel)
                 .tracking(1.4)
                 .foregroundStyle(AppTheme.textSecondary)
 
             HStack(spacing: 12) {
                 Image(systemName: "clock.arrow.circlepath")
-                    .font(.system(size: 18, weight: .semibold))
+                    .font(.title3.weight(.semibold))
                     .foregroundStyle(AppTheme.library)
-                    .frame(width: 36, height: 36)
+                    .frame(width: placeholderIconSize, height: placeholderIconSize)
                     .background(
                         RoundedRectangle(cornerRadius: 10, style: .continuous)
                             .fill(AppTheme.library.opacity(0.18))
                     )
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Your recent takes will appear here")
-                        .font(.system(size: 14, weight: .semibold))
+                        .font(.vocelloFooterTitle)
                         .foregroundStyle(AppTheme.textPrimary)
                     Text("Generate something to start your library.")
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.vocelloCaption)
                         .foregroundStyle(AppTheme.textSecondary)
                 }
                 Spacer()
@@ -85,6 +89,8 @@ struct HomeView: View {
             .background(placeholderBackground)
         }
     }
+
+    @ScaledMetric private var placeholderIconSize: CGFloat = 36
 
     private var placeholderBackground: some View {
         let shape = RoundedRectangle(cornerRadius: LayoutConstants.brandCardRadius, style: .continuous)
@@ -158,6 +164,8 @@ private struct HomeModeLauncherCard: View {
     let label: String
     let sublabel: String
 
+    @ScaledMetric private var iconBadgeSize: CGFloat = 40
+
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             iconBadge
@@ -165,7 +173,7 @@ private struct HomeModeLauncherCard: View {
             Spacer(minLength: 0)
         }
         .padding(18)
-        .frame(maxWidth: .infinity, minHeight: 132, alignment: .topLeading)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
         .background(cardBackground)
     }
 
@@ -173,9 +181,9 @@ private struct HomeModeLauncherCard: View {
         ZStack {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(tint.opacity(0.20))
-                .frame(width: 40, height: 40)
+                .frame(width: iconBadgeSize, height: iconBadgeSize)
             Image(systemName: iconName)
-                .font(.system(size: 17, weight: .semibold))
+                .font(.title3.weight(.semibold))
                 .foregroundStyle(tint)
         }
     }
@@ -183,10 +191,10 @@ private struct HomeModeLauncherCard: View {
     private var textBlock: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(label)
-                .font(.system(size: 15, weight: .semibold))
+                .font(.vocelloLauncherTitle)
                 .foregroundStyle(AppTheme.textPrimary)
             Text(sublabel)
-                .font(.system(size: 12, weight: .medium))
+                .font(.vocelloCaption)
                 .foregroundStyle(AppTheme.textSecondary)
         }
     }

--- a/Sources/Views/Home/VoiceOrb.swift
+++ b/Sources/Views/Home/VoiceOrb.swift
@@ -7,7 +7,14 @@ import SwiftUI
 /// Honors `Reduce Motion`: when on, the rotation is suppressed and the
 /// orb renders as a static gradient.
 struct VoiceOrb: View {
-    var size: CGFloat = 96
+    @ScaledMetric(relativeTo: .largeTitle) private var scaledSize: CGFloat = 96
+    private let overrideSize: CGFloat?
+
+    init(size: CGFloat? = nil) {
+        self.overrideSize = size
+    }
+
+    private var size: CGFloat { overrideSize ?? scaledSize }
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var phase: Angle = .degrees(0)

--- a/Sources/Views/Home/VoiceOrb.swift
+++ b/Sources/Views/Home/VoiceOrb.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// Decorative voice orb used in the Home hero — a slowly-rotating conic
+/// gradient with a soft inner radial highlight and a centered waveform
+/// glyph. Matches `lib/screen-home.jsx:VOrb` from the iOS reference.
+///
+/// Honors `Reduce Motion`: when on, the rotation is suppressed and the
+/// orb renders as a static gradient.
+struct VoiceOrb: View {
+    var size: CGFloat = 96
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var phase: Angle = .degrees(0)
+
+    var body: some View {
+        ZStack {
+            AngularGradient(
+                gradient: Gradient(colors: [
+                    AppTheme.accent,
+                    AppTheme.voiceDesign,
+                    AppTheme.voiceCloning,
+                    AppTheme.brandLavender,
+                    AppTheme.accent
+                ]),
+                center: .center,
+                angle: phase
+            )
+            .blur(radius: size * 0.06)
+
+            Circle()
+                .inset(by: size * 0.10)
+                .fill(
+                    RadialGradient(
+                        gradient: Gradient(colors: [
+                            Color.white.opacity(0.20),
+                            Color(red: 0.04, green: 0.043, blue: 0.051).opacity(0.85)
+                        ]),
+                        center: UnitPoint(x: 0.30, y: 0.30),
+                        startRadius: 0,
+                        endRadius: size * 0.45
+                    )
+                )
+
+            Image(systemName: "waveform")
+                .font(.system(size: size * 0.36, weight: .semibold))
+                .foregroundStyle(Color.white.opacity(0.85))
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+        .overlay(
+            Circle().stroke(AppTheme.cardStroke.opacity(0.4), lineWidth: 0.5)
+        )
+        .shadow(color: AppTheme.brandLavender.opacity(0.25), radius: 14, y: 8)
+        .onAppear { startRotationIfAllowed() }
+        .onChange(of: reduceMotion) { _, _ in startRotationIfAllowed() }
+        .accessibilityHidden(true)
+    }
+
+    private func startRotationIfAllowed() {
+        guard !reduceMotion else {
+            phase = .degrees(90)
+            return
+        }
+        phase = .degrees(90)
+        withAnimation(.linear(duration: 14).repeatForever(autoreverses: false)) {
+            phase = .degrees(450)
+        }
+    }
+}

--- a/Sources/Views/Library/LibraryView.swift
+++ b/Sources/Views/Library/LibraryView.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// Host view for the Library section. Owns the brand H1, the
+/// History/Voices segmented control, and the routing into the per-tab
+/// views.
+@MainActor
+struct LibraryView: View {
+    @Binding var tab: LibraryTab
+    @Binding var historySearchText: String
+    @Binding var historySortOrder: HistorySortOrder
+    let voicesEnrollRequestID: UUID?
+    let canUseSavedVoicesInVoiceCloning: Bool
+    let onUseInVoiceCloning: (Voice) -> Void
+
+    private var tabSegments: [VocelloSegmentedControl<LibraryTab>.Segment] {
+        [
+            .init(value: .history, label: "History", tint: AppTheme.library, accessibilityIdentifier: "library_tab_history"),
+            .init(value: .voices,  label: "Voices",  tint: AppTheme.library, accessibilityIdentifier: "library_tab_voices"),
+        ]
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 14) {
+                Text("Library")
+                    .vocelloH1()
+
+                VocelloSegmentedControl(
+                    segments: tabSegments,
+                    selection: $tab
+                )
+                .frame(maxWidth: 360, alignment: .leading)
+                .accessibilityIdentifier("library_tabSegmented")
+            }
+            .padding(.horizontal, 28)
+            .padding(.top, 24)
+
+            tabContent
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .accessibilityIdentifier("screen_library")
+    }
+
+    @ViewBuilder
+    private var tabContent: some View {
+        switch tab {
+        case .history:
+            HistoryView(
+                searchText: $historySearchText,
+                sortOrder: $historySortOrder
+            )
+            .accessibilityIdentifier("screen_history")
+        case .voices:
+            VoicesView(
+                enrollRequestID: voicesEnrollRequestID,
+                canUseInVoiceCloning: canUseSavedVoicesInVoiceCloning,
+                onUseInVoiceCloning: onUseInVoiceCloning
+            )
+            .accessibilityIdentifier("screen_voices")
+        }
+    }
+}

--- a/Sources/Views/Library/LibraryView.swift
+++ b/Sources/Views/Library/LibraryView.swift
@@ -12,6 +12,9 @@ struct LibraryView: View {
     let canUseSavedVoicesInVoiceCloning: Bool
     let onUseInVoiceCloning: (Voice) -> Void
 
+    @ScaledMetric private var horizontalInset: CGFloat = 28
+    @ScaledMetric private var topInset: CGFloat = 24
+
     private var tabSegments: [VocelloSegmentedControl<LibraryTab>.Segment] {
         [
             .init(value: .history, label: "History", tint: AppTheme.library, accessibilityIdentifier: "library_tab_history"),
@@ -29,11 +32,11 @@ struct LibraryView: View {
                     segments: tabSegments,
                     selection: $tab
                 )
-                .frame(maxWidth: 360, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
                 .accessibilityIdentifier("library_tabSegmented")
             }
-            .padding(.horizontal, 28)
-            .padding(.top, 24)
+            .padding(.horizontal, horizontalInset)
+            .padding(.top, topInset)
 
             tabContent
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/Views/Settings/SettingsView.swift
+++ b/Sources/Views/Settings/SettingsView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Host view for the Settings section. Owns the brand H1 and embeds the
+/// Models tab. Preferences continues to live in the system Settings scene
+/// opened via Cmd+,; integrating it as an in-pane segmented tab is a
+/// follow-up to this brand-refresh refactor.
+@MainActor
+struct SettingsView: View {
+    @Binding var tab: SettingsTab
+    @Binding var pendingHighlightedModelID: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text("Settings")
+                .vocelloH1()
+                .padding(.horizontal, 28)
+                .padding(.top, 24)
+
+            tabContent
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .accessibilityIdentifier("screen_settings")
+    }
+
+    @ViewBuilder
+    private var tabContent: some View {
+        switch tab {
+        case .models, .preferences:
+            ModelsView(highlightedModelID: $pendingHighlightedModelID)
+                .accessibilityIdentifier("screen_models")
+        }
+    }
+}

--- a/Sources/Views/Settings/SettingsView.swift
+++ b/Sources/Views/Settings/SettingsView.swift
@@ -9,12 +9,15 @@ struct SettingsView: View {
     @Binding var tab: SettingsTab
     @Binding var pendingHighlightedModelID: String?
 
+    @ScaledMetric private var horizontalInset: CGFloat = 28
+    @ScaledMetric private var topInset: CGFloat = 24
+
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
             Text("Settings")
                 .vocelloH1()
-                .padding(.horizontal, 28)
-                .padding(.top, 24)
+                .padding(.horizontal, horizontalInset)
+                .padding(.top, topInset)
 
             tabContent
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/Views/Sidebar/SidebarView.swift
+++ b/Sources/Views/Sidebar/SidebarView.swift
@@ -15,7 +15,7 @@ private struct SidebarBrandHeader: View {
                 .vocelloWordmark()
 
             Text("AI-TTS")
-                .font(.system(size: 11, weight: .semibold))
+                .font(.vocelloMicroLabel)
                 .tracking(0.6)
                 .foregroundStyle(AppTheme.textSecondary.opacity(0.55))
 
@@ -24,7 +24,7 @@ private struct SidebarBrandHeader: View {
         .padding(.horizontal, 14)
         .padding(.top, 18)
         .padding(.bottom, 12)
-        .frame(height: LayoutConstants.sidebarBrandHeaderHeight, alignment: .leading)
+        .frame(minHeight: LayoutConstants.sidebarBrandHeaderHeight, alignment: .leading)
         .accessibilityHidden(true)
     }
 }
@@ -79,12 +79,13 @@ private struct SidebarSectionRow: View {
     var body: some View {
         HStack(spacing: 10) {
             Image(systemName: section.iconName)
-                .font(.system(size: 17, weight: isSelected ? .semibold : .regular))
+                .font(.body.weight(isSelected ? .semibold : .regular))
+                .imageScale(.large)
                 .foregroundStyle(iconColor)
                 .frame(width: 22, alignment: .center)
 
             Text(section.rawValue)
-                .font(.system(size: 14, weight: isSelected ? .semibold : .regular))
+                .font(.vocelloSidebarRow(active: isSelected))
                 .foregroundStyle(textColor)
                 .lineLimit(1)
 
@@ -93,7 +94,7 @@ private struct SidebarSectionRow: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(height: 36)
+        .frame(minHeight: 36)
         .background(rowBackground)
         .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         .onTapGesture {

--- a/Sources/Views/Sidebar/SidebarView.swift
+++ b/Sources/Views/Sidebar/SidebarView.swift
@@ -1,358 +1,183 @@
 import SwiftUI
 import QwenVoiceNative
 
-private struct SidebarSectionHeader: View {
-    let title: String
-    let accessibilityID: String
-
-    var body: some View {
-        Text(title)
-            .font(.caption.weight(.semibold))
-            .foregroundStyle(AppTheme.textSecondary)
-            .textCase(nil)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel(title)
-            .accessibilityIdentifier(accessibilityID)
-    }
-}
-
-/// Compact Vocello brand lockup pinned to the top of the sidebar via
-/// `safeAreaInset(edge: .top)`. Reuses the bundled `VocelloHeaderMark`
-/// asset that the iPhone target already ships; the same asset carries the
-/// Vocello wordmark + V glyph so we don't need to ship a separate macOS
-/// lockup. Stays out of the List's scroll region so the brand anchor
-/// remains visible as the user scrolls through sections.
+/// Compact Vocello brand lockup pinned to the top of the sidebar.
+/// Pairs the V monogram (drawn in `VocelloVMark`) with the Cormorant
+/// wordmark + small AI-TTS micro-tag, matching the iOS reference's
+/// `VHeader`. Lives in `safeAreaInset(edge: .top)` so it stays anchored.
 private struct SidebarBrandHeader: View {
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Image("VocelloHeaderMark")
-                .resizable()
-                .scaledToFit()
-                .frame(height: 30)
-                .frame(maxWidth: .infinity, alignment: .leading)
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            VocelloVMark(size: 24)
+                .alignmentGuide(.firstTextBaseline) { d in d[.bottom] - 3 }
 
-            Text("Local voice studio")
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(AppTheme.textSecondary)
-                .textCase(.uppercase)
-                .tracking(1.1)
+            Text("Vocello")
+                .vocelloWordmark()
+
+            Text("AI-TTS")
+                .font(.system(size: 11, weight: .semibold))
+                .tracking(0.6)
+                .foregroundStyle(AppTheme.textSecondary.opacity(0.55))
+
+            Spacer(minLength: 0)
         }
         .padding(.horizontal, 14)
-        .padding(.top, 16)
+        .padding(.top, 18)
         .padding(.bottom, 12)
+        .frame(height: LayoutConstants.sidebarBrandHeaderHeight, alignment: .leading)
         .accessibilityHidden(true)
     }
 }
 
-private struct SidebarRow: View {
+private struct SidebarSectionRow: View {
     @Environment(\.colorScheme) private var colorScheme
 
-    let item: SidebarItem
-    @Binding var selection: SidebarItem?
+    let section: SidebarSection
+    @Binding var selection: SidebarSection?
     let isDisabled: Bool
     @State private var isHovered = false
 
-    private var isSelected: Bool {
-        selection == item
+    private var isSelected: Bool { selection == section }
+
+    private var iconColor: Color {
+        if isDisabled { return Color.secondary.opacity(isSelected ? 0.8 : 0.6) }
+        return isSelected ? section.sidebarTint : AppTheme.textPrimary
+    }
+
+    private var textColor: Color {
+        if isDisabled { return Color.secondary.opacity(isSelected ? 0.88 : 0.72) }
+        return AppTheme.textPrimary
     }
 
     @ViewBuilder
     private var rowBackground: some View {
-        #if QW_UI_LIQUID
-        if #available(macOS 26, *) {
-            if isSelected {
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(AppTheme.sidebarSelectionFill)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .strokeBorder(
-                                // Per-mode selection edge — golden for
-                                // Custom Voice / Library, lavender for
-                                // Voice Design, terracotta for Voice
-                                // Cloning. Matches the non-liquid
-                                // fallback in `borderColor`.
-                                AppTheme.sidebarColor(for: item).opacity(
-                                    colorScheme == .dark ? 0.55 : 0.42
-                                ),
-                                lineWidth: colorScheme == .dark ? AppTheme.surfaceStrokeWidth(for: colorScheme) : 0.9
-                            )
-                    )
-                    .glassEffect(.regular.tint(AppTheme.sidebarColor(for: item).opacity(colorScheme == .dark ? 0.16 : 0.10)).interactive(), in: .rect(cornerRadius: 8))
-                    .glass3DDepth(radius: 8, intensity: colorScheme == .dark ? 0.5 : 0.28)
-            } else if isHovered {
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(AppTheme.sidebarHoverFill)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .strokeBorder(
-                                AppTheme.sidebarHoverStroke.opacity(colorScheme == .dark ? 1.0 : 0.72),
-                                lineWidth: colorScheme == .dark ? AppTheme.surfaceStrokeWidth(for: colorScheme) : 0.85
-                            )
-                    )
-                    .glassEffect(.regular.tint(AppTheme.smokedGlassTint).interactive(), in: .rect(cornerRadius: 8))
-                    .glass3DDepth(radius: 8, intensity: colorScheme == .dark ? 0.25 : 0.16)
-            } else {
-                Color.clear
-            }
+        if isSelected {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(section.sidebarTint.opacity(colorScheme == .dark ? 0.16 : 0.10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .strokeBorder(
+                            section.sidebarTint.opacity(colorScheme == .dark ? 0.55 : 0.42),
+                            lineWidth: 0.75
+                        )
+                )
+        } else if isHovered {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(AppTheme.sidebarHoverFill)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .strokeBorder(
+                            AppTheme.sidebarHoverStroke.opacity(colorScheme == .dark ? 0.85 : 0.50),
+                            lineWidth: 0.5
+                        )
+                )
         } else {
-            legacyRowBackground
+            Color.clear
         }
-        #else
-        legacyRowBackground
-        #endif
-    }
-
-    private var legacyRowBackground: some View {
-        RoundedRectangle(cornerRadius: 8, style: .continuous)
-            .fill(backgroundColor)
-            .overlay {
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .strokeBorder(borderColor, lineWidth: isSelected || isHovered ? 1 : 0)
-            }
-    }
-
-    private var backgroundColor: Color {
-        if isDisabled {
-            return isSelected ? Color.secondary.opacity(0.06) : .clear
-        }
-
-        if isSelected {
-            return AppTheme.sidebarSelectionFill
-        }
-
-        if isHovered {
-            return AppTheme.sidebarHoverFill
-        }
-
-        return .clear
-    }
-
-    private var borderColor: Color {
-        if isDisabled {
-            return isSelected ? Color.secondary.opacity(0.16) : .clear
-        }
-
-        if isSelected {
-            // Per-mode edge accent — the stroke picks up the item's
-            // Vocello palette color so selecting Voice Design shows a
-            // lavender edge, Voice Cloning terracotta, etc. Library
-            // and Settings rows still resolve to accent (golden) via
-            // AppTheme.sidebarColor(for:).
-            return AppTheme.sidebarColor(for: item).opacity(0.32)
-        }
-
-        if isHovered {
-            return AppTheme.sidebarHoverStroke
-        }
-
-        return .clear
-    }
-
-    private var iconColor: Color {
-        if isDisabled {
-            return Color.secondary.opacity(isSelected ? 0.8 : 0.65)
-        }
-
-        return isSelected ? AppTheme.sidebarColor(for: item) : AppTheme.textPrimary
-    }
-
-    private var textColor: Color {
-        if isDisabled {
-            return Color.secondary.opacity(isSelected ? 0.88 : 0.72)
-        }
-
-        return AppTheme.textPrimary
-    }
-
-    private var selectionIndicatorColor: Color {
-        if !isSelected {
-            return .clear
-        }
-
-        return isDisabled ? Color.secondary.opacity(0.6) : AppTheme.sidebarColor(for: item)
-    }
-
-    private var accessibilityStateValue: String {
-        var states: [String] = []
-
-        if isSelected {
-            states.append("selected")
-        } else {
-            states.append("not selected")
-        }
-
-        if isDisabled {
-            states.append("disabled")
-        }
-
-        return states.joined(separator: ", ")
     }
 
     var body: some View {
-        HStack(spacing: 8) {
-            Capsule()
-                .fill(selectionIndicatorColor)
-                .frame(width: 3, height: 16)
-
-            Image(systemName: item.iconName)
+        HStack(spacing: 10) {
+            Image(systemName: section.iconName)
                 .font(.system(size: 17, weight: isSelected ? .semibold : .regular))
                 .foregroundStyle(iconColor)
                 .frame(width: 22, alignment: .center)
 
-            Text(item.rawValue)
+            Text(section.rawValue)
                 .font(.system(size: 14, weight: isSelected ? .semibold : .regular))
                 .foregroundStyle(textColor)
                 .lineLimit(1)
 
             Spacer(minLength: 0)
         }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .frame(height: 34)
-            .background(rowBackground)
-            .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            .onTapGesture {
-                guard !isDisabled else { return }
-                selection = item
-            }
-            .onHover { hovering in
-                isHovered = isDisabled ? false : hovering
-            }
-            .onChange(of: isDisabled) { _, disabled in
-                if disabled {
-                    isHovered = false
-                }
-            }
-            .animation(.easeOut(duration: 0.14), value: isHovered)
-            .animation(.easeOut(duration: 0.14), value: isSelected)
-            .disabled(isDisabled)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(item.rawValue)
-            .accessibilityValue(accessibilityStateValue)
-            .accessibilityIdentifier(item.accessibilityID)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(height: 36)
+        .background(rowBackground)
+        .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .onTapGesture {
+            guard !isDisabled else { return }
+            selection = section
+        }
+        .onHover { hovering in
+            isHovered = isDisabled ? false : hovering
+        }
+        .animation(.easeOut(duration: 0.14), value: isHovered)
+        .animation(.easeOut(duration: 0.14), value: isSelected)
+        .disabled(isDisabled)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(section.rawValue)
+        .accessibilityValue(isSelected ? "selected" : "not selected")
+        .accessibilityIdentifier(section.accessibilityID)
     }
 }
 
 struct SidebarView: View {
     @EnvironmentObject private var audioPlayer: AudioPlayerViewModel
 
-    @Binding var selection: SidebarItem?
-    let disabledItems: Set<SidebarItem>
-
-    private var usesNativeListSelection: Bool {
-        guard let selection else { return true }
-        return !disabledItems.contains(selection)
-    }
+    @Binding var selectedSection: SidebarSection?
+    let disabledSections: Set<SidebarSection>
 
     var body: some View {
-        Group {
-            if usesNativeListSelection {
-                List(selection: $selection) {
-                    sidebarListContent
-                }
-            } else {
-                List {
-                    sidebarListContent
+        VStack(spacing: 0) {
+            List(selection: $selectedSection) {
+                ForEach(SidebarSection.allCases) { section in
+                    SidebarSectionRow(
+                        section: section,
+                        selection: $selectedSection,
+                        isDisabled: disabledSections.contains(section)
+                    )
+                    .tag(section as SidebarSection?)
+                    .listRowInsets(EdgeInsets(top: 2, leading: 8, bottom: 2, trailing: 8))
+                    .listRowBackground(Color.clear)
                 }
             }
+            .listStyle(.sidebar)
+            .scrollContentBackground(.hidden)
         }
-        .listStyle(.sidebar)
-        .scrollContentBackground(.hidden)
         .vocelloGlassRail()
         .safeAreaInset(edge: .top, spacing: 0) {
             SidebarBrandHeader()
         }
-        .safeAreaInset(edge: .bottom) {
-            SidebarFooterRegion()
-                .environmentObject(audioPlayer)
-        }
-    }
-
-    @ViewBuilder
-    private var sidebarListContent: some View {
-        ForEach(SidebarItem.Section.allCases, id: \.self) { section in
-            Section {
-                ForEach(section.items) { item in
-                    SidebarRow(
-                        item: item,
-                        selection: $selection,
-                        isDisabled: disabledItems.contains(item)
-                    )
-                        .tag(item as SidebarItem?)
-                        .listRowInsets(EdgeInsets(top: 2, leading: 8, bottom: 2, trailing: 8))
-                        .listRowBackground(Color.clear)
-                }
-            } header: {
-                SidebarSectionHeader(
-                    title: section.rawValue,
-                    accessibilityID: section.accessibilityID
-                )
-            }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            SidebarFooterStatus()
         }
     }
 }
 
-private struct SidebarFooterRegion: View {
-    @Environment(\.colorScheme) private var colorScheme
-    @EnvironmentObject private var audioPlayer: AudioPlayerViewModel
+/// Memory/health status pill at the bottom of the sidebar — the
+/// take-player chrome moved to the global window-footer player so this
+/// region only carries runtime telemetry now.
+private struct SidebarFooterStatus: View {
     @EnvironmentObject private var ttsEngineStore: TTSEngineStore
+    @Environment(\.colorScheme) private var colorScheme
 
     private let appEngineSelection = AppEngineSelection.current()
 
     private var resolvedSidebarStatus: SidebarStatus {
         appEngineSelection.resolveSidebarStatus(
             ttsEngineSnapshot: ttsEngineStore.snapshot,
-            prefersInlinePresentation: audioPlayer.isLiveStream
-        )
-    }
-
-    private var footerPresentation: SidebarFooterPresentation {
-        SidebarFooterPresentation.resolve(
-            sidebarStatus: resolvedSidebarStatus,
-            isLiveStream: audioPlayer.isLiveStream
+            prefersInlinePresentation: false
         )
     }
 
     var body: some View {
         VStack(spacing: 0) {
             Rectangle()
-                .fill(AppTheme.railStroke.opacity(colorScheme == .dark ? 0.9 : 0.34))
-                .frame(height: 1)
+                .fill(AppTheme.railStroke.opacity(colorScheme == .dark ? 0.85 : 0.30))
+                .frame(height: 0.5)
 
-            VStack(alignment: .leading, spacing: 10) {
-                if audioPlayer.hasAudio {
-                    SidebarPlayerView(inlinePlayerActivity: footerPresentation.inlinePlayerActivity)
-
-                    if footerPresentation.showsStandaloneStatus {
-                        Rectangle()
-                            .fill(AppTheme.railStroke.opacity(colorScheme == .dark ? 0.65 : 0.22))
-                            .frame(height: 1)
-                    }
+            SidebarStatusView(
+                sidebarStatus: resolvedSidebarStatus,
+                clearError: {
+                    appEngineSelection.clearSidebarError(ttsEngineStore: ttsEngineStore)
                 }
-
-                if footerPresentation.showsStandaloneStatus {
-                    SidebarStatusView(
-                        sidebarStatus: resolvedSidebarStatus,
-                        clearError: {
-                            appEngineSelection.clearSidebarError(
-                                ttsEngineStore: ttsEngineStore
-                            )
-                        }
-                    )
-                }
-            }
-            .padding(.horizontal, LayoutConstants.shellPadding)
-            .padding(.top, LayoutConstants.generationSectionSpacing)
-            .padding(.bottom, LayoutConstants.shellPadding)
+            )
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .background(AppTheme.railBackground.opacity(colorScheme == .dark ? 0.92 : 0.985))
-        .vocelloGlassSurface(
-            padding: 0,
-            radius: 0,
-            fill: AppTheme.railBackground.opacity(colorScheme == .dark ? 0.76 : 0.90)
-        )
     }
 }

--- a/Sources/Views/Sidebar/TopGlassBar.swift
+++ b/Sources/Views/Sidebar/TopGlassBar.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// 44pt glass strip across the top of the window that pairs with
+/// `WindowChromeConfigurator`'s hidden-titlebar configuration. Provides a
+/// glass background that the OS-positioned traffic lights inset cleanly into
+/// (left third), with room on the right for contextual toolbar content.
+///
+/// This view is intentionally minimal — it carries no controls of its own.
+/// Per-screen toolbar items continue to live in SwiftUI's `.toolbar` modifier
+/// inside `ContentView`; the OS renders them above this glass bar via the
+/// `.fullSizeContentView` style mask.
+struct TopGlassBar: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Rectangle()
+            .fill(.clear)
+            .frame(height: LayoutConstants.topGlassBarHeight)
+            .background {
+                Rectangle()
+                    .fill(AppTheme.railBackground.opacity(colorScheme == .dark ? 0.62 : 0.85))
+                    .background(.ultraThinMaterial)
+                    .overlay(alignment: .bottom) {
+                        Rectangle()
+                            .fill(AppTheme.railStroke.opacity(colorScheme == .dark ? 0.85 : 0.30))
+                            .frame(height: 0.5)
+                    }
+            }
+            .ignoresSafeArea(edges: [.top, .horizontal])
+            .accessibilityHidden(true)
+    }
+}

--- a/docs/superpowers/specs/2026-04-24-vocello-macos-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-24-vocello-macos-redesign-design.md
@@ -1,0 +1,314 @@
+# Vocello macOS UI — Ground-Up Refactor (Design Spec)
+
+## Context
+
+The macOS app last received a major UI pass in commit `f55fc04` ("Implement Vocello Liquid Glass redesign"). Since then, a separate iOS reference design has matured (`/Users/patricedery/Downloads/Vocello/`) that defines the canonical Vocello brand language: V monogram, Cormorant Garamond wordmark, dark-canvas glass with warm hairlines, per-mode tints (Custom champagne / Design lavender / Clone peach / Library silver-gold / Settings silver), and a coherent component vocabulary (capsule segmented, animated waveform, mini player, voice orb, status chip).
+
+The intent is to rebuild the macOS app around that brand language with a desktop-native layout — NOT a phone tab bar scaled up. The app must look intentional and uncramped at every supported window size, from 720p displays to 4K, and respect macOS Display scale settings.
+
+The intended outcome is one unified refactor that lands on `main` as a coherent diff, replacing the chrome and per-screen visual treatment in a single coordinated change.
+
+## Decisions Locked (from brainstorming)
+
+1. **Theme intent**: macOS inherits iOS brand identity (V mark, Cormorant wordmark, dark canvas, glass surfaces, per-mode tints) and component primitives (waveform, mini player, status chip, capsule segmented, voice orb). Layout is desktop-native, not iOS-ported.
+2. **Scope**: Single unified spec, full refactor in one go.
+3. **Scaling constraint**: Must look excellent from 720p to 4K, across all macOS Display scale settings.
+4. **Top-level navigation**: `NavigationSplitView` with a flat 4-row sidebar — **Home / Generate / Library / Settings**. Generate's three modes (Custom / Design / Clone) collapse from sidebar children into a top capsule **segmented control inside the Generate detail**. Library and Settings sub-tabs become in-pane segmented controls similarly.
+5. **Home screen**: New landing screen above Generate (greeting, recent takes, three mode launchers, runtime/memory status). Default initial selection.
+6. **Persistent player**: **Window-footer, full-width** glass strip across the bottom of the entire window (under sidebar + detail). Always visible across all four sections. Apple-Music / Spotify positioning, with iOS theming (per-mode tint, animated waveform, glass blur).
+7. **Wide-window behavior**: **Hybrid by content type** — text editors and forms cap at ~720pt centered, grids fill width with auto-flowing columns, player footer is always full-bleed.
+8. **Color modes**: **Dark only** for this refactor. Light mode is explicitly out of scope.
+9. **Window chrome**: **Hidden titlebar**, content extends to top edge. Traffic lights inset into a glass top bar. Vocello wordmark anchors the top of the sidebar; screen title anchors the top of the detail pane.
+10. **Type identity**: Cormorant Garamond serif for the wordmark and the H1 screen title at the top of each detail pane. Body text and controls remain SF Pro.
+11. **Window sizing**: Min `1100×720`. Sidebar collapses to 64pt icon-only rail under 1100pt width. Below 900pt the sidebar can be hidden via toolbar toggle. Above 1400pt, sidebar expands to fully labeled state. Player footer is always full-width.
+12. **Motion**: Restrained — animated waveform when playing, smooth segmented/tab transitions (180–240ms), gentle hover lift on cards, animated voice orb on Home. No ambient drift, no parallax. `Reduce Motion` accessibility setting honored throughout.
+
+## Visual Token System
+
+All tokens move into a new `Sources/Views/Components/VocelloTokens.swift` (or extend `AppTheme` in place — see Implementation Order below). Values mirror `Sources/iOS/IOSShellPrimitives.swift IOSBrandTheme` exactly so iOS and macOS share one brand truth.
+
+### Mode tints (the visual spine)
+
+| Token | Hex | Used for |
+|---|---|---|
+| `accent` (Custom) | `#EDCC8A` champagne gold | Custom Voice mode, primary CTA when in Custom |
+| `design` | `#BFABDB` lavender | Voice Design mode |
+| `clone` | `#DBA887` peach clay | Voice Cloning mode |
+| `library` | `#BFBCB5` silver-gold | Library section chrome (History + Voices) |
+| `settings` | `#ADB5C2` silver | Settings section chrome (Models + Preferences) |
+| `purple` | `#BAA8D6` | V mark gradient back |
+| `lavender` | `#DED1ED` | V mark gradient front |
+| `healthy` / `guarded` / `critical` | `#8CB38C` / `#D9B373` / `#D98080` | Status chip dot |
+
+### Surfaces
+
+| Token | Value | Used for |
+|---|---|---|
+| `canvas` | `#0A0B0D` | Window background base |
+| `deepNav` | `#0F1115` | Beneath canvas in vignettes |
+| `surface` | `rgba(36,38,46, 0.86)` | Glass card fill |
+| `surfaceMuted` | `rgba(46,48,56, 0.74)` | Recessed/secondary glass |
+| `inputFill` | `#1C1E26` | Solid editor surfaces (text editors, file drops) |
+| `tabBar` | `rgba(20,22,28, 0.93)` | Window-footer player chrome, top glass bar |
+| `surfaceStroke` | `rgba(247,235,209, 0.10)` | Universal warm 0.5pt hairline |
+| `inputStroke` | `rgba(245,235,209, 0.12)` | Editor surface strokes |
+
+### Material recipes
+
+- **Glass card**: `surface` fill + `0.5pt surfaceStroke` border + `glassEffect(.regular)` + `glass3DDepth(intensity: 1.0)`. Radius **22pt**.
+- **Inline panel** (in-card sub-surface): `surfaceMuted` fill + same stroke. Radius **16pt**.
+- **Mode-tinted glass card**: same recipe, with `cardGlassTint` env set to the mode color → tint resolves via `surfaceGlassTint(color, scheme)` (~14% alpha) and stroke via `accentStroke(color, scheme)` (~34% alpha).
+- **Footer/chrome glass**: `tabBar` fill + stronger blur (`saturate 180%`).
+- **Editor input**: `inputFill` solid + `inputStroke` 0.5pt. Radius **18pt**.
+
+### Type
+
+| Role | Font | Size | Weight |
+|---|---|---|---|
+| Wordmark | Cormorant Garamond | 23pt | 700 |
+| H1 screen title | Cormorant Garamond | 32pt | 700, tracking -0.6 |
+| H2 section heading | SF Pro Display | 17pt | 600 |
+| Body | SF Pro Text | 14pt | 400/500 |
+| Caption / metadata | SF Pro Text | 12pt | 500 |
+| Label (uppercase) | SF Pro Text | 11pt | 600, tracking +1.4, uppercased |
+| Button label | SF Pro Text | 14–16pt | 600/700, tracking -0.1 |
+
+The H1 serif size scales via `@ScaledMetric` so it honors macOS accessibility text scaling without breaking layout. All other text is `Font` literals (no `@ScaledMetric`) — chrome stays predictable; if a user picks a larger Display scale, the OS handles pt→px scaling at the rendering layer.
+
+### Radii / spacing
+
+`radii = { input 18, card 22, inlinePanel 16, capsule 999, primaryCTA 32 }`. `spacing = { 4, 8, 12, 16, 22, 32 }` (8pt base). These get exposed as `LayoutConstants` extensions so existing constants stay backwards-compatible during the transition.
+
+### Motion
+
+| Animation | Duration | Curve |
+|---|---|---|
+| Segmented active swap | 200ms | `easeInOut` |
+| Sidebar selection / hover | 140ms | `easeOut` |
+| Card hover lift | 160ms | `easeOut` |
+| Footer player tint change | 240ms | `easeInOut` |
+| Waveform bar animation | 0.5–0.7s | spline `0.4 0 0.6 1` |
+| Voice orb conic rotation | 14s linear | infinite |
+
+All animations gated through `AppLaunchConfiguration.current.animation(...)` (existing `.appAnimation` extension), which already respects `Reduce Motion` and the test-mode flag.
+
+## Layout Shell
+
+### Window
+
+- `NSWindow` style: `.hiddenTitleBar` + `.fullSizeContentView` + `titlebarAppearsTransparent = true`. Configured via existing `WindowChromeConfigurator`.
+- Background: `VocelloStudioBackground` gradient (existing) re-tinted to true dark canvas (#0A0B0D → #06070A vertical) plus warm/lavender bloom radials at top-right and bottom-left (matching the iOS device frame).
+- Min size: `1100×720`. Saved size restored from `NSWindow` defaults.
+
+### Top glass bar (over sidebar + detail)
+
+- Height: `44pt`. Glass material (tabBar fill + 24pt blur saturate 180%).
+- Left third: traffic lights inset (system-positioned, no overlay needed).
+- Center/right: optional contextual toolbar items (existing `MainWindowToolbar` content moves here — search field for History, "Add Voice Sample" for Voices, sort menu).
+
+### Sidebar
+
+- New flat structure (replaces current 3-section nested):
+  ```
+  Home
+  Generate
+  Library
+  Settings
+  ```
+- `SidebarItem` enum collapses from 6 cases to 4. The current `customVoice / voiceDesign / voiceCloning / history / voices / models` cases survive as **child** enums (e.g., `GenerateMode.{custom,design,clone}`, `LibraryTab.{history,voices}`, `SettingsTab.{models,preferences}`) used inside each detail pane.
+- Brand header at the top: V mark + Cormorant "Vocello" + small "AI-TTS" mark — replaces current `SidebarBrandHeader`. Lives in `safeAreaInset(.top)` so it stays anchored.
+- Row treatment: 22pt radius pills, mode-tint when selected (per-row tint resolved via `AppTheme.sidebarColor(for:)`), 1pt warm stroke on selected, glass effect with `interactive()` on hover.
+- Width: `navigationSplitViewColumnWidth(min: 240, ideal: 280, max: 320)` at full state. Below 1100pt window width the sidebar binds to `.compact` (icon-only 64pt rail) via `navigationSplitViewVisibility`. Below 900pt the sidebar can be hidden via toolbar toggle.
+- No more sidebar-footer player or sidebar-footer status — both move to the global window footer.
+- Sidebar-footer status chip (memory/healthy) becomes a subtle bottom-of-sidebar pill, ~32pt tall, matching the iOS `VHeader` chip pattern.
+
+### Detail pane
+
+- One persistent shell that hosts the active screen.
+- Each screen owns its own H1 (Cormorant 32pt) at the top, plus the in-pane segmented control for sub-sections.
+- Content scrolls vertically inside the detail; the footer player is OUTSIDE the scroll region.
+- Forms/editors get `.contentColumn(maxWidth: 720)` (centered with breathing room). Grids use `.frame(maxWidth: .infinity)` with adaptive `LazyVGrid(columns: [.adaptive(minimum: 220, maximum: 320)])`.
+
+### Window-footer player
+
+- New file: `Sources/Views/Components/WindowFooterPlayer.swift`.
+- Full window width, fixed height **76pt** at default scale (becomes 64pt below 900pt window height).
+- Material: glass `tabBar` fill + 24pt blur, top hairline only (no bottom — sits on window edge).
+- Three regions:
+  - **Left** (240pt fixed): play/pause disc (44pt circle, mode-tinted gradient when ready), then take title + subtitle (mode label · duration · sample rate). Truncates with ellipsis at narrow widths.
+  - **Center** (flex): scrubable animated waveform. At 720p widths, ~400pt wide; at 4K, expands to fill but caps at 1200pt centered. Mode-tinted; played/unplayed split.
+  - **Right** (180pt fixed): Take number badge, Download button, Ellipsis (more actions).
+- States: idle (no audio yet — muted, "Latest take will appear here"), generating (orbit spinner), ready, playing.
+- Replaces both `SidebarPlayerView` and the current `SidebarFooterRegion`. `AudioPlayerViewModel` continues to drive it.
+
+## Responsive Scaling Strategy
+
+### Breakpoints
+
+| Window width | Behavior |
+|---|---|
+| `< 900pt` | Sidebar hidden by default (toggle in toolbar). Detail uses full window width. Footer player drops to 64pt height with compact layout (waveform shrinks, badges hidden). |
+| `900–1099pt` | Sidebar in icon-only `.compact` mode (64pt rail). Labels appear on hover/tooltip. |
+| `1100–1399pt` | Sidebar full but at `min: 240`. Detail forms cap at 720pt centered. Grids use 2-3 columns. |
+| `1400–1919pt` | Sidebar at `ideal: 280`. Forms still cap at 720pt. Grids 3-4 columns. |
+| `≥ 1920pt` | Sidebar at `max: 320`. Forms cap at 720pt with extra side padding. Grids 4-6 columns. Footer player center waveform caps at 1200pt centered. |
+
+### Display scale settings
+
+- macOS Display scale ("Larger Text", "Default", "More Space") changes the rendering scale at the OS level. All point-based values automatically follow.
+- The H1 serif uses `@ScaledMetric` so it additionally respects accessibility text size.
+- All grids use `LazyVGrid(columns: [GridItem(.adaptive(minimum: X))])` so column count adjusts naturally to scale + window width.
+- Min window size (1100×720) is chosen so even at "Larger Text" scale on a 1280×800 panel, the app remains usable (the OS quantizes 1280 → ~1024pt at largest scale, which still clears our 900pt fallback breakpoint).
+
+### Scrolling
+
+- Detail pane scrolls vertically (each screen is its own `ScrollView`).
+- Sidebar scrolls vertically when content exceeds height (rare with 4 items).
+- Footer player NEVER scrolls — it's a fixed window inset.
+- No horizontal scrolling anywhere.
+
+## Per-Screen Designs
+
+### Home (NEW)
+
+`Sources/Views/Home/HomeView.swift`. Mirrors `lib/screen-home.jsx` but desktop-laid-out.
+
+- H1: "Good <time-of-day>" + Cormorant gradient line: "What should we voice today?" (champagne→lavender→peach gradient).
+- **Hero card** (full-width within content cap of 1040pt): voice orb (animated conic gradient, 96pt) + tagline + a script-prompt input that on click navigates to Generate with focus in the editor.
+- **Three mode launchers** (3-column grid, each card 240–320pt wide, mode-tinted): Choose Voice (Custom) / Describe Voice (Design) / Use Reference (Clone). Click navigates to Generate and pre-selects the mode segment.
+- **Recent takes** card (full-width up to 1040pt cap): list of last 5 takes (title, mode chip, duration, when, mini waveform). "See all" link routes to Library/History.
+- **Runtime status pill** at the bottom: model name, memory loaded, hardware identifier. Matches the iOS `VHeader` chip palette but laid out horizontally for the wider canvas.
+
+### Generate
+
+`Sources/Views/Generate/GenerateView.swift` (NEW host) — replaces direct routing to `CustomVoiceView` / `VoiceDesignView` / `VoiceCloningView`.
+
+- Top: H1 "Generate" (Cormorant) + capsule segmented control (Custom / Design / Clone), each segment tinted with its mode color when active.
+- Body: switches between three sub-views based on segment. Each sub-view keeps its current responsibility (drafts, generation runner, etc.) but receives a refreshed visual treatment via the new tokens.
+- Forms cap at 720pt centered. Voice/emotion picker grids use adaptive columns.
+- The current per-screen "Generate" CTA button becomes redundant — the bottom strip below the editor still has a primary CTA, but a duplicate "Create" is also pinned in the footer player while in idle state (matching iOS embedded CTA pattern). Pressing either triggers generation; the footer CTA is hidden once the take is ready.
+- Existing files affected: `CustomVoiceView.swift`, `VoiceDesignView.swift`, `VoiceCloningView.swift` keep their inner content but lose their own H1/title chrome (now owned by `GenerateView`).
+
+### Library
+
+`Sources/Views/Library/LibraryView.swift` (NEW host).
+
+- Top: H1 "Library" (Cormorant) + capsule segmented (History / Voices), tinted with `library` silver-gold.
+- Body: switches between `HistoryView` and `VoicesView`. Both remain in their existing files but lose the per-screen H1.
+- History: list of takes (already present), now styled with new card recipe. Search field and sort menu live in the top glass bar (already wired via `MainWindowToolbar`).
+- Voices: grid layout (`adaptive(minimum: 240)`) of saved voice cards, each with the voice's tint chip. "Add Voice Sample" button stays in the top glass bar.
+
+### Settings
+
+`Sources/Views/Settings/SettingsView.swift` (NEW host).
+
+- Top: H1 "Settings" (Cormorant) + capsule segmented (Models / Preferences), tinted with `settings` silver.
+- Body: switches between `ModelsView` and `PreferencesView`.
+- This **replaces** the current pattern where `Models` is a sidebar item and `Preferences` is a separate `Settings` scene opened via `Cmd+,`. The system Settings scene at `QwenVoiceApp.swift:settingsScene` either:
+  - **Option A (preferred)**: keeps the system Settings scene in place but routes `Cmd+,` to the in-app Settings sidebar item via `appCommandRouter.sidebarSelection.send(.settings)`. The system scene becomes a thin wrapper that just opens the main window on Settings.
+  - **Option B**: deletes the system Settings scene; `Cmd+,` selects the Settings sidebar item directly.
+  - Decision deferred to implementation; either is consistent with the spec.
+
+## Files to Create / Modify
+
+### New files
+
+- `Sources/Views/Home/HomeView.swift`
+- `Sources/Views/Home/VoiceOrb.swift`
+- `Sources/Views/Home/RecentTakesCard.swift`
+- `Sources/Views/Generate/GenerateView.swift` (host)
+- `Sources/Views/Library/LibraryView.swift` (host)
+- `Sources/Views/Settings/SettingsView.swift` (host)
+- `Sources/Views/Components/WindowFooterPlayer.swift`
+- `Sources/Views/Components/VocelloSegmentedControl.swift`
+- `Sources/Views/Components/VocelloStatusChip.swift`
+- `Sources/Views/Components/VocelloVMark.swift` (Swift port of the SVG monogram)
+- `Sources/Views/Components/CormorantTitle.swift` (font helper + H1 modifier)
+- `Sources/Views/Sidebar/TopGlassBar.swift` (the 44pt glass bar across the top, holding traffic-light inset + contextual toolbar)
+
+### Heavily modified
+
+- `Sources/Views/Components/AppTheme.swift` — port iOS exact hex values; add the new tokens listed above; keep existing modifiers but retire the duplicated `vocelloGold/Lavender/Terracotta` aliases now that mode tokens are canonical.
+- `Sources/Views/Components/LayoutConstants.swift` — refresh radii (22 / 18 / 16), spacing scale, footer-player heights, breakpoint constants.
+- `Sources/Views/Sidebar/SidebarView.swift` — flatten `SidebarItem` from 6 cases to 4 (`home`, `generate`, `library`, `settings`); replace nested-section structure; remove `SidebarFooterRegion` (moves to global footer); add new brand header.
+- `Sources/ContentView.swift` — top-level layout becomes `VStack { TopGlassBar; NavigationSplitView { Sidebar } detail { Detail }; WindowFooterPlayer }` (or equivalent overlay topology). Sidebar selection state becomes a 4-value enum; per-screen sub-state (mode, library tab, settings tab) persists per-screen.
+- `Sources/QwenVoiceApp.swift` — register `WindowChromeConfigurator` to apply hidden titlebar + full-size content; route `Cmd+,` per the Settings decision above.
+- `Sources/Views/Generate/CustomVoiceView.swift`, `VoiceDesignView.swift`, `VoiceCloningView.swift` — remove top-level page chrome (H1, mode tint backdrop) which now belongs to `GenerateView`. Internal forms keep their existing structure but adopt the new card recipe via `.studioCard(...)` (already aliased; tokens behind it change).
+- `Sources/Views/Library/HistoryView.swift`, `VoicesView.swift` — remove top-level page chrome.
+- `Sources/Views/Settings/ModelsView.swift`, `PreferencesView.swift` — remove top-level page chrome.
+- `Sources/Views/Components/SidebarPlayerView.swift` — DELETE (replaced by `WindowFooterPlayer`).
+- `Sources/Views/Components/SidebarStatusView.swift` — RELOCATE its memory/healthy chip to a sidebar-bottom pill; the engine-error inline messaging moves into the footer player's left region as an overlay banner.
+- `Sources/Views/Components/WindowChromeConfigurator.swift` — set `titleVisibility = .hidden`, `titlebarAppearsTransparent = true`, `styleMask.insert(.fullSizeContentView)`, `isMovableByWindowBackground = true`, `minSize = NSSize(1100, 720)`.
+
+### Untouched (functional code stays as-is)
+
+- `Sources/Services/*`, `Sources/Models/*`, all generation runners, audio service, database, MLX integration — none of this is visual.
+- `Sources/QwenVoiceCore`, engine service, native runtime — engine layer is unchanged.
+- `Sources/iOS/*` — out of scope. iOS keeps its existing shell.
+- `Sources/Views/Components/GenerationWorkflowView.swift`, `WaveformView.swift`, `TextInputView.swift`, `EmotionPickerView.swift`, `ContinuousVoiceDescriptionField.swift`, `BatchGenerationSheet.swift`, `FlowLayout.swift` — internal generation UI, kept but re-skinned via the token swap (no structural changes needed).
+
+## Implementation Order Within the Unified Refactor
+
+Even though this lands as one coherent diff, the work proceeds in this order to keep each interim build green:
+
+1. **Token foundation** — port iOS exact hex values into `AppTheme.swift`; add new constants to `LayoutConstants.swift`; create `CormorantTitle.swift` font helper. Build still passes; existing screens slightly recolor.
+2. **New shared components** — `VocelloVMark`, `VocelloSegmentedControl`, `VocelloStatusChip`, `WindowFooterPlayer`, `TopGlassBar`. Built against tokens from step 1, not yet wired into the shell.
+3. **Window chrome** — update `WindowChromeConfigurator` for hidden titlebar, set min size, configure the top glass bar. Sidebar still has its old 6-row structure at this point; build passes.
+4. **Sidebar flatten** — collapse `SidebarItem` to 4 cases. Each renamed item routes to a new host (`HomeView`, `GenerateView`, `LibraryView`, `SettingsView`). Hosts initially just embed the existing per-screen views with no segmented control. Test plans (`tests/Plans/*.xctestplan`) updated to use the new accessibility identifiers (`screen_home`, `screen_generate`, `screen_library`, `screen_settings` plus per-tab IDs like `generate_tab_custom`).
+5. **Per-host segmented controls** — add the in-pane segmented control to `GenerateView`, `LibraryView`, `SettingsView`. Existing per-mode H1 chrome removed from inner views.
+6. **Footer player wired in** — `WindowFooterPlayer` becomes the top-level view inset; `SidebarFooterRegion` and `SidebarPlayerView` deleted; sidebar bottom shows only the new compact status pill.
+7. **Home screen built** — `HomeView`, `VoiceOrb`, `RecentTakesCard`. Recent takes pulls from existing history database via `HistoryView`'s data source.
+8. **Visual QA pass** — manual sweep at 1100×720, 1440×900, 1920×1200, 2560×1440, 3840×2160; at each macOS Display scale setting on a 1440×900 panel; with `Reduce Motion` on.
+
+## Verification
+
+### Code gates (must pass before claiming done)
+
+```bash
+./scripts/check_project_inputs.sh
+python3 scripts/harness.py validate
+./scripts/build_foundation_targets.sh macos
+./scripts/build_foundation_targets.sh ios            # iPhone target must stay compile-green
+python3 scripts/harness.py test --layer swift
+python3 scripts/harness.py test --layer e2e
+```
+
+### Visual QA matrix (manual, on the controlled Mac)
+
+For each of these window sizes — `1100×720`, `1440×900`, `1920×1200`, `2560×1440`, `3840×2160` — verify:
+- Sidebar sits at the expected breakpoint state (full / icon-only / hidden).
+- Top glass bar renders without gaps next to the traffic lights.
+- Forms (Generate text editor, Voice Cloning script) cap at 720pt and look centered, not cramped.
+- Library voices grid shows the expected adaptive column count (3 at 1440, 4 at 1920, 5–6 at 2560+).
+- Footer player center waveform caps at 1200pt at 4K, fills width below.
+- H1 serif renders without truncation at all widths.
+
+For each macOS Display scale on a 1440×900 panel — `Larger Text`, `Default`, `More Space` — verify:
+- App opens to a usable size (≥ 1100pt effective width after scaling).
+- No clipping in sidebar rows, segmented controls, footer player.
+- Text remains legible (no sub-11pt rendered text).
+
+For accessibility — with `Reduce Motion` on:
+- Voice orb conic rotation is replaced by a static gradient.
+- Waveform animation collapses to a static played/unplayed split.
+- Segmented active swap is instant (no slide).
+
+### Test-plan changes
+
+- `tests/Plans/QwenVoiceSource.xctestplan` and `QwenVoiceRuntime.xctestplan` — accept renamed accessibility identifiers (`screen_home`, `screen_generate`, etc.). Update XCUITest path expectations.
+- `tests/Plans/VocelloUISmoke.xctestplan` — exercise the new sidebar 4-row navigation + at least one segmented control change inside Generate.
+
+### Rollback
+
+- Single `git revert` of the merged commit returns the app to the current Liquid Glass shell. Token swap is mechanical so a forward-fix is preferred over revert if a regression surfaces.
+
+## Files Critical to Read Before Implementing
+
+- `Sources/Views/Components/AppTheme.swift` (token surface area; existing helpers must keep working)
+- `Sources/Views/Sidebar/SidebarView.swift` + `Sources/ContentView.swift` (current shell topology)
+- `Sources/Views/Components/LayoutConstants.swift` (sizing primitives)
+- `Sources/Views/Components/WindowChromeConfigurator.swift` (window styling entry point)
+- `Sources/iOS/IOSShellPrimitives.swift` (`IOSBrandTheme` — canonical token source)
+- `Sources/QwenVoiceApp.swift` (settings-scene wiring decision)
+- `tests/Plans/*.xctestplan` (accessibility identifiers under test)
+- Reference: `/Users/patricedery/Downloads/Vocello/lib/{vocello-tokens,vocello-chrome,screen-home,screen-generate,screen-library-settings,vocello-icons}.jsx` (canonical visual source)


### PR DESCRIPTION
## Summary

Land the macOS UI ground-up refactor — sidebar, chrome, footer player, and Home screen — around the iOS reference brand language (V monogram, Cormorant wordmark, dark-canvas glass, per-mode tints, capsule segmented, animated waveform/voice orb). Spec lives at [`docs/superpowers/specs/2026-04-24-vocello-macos-redesign-design.md`](docs/superpowers/specs/2026-04-24-vocello-macos-redesign-design.md).

- Flat 4-row sidebar (Home / Generate / Library / Settings); per-section sub-tabs collapse into in-pane segmented controls
- New `WindowFooterPlayer` full-width strip replaces the sidebar-bottom player
- New `HomeView` with greeting, animated `VoiceOrb`, three mode launcher cards, recent-takes placeholder
- Hidden titlebar, min size 1100×720, scale-aware breakpoint constants

## Test plan

- [x] `./scripts/check_project_inputs.sh`
- [x] `python3 scripts/harness.py validate`
- [x] `./scripts/build_foundation_targets.sh macos`
- [x] `./scripts/build_foundation_targets.sh ios` (untouched — `Sources/Views/` is excluded from the iOS target)
- [x] `python3 scripts/harness.py test --layer swift` — 153 tests passed, 0 failed
- [x] Visual QA captured for all 4 sections + all 3 Generate modes + both Library tabs at 1100×720
- [ ] `python3 scripts/harness.py test --layer e2e` (XCUITest macOS smoke; not run from this session)
- [ ] Visual QA at 1440×900 / 1920×1200 / 2560×1440 / 3840×2160 (display constrained on this Mac — needs a "More Space" or "Default" Display scale or a higher-res panel)
- [ ] Manual Reduce Motion verification (VoiceOrb code already gates rotation on `accessibilityReduceMotion`)

## Notes

- Existing `screen_customVoice` / `screen_voiceDesign` / `screen_voiceCloning` / `screen_history` / `screen_voices` / `screen_models` accessibility identifiers preserved as legacy aliases on the new sub-screens, so `LivePreviewSmokeTests` should keep passing without updates.
- `AppCommandRouter`'s `SidebarItem` API still routes correctly through the new section + sub-tab state.
- `AppLaunchConfiguration` now also accepts `--uitest-screen=home`.
- `SidebarPlayerView.swift` is now unreferenced dead code (footer player took over) — left in place for the next cleanup commit rather than deleted in this PR.
- Cormorant Garamond is wired via `Font.custom("Cormorant Garamond")` and falls back to the system serif (Charter on macOS); bundling the actual TTF is a small follow-up.
- `RecentTakesCard` is a placeholder card on Home; live integration with the GRDB history database is a planned follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)