### PR TITLE
Pin GitHub Actions to commit SHAs (supply-chain hygiene)

### DIFF
--- a/.github/workflows/apple-platform-validation.yml
+++ b/.github/workflows/apple-platform-validation.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Select Xcode
         run: |
@@ -39,7 +39,7 @@ jobs:
         run: command -v xcodegen >/dev/null 2>&1 || brew install xcodegen
 
       - name: Cache Swift packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             build/foundation/source-packages
@@ -114,7 +114,7 @@ jobs:
 
       - name: Upload build result bundles
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: apple-platform-build-xcresults
           if-no-files-found: warn
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload release verification artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: apple-platform-release-proof
           if-no-files-found: warn

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 180
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.git_ref }}
           fetch-depth: 0
@@ -45,7 +45,7 @@ jobs:
         run: command -v xcodegen >/dev/null 2>&1 || brew install xcodegen
 
       - name: Cache Swift packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             build/foundation/source-packages
@@ -136,7 +136,7 @@ jobs:
           fi
 
       - name: Upload iOS release artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: vocello-ios-testflight
           if-no-files-found: warn

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 180
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.git_ref }}
           fetch-depth: 0
@@ -50,7 +50,7 @@ jobs:
         run: command -v xcodegen >/dev/null 2>&1 || brew install xcodegen
 
       - name: Cache Swift packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             build/foundation/source-packages
@@ -192,7 +192,7 @@ jobs:
           shasum -a 256 "build/Vocello-macos26.dmg" | awk '{print $1 "  Vocello-macos26.dmg"}' > "build/Vocello-macos26.dmg.sha256"
 
       - name: Upload notarized artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: vocello-macos26-release
           if-no-files-found: error

--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.git_ref || 'main' }}
 
@@ -68,7 +68,7 @@ jobs:
         run: ./scripts/qa.sh validate
 
       - name: Cache SPM
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             build/foundation/source-packages
@@ -77,7 +77,7 @@ jobs:
 
       - name: Cache Hugging Face TTS models
         id: cache-models
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ github.workspace }}/.qwenvoice-models
           # Bump the suffix when model sources/revisions change so the
@@ -133,7 +133,7 @@ jobs:
 
       - name: Upload perf-nightly artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: perf-nightly-results
           path: |

--- a/.github/workflows/project-inputs.yml
+++ b/.github/workflows/project-inputs.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Select Xcode
         run: |


### PR DESCRIPTION
## Summary

Workflow audit C4 finding: every `uses: actions/X@vN` reference across the five workflow files is pinned to a floating major tag. Pin to commit SHAs (with major tag as a comment) so future patches under those tags don't ship silently.

15 references swapped across 5 files:
- `actions/checkout@v6` → `@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (5 refs)
- `actions/cache@v5` → `@27d5ce7f107fe9357f9df03efb73ab90386fccae` (4 refs)
- `actions/upload-artifact@v7` → `@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (5 refs)

Files: `apple-platform-validation`, `ios-testflight`, `macos-release`, `perf-nightly`, `project-inputs`.

## Test plan

- [x] `yaml.safe_load` parses each workflow
- [x] `qa.sh validate` clean
- [x] `git diff --check` clean
- [x] `grep "uses: actions/"` shows all 15 are now `@<SHA> # vN` form
- [ ] `validate-apple-platforms` passes on this PR
- [ ] post-merge: the next QA Gate run on `main` still pulls the same action behaviors (the SHAs are what `v6`/`v5`/`v7` currently resolve to)

## Notes

- May depend on PR #37 merging first (both touch `.github/workflows/perf-nightly.yml`, but on disjoint lines — rebase should auto-resolve).
- Bumping a SHA pin in the future becomes a deliberate "bump-and-test" act rather than a silent supply-chain update.