### PR TITLE
Fix Perf Nightly Python step (PEP 668: use venv instead of --user)

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -90,8 +90,13 @@ jobs:
         if: steps.cache-models.outputs.cache-hit != 'true'
         run: |
           mkdir -p "$QWENVOICE_AUDIO_QC_MODELS_ROOT"
-          python3 -m pip install --user --quiet huggingface_hub
-          python3 - <<'PY'
+          # macos-26 ships system Python 3 with PEP 668 "externally-managed"
+          # protection, so `pip install --user` is rejected. Use an
+          # ephemeral venv to install huggingface_hub cleanly without
+          # fighting the protection or polluting the runner.
+          python3 -m venv /tmp/perf-nightly-venv
+          /tmp/perf-nightly-venv/bin/pip install --quiet huggingface_hub
+          /tmp/perf-nightly-venv/bin/python - <<'PY'
           from huggingface_hub import snapshot_download
           import os, pathlib
           root = pathlib.Path(os.environ["QWENVOICE_AUDIO_QC_MODELS_ROOT"])


### PR DESCRIPTION
## Summary

First dispatched Perf Nightly run failed in 1.7 min at the model-download step with `error: externally-managed-environment`. macos-26 runner Python 3 has PEP 668 enabled — `pip install --user` is rejected without an override.

Swap to an ephemeral venv (`/tmp/perf-nightly-venv`) so pip installs huggingface_hub cleanly without fighting PEP 668 or polluting the runner.

## Test plan

- [x] yaml.safe_load passes
- [x] qa.sh validate clean
- [x] git diff --check clean
- [ ] validate-apple-platforms passes on this PR (required for merge)
- [ ] post-merge: `gh workflow run "Perf Nightly"` succeeds end-to-end (cold cache, ~30-60 min)

## Related

- First failed dispatch: run 25809794306
- Out of scope: changing the model-download step's design or caching strategy — only the Python invocation changes