### PR TITLE
Point README and website at the v2.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@
 
 <p align="center">
   <a href="https://vocello.vercel.app/"><img src="https://img.shields.io/badge/Website-vocello.vercel.app-7b61ff?style=flat-square&logo=vercel" alt="Website"></a>
-  <a href="https://github.com/PowerBeef/QwenVoice/releases/tag/v2.0.0"><img src="https://img.shields.io/badge/Vocello-2.0.0-7b61ff?style=flat-square" alt="Vocello 2.0.0"></a>
+  <a href="https://github.com/PowerBeef/QwenVoice/releases/tag/v2.1.0"><img src="https://img.shields.io/badge/Vocello-2.1.0-7b61ff?style=flat-square" alt="Vocello 2.1.0"></a>
   <img src="https://img.shields.io/badge/macOS-26%2B-111827?style=flat-square&logo=apple" alt="macOS 26+">
   <img src="https://img.shields.io/badge/iPhone-arriving%20soon-7b61ff?style=flat-square&logo=apple" alt="iPhone — arriving soon">
   <img src="https://img.shields.io/badge/Apple%20Silicon-required-111827?style=flat-square&logo=apple" alt="Apple Silicon">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue?style=flat-square" alt="License: MIT"></a>
-  <a href="https://github.com/PowerBeef/QwenVoice/releases/tag/v2.0.0"><img src="https://img.shields.io/github/downloads/PowerBeef/QwenVoice/v2.0.0/total?label=2.0.0%20downloads&style=flat-square" alt="Downloads"></a>
+  <a href="https://github.com/PowerBeef/QwenVoice/releases/tag/v2.1.0"><img src="https://img.shields.io/github/downloads/PowerBeef/QwenVoice/v2.1.0/total?label=2.1.0%20downloads&style=flat-square" alt="Downloads"></a>
 </p>
 
 <p align="center">
   <img src="docs/readme_banner_vocello.png" alt="Vocello banner with abstract voice waves and the Vocello logo" width="920">
 </p>
 
-<p align="center"><em>Formerly QwenVoice — now Vocello 2.0.</em></p>
+<p align="center"><em>Formerly QwenVoice — now Vocello 2.1.</em></p>
 
 ---
 
@@ -32,7 +32,7 @@
 
 | Platform | Build | Notes |
 | --- | --- | --- |
