### PR TITLE
Rename MLXTTSEngineError to TTSEngineError + back-compat alias

### DIFF
--- a/Sources/QwenVoiceCore/MLXTTSEngine.swift
+++ b/Sources/QwenVoiceCore/MLXTTSEngine.swift
@@ -4,7 +4,17 @@ import Foundation
 @preconcurrency import MLX
 @preconcurrency import MLXAudioTTS
 
-public enum MLXTTSEngineError: LocalizedError, Equatable {
+/// Engine-protocol-level error type. Adopted by every conformer of
+/// `TTSEngine` and by every throwing function on that protocol once the
+/// typed-throws sweep is complete. Conformers catch downstream typed
+/// errors (e.g. `AudioPreparationError`, `DocumentIOError`,
+/// `ExtensionEngineHostManagerError`) and rethrow them as
+/// `.generationFailed(<localized description>)`. The cross-process
+/// transports (`Sources/QwenVoiceNative/XPCNativeEngineClient.swift`,
+/// `Sources/QwenVoiceCore/ExtensionBackedTTSEngine.swift`) carry
+/// instances of this type across `NSXPCConnection` and `AppExtension`
+/// boundaries.
+public enum TTSEngineError: LocalizedError, Equatable {
     case notInitialized
     case unknownModel(String)
     case modelUnavailable(String)
@@ -24,6 +34,12 @@ public enum MLXTTSEngineError: LocalizedError, Equatable {
         }
     }
 }
+
+/// Source-compatibility alias for the prior name. Existing call sites
+/// that reference `MLXTTSEngineError.<case>` continue to work; the type
+/// they see is now `TTSEngineError`. Retained for the duration of the
+/// typed-throws sweep so individual files can migrate incrementally.
+public typealias MLXTTSEngineError = TTSEngineError
 
 @MainActor
 public final class MLXTTSEngine: TTSEngineRuntimeControlling {


### PR DESCRIPTION
## Summary

Step 1 of the Swift 6 typed-throws sweep at the `TTSEngine` protocol surface. Renames the engine-level error type from `MLXTTSEngineError` to `TTSEngineError` and keeps the old name as a typealias so existing call sites keep working without churn.

The historical name was framed around the MLX conformer, but the same error type is consumed by every conformer of the protocol — including the iPhone extension path (`Sources/QwenVoiceCore/ExtensionBackedTTSEngine.swift`) and the macOS XPC service (`Sources/QwenVoiceEngineService/EngineServiceHost.swift`). The new name reflects that scope.

## Course Correction

The original plan called for an 8-commit cascade landing typed throws across the entire engine surface in a single PR. After commit 1 landed cleanly, I realized the leaf-level work (each `throws` becoming `throws(<ConcreteError>)`) is far more invasive than the inventory estimated — every internal `try` to AVFoundation/Foundation needs `do/catch` wrapping, easily 100-200 edits across 20-30 files. That's the kind of large refactor that's better landed in small, separately-reviewable PRs.

This PR ships only the foundational rename. Follow-up PRs can adopt typed throws **incrementally**, one leaf or one transport adapter at a time, each with its own review and validation cycle.

## Changes

- `Sources/QwenVoiceCore/MLXTTSEngine.swift`: rename `enum MLXTTSEngineError` to `TTSEngineError` with a header comment documenting its protocol-level role; add `public typealias MLXTTSEngineError = TTSEngineError` for source compatibility during the migration.

## Behavior

No behavior change. The 5 existing cases (`notInitialized`, `unknownModel`, `modelUnavailable`, `unsupportedRequest`, `generationFailed`) are preserved with their original messages. All existing `MLXTTSEngineError.<case>` references continue to resolve correctly through the typealias.

## Test plan

- [x] `./scripts/build_foundation_targets.sh macos` — clean build
- [x] `./scripts/check_project_inputs.sh` — clean
- [x] `./scripts/qa.sh validate` — clean
- [x] `git diff --check` — clean
- [ ] `Apple Platform Build Gate` passes on this PR (project regen + builds)
- [ ] `Project Inputs` passes on this PR