-| **macOS 26+** (Apple Silicon) | **Vocello 2.0.0** — [Download DMG](https://github.com/PowerBeef/QwenVoice/releases/tag/v2.0.0) | Signed, notarized, stable. Double-click to open. |
+| **macOS 26+** (Apple Silicon) | **Vocello 2.1.0** — [Download DMG](https://github.com/PowerBeef/QwenVoice/releases/tag/v2.1.0) | Signed, notarized, stable. Double-click to open. |
 | **macOS 15** | QwenVoice 1.2.3 — [Download legacy](https://github.com/PowerBeef/QwenVoice/releases/tag/v1.2.3) | Legacy build. No 2.x backport planned. |
 | **iPhone** (iOS 26+, Apple Silicon) | **Arriving soon** | The same on-device engine; ships via App Store / TestFlight (not GitHub Releases). |
 
@@ -94,7 +94,7 @@
 
 ## Install (macOS)
 
-1. Download [`Vocello-macos26.dmg`](https://github.com/PowerBeef/QwenVoice/releases/tag/v2.0.0).
+1. Download [`Vocello-macos26.dmg`](https://github.com/PowerBeef/QwenVoice/releases/tag/v2.1.0).
 2. Open the DMG and drag `Vocello.app` to `/Applications`.
 3. Open Vocello.
 4. Go to **Settings → Model downloads** and install the voice models you want.
@@ -119,7 +119,7 @@ A `release-metadata.txt` (commit SHA, Xcode version, SDK, marketing version, bui
 
 **Speed** models are smaller 4-bit packages for faster startup and lower memory use. **Quality** models are larger 8-bit packages for devices with more headroom.
 
-Vocello 2.0.0 is the current stable macOS release. For macOS 15, use [QwenVoice v1.2.3](https://github.com/PowerBeef/QwenVoice/releases/tag/v1.2.3); no 2.x backport is planned. Every macOS GitHub Release ships a notarized, stapled, Developer ID–signed DMG — a normal double-click install with no Gatekeeper workarounds.
+Vocello 2.1.0 is the current stable macOS release. For macOS 15, use [QwenVoice v1.2.3](https://github.com/PowerBeef/QwenVoice/releases/tag/v1.2.3); no 2.x backport is planned. Every macOS GitHub Release ships a notarized, stapled, Developer ID–signed DMG — a normal double-click install with no Gatekeeper workarounds.
 
 ## Local-first privacy
 
@@ -131,7 +131,7 @@ Vocello 2.0.0 is the current stable macOS release. For macOS 15, use [QwenVoice 
 
 ## Build from source
 
-The `main` branch contains the current Vocello codebase (macOS app, iPhone app, and the `vocello` CLI). The stable macOS release is tagged [`v2.0.0`](https://github.com/PowerBeef/QwenVoice/releases/tag/v2.0.0).
+The `main` branch contains the current Vocello codebase (macOS app, iPhone app, and the `vocello` CLI). The stable macOS release is tagged [`v2.1.0`](https://github.com/PowerBeef/QwenVoice/releases/tag/v2.1.0).
 
 Vocello's engine is **native Swift + MLX** — no Python, no bundled weights. On macOS it runs **out-of-process** in an isolated XPC service; on iPhone it runs **in-process**, fully on-device. Architecture, engine invariants, and release policy live in [`CLAUDE.md`](CLAUDE.md).
 

--- a/website/PRODUCT.md
+++ b/website/PRODUCT.md
@@ -29,5 +29,5 @@ Warm, clear, confident, and human. Vocello explains local AI generation plainly.
 - Privacy is the architecture, not a badge.
 - The Mac app is the hero. Product screenshots and concrete workflows should carry trust.
 - The page should feel calm, polished, and Apple-native, with quiet motion and no decorative excess.
-- The primary CTA is Vocello 2.0 for macOS 26 and Apple Silicon (stable, released 2026-05-20). QwenVoice 1.2.3 remains the stable fallback for macOS 15.
+- The primary CTA is Vocello 2.1 for macOS 26 and Apple Silicon (stable, released 2026-06-12). QwenVoice 1.2.3 remains the stable fallback for macOS 15.
 - The site should acknowledge the QwenVoice rebrand quietly (inline "formerly QwenVoice" by the wordmark, the v1.2.3 fallback line, and the GitHub repo name). It is not a hero moment.

--- a/website/index.html
+++ b/website/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vocello 2.0: Local AI Voice Studio for Mac</title>
+    <title>Vocello 2.1: Local AI Voice Studio for Mac</title>
     <meta
       name="description"
-      content="Vocello 2.0 is a stable Qwen3-TTS Mac app for private text to speech on Apple Silicon. Generate locally after Hugging Face model download, with no subscription meter or Python setup."
+      content="Vocello 2.1 is a stable Qwen3-TTS Mac app for private text to speech on Apple Silicon. Generate locally after Hugging Face model download, with no subscription meter or Python setup."
     />
     <meta
       name="keywords"
@@ -16,7 +16,7 @@
 
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Vocello" />
-    <meta property="og:title" content="Vocello 2.0: Local AI Voice Studio for Mac" />
+    <meta property="og:title" content="Vocello 2.1: Local AI Voice Studio for Mac" />
     <meta
       property="og:description"
       content="A stable Qwen3-TTS Mac app for macOS 26 on Apple Silicon. Custom Voice, Voice Design, and Voice Cloning run locally after model download."
@@ -24,7 +24,7 @@
     <meta property="og:image" content="/assets/social_preview.png" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Vocello 2.0: Local AI Voice Studio for Mac" />
+    <meta name="twitter:title" content="Vocello 2.1: Local AI Voice Studio for Mac" />
     <meta
       name="twitter:description"
       content="Private text to speech for Apple Silicon Macs. Generate locally after Hugging Face model download, with no subscription meter or Python setup."

--- a/website/src/sections/FinalCTA.jsx
+++ b/website/src/sections/FinalCTA.jsx
@@ -7,7 +7,7 @@ export const FinalCTA = () => (
     <div className="container">
       <div className="cta-block">
         <p className="cta-body">
-          Vocello 2.0.0 for macOS 26 and Apple Silicon. Free, open-source,
+          Vocello 2.1.0 for macOS 26 and Apple Silicon. Free, open-source,
           ready to install in under a minute.
         </p>
         <div className="hero-ctas hero-ctas--center">

--- a/website/src/sections/Hero.jsx
+++ b/website/src/sections/Hero.jsx
@@ -8,7 +8,7 @@ export const Hero = () => (
       <div className="hero-copy">
         <div className="hero-eyebrow">
           <span className="dot" aria-hidden="true" />
-          Vocello 2.0.0 · macOS 26+ · Apple Silicon
+          Vocello 2.1.0 · macOS 26+ · Apple Silicon
         </div>
         <h1 className="hero-title">
           A voice studio that <span className="accent-gold">never leaves</span> your Mac.
@@ -21,7 +21,7 @@ export const Hero = () => (
           <a className="btn btn-primary" href={RELEASE_LATEST} target="_blank" rel="noreferrer">
             <Icon name="apple" size={16} />
             Download for macOS&nbsp;26
-            <span className="platform-mini">· 2.0.0</span>
+            <span className="platform-mini">· 2.1.0</span>
           </a>
           <a className="btn btn-secondary" href="#listen">
             <Icon name="play" size={14} />

--- a/website/src/sections/Limitations.jsx
+++ b/website/src/sections/Limitations.jsx
@@ -3,7 +3,7 @@ import React from "react";
 const LIMITATIONS = [
   {
     k: "macOS 26+",
-    v: "Vocello 2.0.0 targets macOS 26. QwenVoice 1.2.3 remains the macOS 15 fallback.",
+    v: "Vocello 2.1.0 targets macOS 26. QwenVoice 1.2.3 remains the macOS 15 fallback.",
   },
   {
     k: "Apple Silicon only",


### PR DESCRIPTION
## Summary

Vocello 2.1.0 shipped yesterday (2026-06-12), but the project page and marketing site still pointed at 2.0.0. This PR updates every stale reference:

**README.md** (the GitHub project page, per the screenshot)
- Version badge + downloads-counter badge now read 2.1.0 and link to the `v2.1.0` release
- "Get Vocello" table: **Vocello 2.1.0 — Download DMG** → `releases/tag/v2.1.0`
- Install step 1 DMG link → `v2.1.0`
- "Vocello 2.1.0 is the current stable macOS release" + the Build-from-source tag reference
- Tagline updated to "now Vocello 2.1"

**website/** (marketing site)
- Hero badge, platform chip, Limitations card, and Final CTA: 2.0.0 → 2.1.0
- `index.html` page title + OG/Twitter meta: "Vocello 2.1"
- `PRODUCT.md` primary-CTA note: 2.1, released 2026-06-12
- The site's download buttons use `releases/latest` (`credits.js`) and already resolve to 2.1.0 — no change needed there

macOS 15 / QwenVoice 1.2.3 legacy links are intentionally untouched.

## Verification
- Confirmed the `v2.1.0` release is published with `Vocello-macos26.dmg` attached
- `scripts/check_project_inputs.sh` clean
- `npm --prefix website run build` succeeds

https://claude.ai/code/session_01SZ3pBdDRTfE6qFSLD18jYM

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZ3pBdDRTfE6qFSLD18jYM)_