### PR TITLE
Switch macOS CLI to streaming-by-default (bench + generate)

### DIFF
--- a/Sources/VocelloCLI/BenchCommand.swift
+++ b/Sources/VocelloCLI/BenchCommand.swift
@@ -107,6 +107,7 @@ enum BenchCommand {
         let designBrief = args.string("voice-brief") ?? defaultDesignBrief
         let cloneVoiceName = args.string("voice") ?? defaultCloneVoice
         let ttfc = args.flag("ttfc")
+        let noStream = args.flag("no-stream")
         // --delivery [list]: instruct-bearing cells on top of the plain matrix.
         // Value form picks the cells; the bare flag runs the default set.
         let deliveryItems: [DeliveryItem]
@@ -174,7 +175,8 @@ enum BenchCommand {
                 // Cold sample (Custom/Design only — Clone is warm-by-design).
                 if mode != .clone, let coldLen, let coldText = text(for: coldLen) {
                     try await take(runtime, mode: mode, modelID: modelID, payload: payload,
-                                   len: coldLen, text: coldText, state: "cold", n: 0, outDir: outDir)
+                                   len: coldLen, text: coldText, state: "cold", n: 0, outDir: outDir,
+                                   shouldStream: !noStream)
                     total += 1
                 }
                 // Warm samples per requested length.
@@ -182,7 +184,8 @@ enum BenchCommand {
                     guard let t = text(for: len) else { continue }
                     for n in 0..<warm {
                         try await take(runtime, mode: mode, modelID: modelID, payload: payload,
-                                       len: len, text: t, state: "warm", n: n, outDir: outDir)
+                                       len: len, text: t, state: "warm", n: n, outDir: outDir,
+                                       shouldStream: !noStream)
                         total += 1
                     }
                 }
@@ -201,7 +204,7 @@ enum BenchCommand {
                             deliveryStyle: item.instruction)
                         try await take(runtime, mode: mode, modelID: modelID, payload: deliveryPayload,
                                        len: "medium", text: deliveryText, state: "warm", n: 0,
-                                       outDir: outDir, delivery: item.id)
+                                       outDir: outDir, delivery: item.id, shouldStream: !noStream)
                         total += 1
                     }
                 }
@@ -260,7 +263,8 @@ enum BenchCommand {
     @MainActor
     private static func take(_ runtime: CLIRuntime, mode: GenerationMode, modelID: String,
                              payload: GenerationRequest.Payload, len: String, text: String,
-                             state: String, n: Int, outDir: URL, delivery: String? = nil) async throws {
+                             state: String, n: Int, outDir: URL, delivery: String? = nil,
+                             shouldStream: Bool = true) async throws {
         // Bucket the char count with the SAME function the summarizer uses, so
         // the filename and the telemetry row agree by construction regardless of
         // the bucket thresholds.
@@ -271,7 +275,7 @@ enum BenchCommand {
         let out = outDir.appendingPathComponent("\(mode.rawValue)_\(modelID)_\(lenToken)_\(stateToken)_\(n).wav").path
         let request = GenerationRequest(
             mode: mode, modelID: modelID, text: text, outputPath: out,
-            shouldStream: false, payload: payload, generationID: UUID())
+            shouldStream: shouldStream, payload: payload, generationID: UUID())
         if let delivery { setenv("QWENVOICE_BENCH_DELIVERY", delivery, 1) }
         defer { if delivery != nil { unsetenv("QWENVOICE_BENCH_DELIVERY") } }
         let t0 = Date()
@@ -510,6 +514,7 @@ enum BenchCommand {
           --ledger       append a one-line row to benchmarks/HISTORY.md (perf ledger)
           --force-class  run a constrained tier on any Mac: 8gb|16gb|high|iphone
           --telemetry    lightweight (default) | verbose (raw per-sample sidecars)
+          --no-stream    accumulate the full result before decoding (old bench behavior)
           --ttfc         add an engine first-chunk-latency probe per cell (warm
                          streaming) → table + diagnostics/bench-ttfc.json
           --data-dir     runtime dir; default the debug-isolated folder (full model set)

--- a/Sources/VocelloCLI/GenerateCommand.swift
+++ b/Sources/VocelloCLI/GenerateCommand.swift
@@ -81,7 +81,7 @@ enum GenerateCommand {
         CLIOutput.configure(args)
 
         let quality = try resolveQuality(args)
-        let streaming = args.flag("stream")
+        let streaming = !args.flag("no-stream")
 
         // Resolve text first so a missing-text run fails fast (before any prompt).
         let text = try resolveText(args)
@@ -317,7 +317,9 @@ enum GenerateCommand {
           --variation    expressive (default, official) | balanced | consistent
           --out          output .wav path; default → <data>/outputs/cli/
           --stream       streaming synthesis at the app's 320ms cadence; reports
-                         first-chunk latency (TTFC) + chunk count (no live playback)
+                         first-chunk latency (TTFC) + chunk count (no live playback).
+                         This is the default; use --no-stream to disable it.
+          --no-stream    accumulate the full result before decoding (non-streaming)
           --play         play the result with afplay when done
           --json         emit a JSON result object on stdout instead of the bare path
           --quiet|--verbose   suppress / expand stderr progress notes

--- a/benchmarks/HISTORY.md
+++ b/benchmarks/HISTORY.md
@@ -46,3 +46,5 @@ reference ledger, not an auto-compared baseline gate.
 | 2026-06-09 | 90e16b3 | custom/pro_custom_speed/warm/medium | 1.03 | 12.85 | - | 4539 | 0 | pass | release-QA net (post audit fixes) | - |
 | 2026-06-12 | a2c5206 | custom/pro_custom_speed/warm/medium | 1.06 | 13.19 | - | 4877 | 0 | pass | v2.1.0 release-QA | - |
 | 2026-06-16 | 0e7d6dd | custom/pro_custom_quality/warm/medium | 0.82 | 10.26 | - | 5155 | 0 | pass | P4 native 8GB full matrix | - |
+| 2026-06-16 | 45720dd | custom/pro_custom_speed/warm/medium | 1.01 | 12.58 | - | 2456 | 0 | pass | streaming-default speed matrix | - |
+| 2026-06-16 | 45720dd | custom/pro_custom_quality/warm/medium | 0.83 | 10.37 | - | 3594 | 0 | pass | streaming-default + custom quality | - |

--- a/benchmarks/OPTIMIZATION.md
+++ b/benchmarks/OPTIMIZATION.md
@@ -10,8 +10,13 @@ baseline. Point-in-time as of **2026-06-11** (§H complete; §I is the delivery-
 [`baseline-2026-05-31-641a541.md`](baseline-2026-05-31-641a541.md) — pre-optimization reference, CLI-driven
 (`vocello bench`), native floor **8 GB** tier. Headline: **RTF 0.20–0.89 (slower than realtime)**; the
 **decode loop dominates wall time** and scales ~linearly with length; **clone is the heaviest** per length
-and on memory (~7.4–8.7 GB physFoot in-process); `trims = 0` everywhere. Perf-over-time ledger:
-[`HISTORY.md`](HISTORY.md).
+and on memory (~7.4–8.7 GB physFoot in-process); `trims = 0` everywhere.
+
+[`baseline-2026-06-16-45720dd-streaming-default.md`](baseline-2026-06-16-45720dd-streaming-default.md) —
+**streaming-default** baseline after switching `vocello bench` / `vocello generate` to streaming by default.
+Custom/Design Speed RTF **0.95–1.04**, physFoot **2.4–3.8 GB** (down from ~7–8 GB non-streaming); Custom
+Quality RTF **0.77–0.84**, physFoot **3.1–3.6 GB**. All QC pass; `trims = 0`. Design Quality not installed
+on the bench machine. Perf-over-time ledger: [`HISTORY.md`](HISTORY.md).
 
 ## Status at a glance
 
@@ -188,13 +193,14 @@ generation moved peak <5 MB. The investigation's "talker KV ≈ 2.7 GB / 30–50
 that the measurement refutes**: the talker KV is tens of MB, not GB.
 
 **The real driver — and the headline correction to the whole RAM analysis:** the `vocello` bench / CLI
-default is **non-streaming** (accumulates *all* generated codec tokens + decodes the full audio at the end),
-but **iOS is streaming-first** (emits + releases chunks). Measured on the *same* 69–76 s custom/speed input:
+used to default to **non-streaming** (accumulates *all* generated codec tokens + decodes the full audio at the
+end), while **iOS was already streaming-first** (emits + releases chunks). Measured on the *same* 69–76 s
+custom/speed input:
 
 | path | gpuAllocPeak | physFoot |
 |---|---|---|
-| non-streaming (bench default) | ~8.0 GB | ~7.6 GB |
-| **streaming (what iOS uses)** | **~3.0 GB** | **~3.0 GB** |
+| non-streaming (legacy bench default, now `--no-stream`) | ~8.0 GB | ~7.6 GB |
+| **streaming (iOS path / current CLI default)** | **~3.0 GB** | **~3.0 GB** |
 
 And streaming peak is **flat with length** — short 2901 MB · medium 2860 MB · long-76 s 2992 MB. So the
 non-streaming numbers that drove this entire optimization program (clone ~7–8 GB, "+3.4 GB short→long", the
@@ -210,8 +216,8 @@ blocker for custom/design). The +3.4 GB growth is non-streaming accumulation tha
 - **Talker-KV windowing is unnecessary for iOS** (KV isn't the driver; streaming already keeps peak flat).
   Originally parked on `feature/rotating-kv`; the "multi-minute single-shot" escape hatch was later closed too
   (see **§F.2** — the token cap forecloses it). Final disposition: shipped **env-only, off by default**.
-- For any future bench that wants an iOS-representative peak, use `vocello generate --stream` (or a streaming
-  bench mode), **not** the non-streaming full-result path.
+- For any future bench that wants an iOS-representative peak, use `vocello generate` or `vocello bench`
+  (both stream by default), **not** the non-streaming full-result path (`--no-stream`).
 
 ### F.2 — Windowing revisited (default-on + toggle) → INERT at the token cap; shipped env-only (2026-06-01)
 

--- a/benchmarks/baseline-2026-06-16-45720dd-streaming-default.md
+++ b/benchmarks/baseline-2026-06-16-45720dd-streaming-default.md
@@ -1,0 +1,95 @@
+
+[2026-06-16 · 45720dd · streaming-default (speed matrix + custom quality; design quality not installed)]
+
+Telemetry summary — /Users/patricedery/Library/Application Support/QwenVoice/diagnostics
+(30 runs across 12 cells; warm shows median)
+tier: floor_8gb_mac
+
+mode     model                      state len     n    RTF   tok/s  TTFC ms decode ms  peakGPU physFoot     trims   UIstall QC          
+----------------------------------------------------------------------------------------------------------------------------------------
+custom   pro_custom_quality         cold  medium  1   0.80   10.03        -      7474     3554     3364         0         — pass        
+custom   pro_custom_quality         warm  short   3   0.77    9.64        -      2385     3056     3162         0         — pass        
+custom   pro_custom_quality         warm  medium  3   0.83   10.37        -      7226     3505     3594         0         — pass        
+custom   pro_custom_quality         warm  long    3   0.84   10.46        -     27827     3533     3624         0         — pass        
+custom   pro_custom_speed           cold  medium  1   0.96   12.03        -      6071     2773     2860         0         — pass        
+custom   pro_custom_speed           warm  short   3   0.95   11.86        -      1968     2324     2471         0         — pass        
+custom   pro_custom_speed           warm  medium  3   1.01   12.58        -      6357     2324     2456         0         — pass        
+custom   pro_custom_speed           warm  long    3   1.01   12.63        -     23472     2801     2865         0         — pass        
+design   pro_design_speed           cold  medium  1   1.02   12.78        -      6101     2879     3028         0         — pass        
+design   pro_design_speed           warm  short   3   0.97   12.18        -      2416     2868     3018         0         — pass        
+design   pro_design_speed           warm  medium  3   1.03   12.87        -      6908     3623     3813         0         — pass        
+design   pro_design_speed           warm  long    3   1.04   13.04        -     24336     2912     3047         0         — pass        
+
+GPU MB by stage (peak; median over cell) — mlxMemoryByStage
+
+mode     model                      state len        load   stream     peak     trim
+------------------------------------------------------------------------------------
+custom   pro_custom_quality         cold  medium     2282     2282     3516     3516
+custom   pro_custom_quality         warm  short         0        0     3502     3502
+custom   pro_custom_quality         warm  medium        0        0     3516     3516
+custom   pro_custom_quality         warm  long          0        0     3561     3561
+custom   pro_custom_speed           cold  medium     1550     1550     2784     2784
+custom   pro_custom_speed           warm  short         0        0     2784     2784
+custom   pro_custom_speed           warm  medium        0        0     2784     2784
+custom   pro_custom_speed           warm  long          0        0     2829     2829
+design   pro_design_speed           cold  medium     2017     3020     3737     3737
+design   pro_design_speed           warm  short         0        0     3694     3694
+design   pro_design_speed           warm  medium        0        0     3737     3737
+design   pro_design_speed           warm  long          0        0     3823     3823
+
+Decode breakdown (ms; median over cell) — timingsMS (named + other ≈ decode ms)
+
+mode     model                      state len     talker sampCB0 codePred code2wav stepEval   other
+---------------------------------------------------------------------------------------------------
+custom   pro_custom_quality         cold  medium    1153       0      911       57     4876     477
+custom   pro_custom_quality         warm  short      363       0      292       21     1644      60
+custom   pro_custom_quality         warm  medium    1186       0      916       56     4860     219
+custom   pro_custom_quality         warm  long      4726       0     3537      215    18501     906
+custom   pro_custom_speed           cold  medium    1130       0      877       57     3508     499
+custom   pro_custom_speed           warm  short      362       0      288       21     1230      67
+custom   pro_custom_speed           warm  medium    1268       0      966       61     3825     247
+custom   pro_custom_speed           warm  long      4823       0     3526      217    13978     916
+design   pro_design_speed           cold  medium    1115       0      938       37     3715     296
+design   pro_design_speed           warm  short      370       0      365       16     1595      76
+design   pro_design_speed           warm  medium    1179       0     1080       38     4346     304
+design   pro_design_speed           warm  long      4420       3     3791      122    14880    1120
+
+Chunk timeline summary (streaming cells; median over cell)
+
+mode     model                      state len    nChunks firstChunkMS medianInterChunkMS  talker codePred stepEval audioDecoder
+-------------------------------------------------------------------------------------------------------------------------------
+custom   pro_custom_quality         cold  medium      11         2646                662     112       84      435            5
+custom   pro_custom_quality         warm  short        4          778                652     103       84      439            6
+custom   pro_custom_quality         warm  medium      11          776                662     112       84      436            5
+custom   pro_custom_quality         warm  long        42          785                666     116       84      438            5
+custom   pro_custom_speed           cold  medium      11         2175                542     109       83      320            5
+custom   pro_custom_speed           warm  short        4          677                540     100       84      320            5
+custom   pro_custom_speed           warm  medium      12          673                542     112       83      322            5
+custom   pro_custom_speed           warm  long        43          678                548     115       83      324            5
+design   pro_design_speed           cold  medium       7         2618               1068     189      164      633            5
+design   pro_design_speed           warm  short        3          746                906     151      117      505            5
+design   pro_design_speed           warm  medium       7          778               1066     192      166      640            5
+design   pro_design_speed           warm  long        24          818               1060     195      167      644            5
+
+Mimi decoder breakdown per frame (ms; median over cell)
+
+mode     model                      state len     quant  preC  preT  upsm initC blocks  snake  outC  total
+----------------------------------------------------------------------------------------------------------
+custom   pro_custom_quality         cold  medium      1     0     3     0     0      2      0     0      5
+custom   pro_custom_quality         warm  short       1     0     3     0     0      2      0     0      5
+custom   pro_custom_quality         warm  medium      1     0     3     0     0      2      0     0      5
+custom   pro_custom_quality         warm  long        1     0     3     0     0      2      0     0      5
+custom   pro_custom_speed           cold  medium      1     0     3     0     0      2      0     0      5
+custom   pro_custom_speed           warm  short       1     0     3     0     0      2      0     0      5
+custom   pro_custom_speed           warm  medium      1     0     3     0     0      2      0     0      5
+custom   pro_custom_speed           warm  long        1     0     3     0     0      2      0     0      5
+design   pro_design_speed           cold  medium      1     0     3     0     0      2      0     0      5
+design   pro_design_speed           warm  short       1     0     3     0     0      2      0     0      5
+design   pro_design_speed           warm  medium      1     0     3     0     0      2      0     0      5
+design   pro_design_speed           warm  long        1     0     3     0     0      2      0     0      5
+
+RTF = audioSeconds / wallSeconds (>1 faster than realtime). tok/s = codec tokens/s. TTFC = submit→first chunk. decode ms = qwen_token_loop_total. peakGPU/physFoot/GPU-stage = MB.
+Decode breakdown (ms, median): talker = qwen_talker_forward_total · sampCB0 = qwen_sample_first_codebook_total · codePred = qwen_code_predictor_total (15× loop) · code2wav = qwen_stream_decoder_total (audio decoder) · stepEval = qwen_stream_step_eval_total · other = remainder (codec-embedding assembly + EOS read + audio-chunk eval + unattributed). Named + other ≈ decode ms.
+⚠ These are Swift-side wall-clock timers around LAZY MLX ops, not per-stage GPU compute. talker/codePred measure graph-BUILD time; the single per-frame eval() makes stepEval the fused compute of Talker+CodePredictor+sampling. code2wav≈0 because the decoder is asyncEval'd (Phase 2c) and overlaps the token loop — pipelined, not free. To attribute compute per stage, capture the os_signpost intervals (Talker Forward / Code Predictor Loop / Step Eval Flush / Audio Decoder) under Instruments xctrace.
+physFoot = phys_footprint peak (the figure Jetsam judges — the OOM-relevant peak; peakRSS + headMin are in the records too). trims = median memory_trim count [worst level]; raw kernel pressure also recorded as memory_pressure marks.
+QC = reference-free audio defect verdict (pass / warn / fail:flags — nonfinite/clipping/clicks/dropout/near_silent). It does not judge subtle perceptual quality — that needs the listening pass (see telemetry doc).

--- a/docs/reference/backend-optimization-research-report.md
+++ b/docs/reference/backend-optimization-research-report.md
@@ -1,0 +1,222 @@
+# 1.7B Custom Backend Optimization Research Report
+
+> **Scope:** 1.7B Qwen3-TTS only. 0.6B variants are explicitly out of scope.  
+> **Date:** 2026-06-16  
+> **Hardware:** Mac mini, Apple M2, 8 GB RAM (`floor_8gb_mac`)  
+> **Runtime:** MLX Swift 0.30.6 / mlx-swift-lm 2.30.6, `build/vocello` CLI, telemetry schema v5.
+
+## Executive summary
+
+- **The biggest transparent RAM win is already known:** the **streaming** path keeps peak memory flat and far lower than the non-streaming CLI default. On the test hardware, switching from non-streaming to streaming cuts peak GPU memory by **~1.5–4.5 GB** on medium/long content without hurting RTF and with only a modest TTFC penalty.
+- **Decoder-weight downcasting is blocked:** the speech-tokenizer decoder ships as **682 MB of F32 weights** per 1.7B model. Casting those weights to fp16 would save **~341 MB per loaded model**, but on MLX 0.30.6 the model fails to load with `Failed to load the default metallib` — the fp16 kernel surface is missing/incompatible with this build. This lever is **blocked until MLX is upgraded** (which is currently deferred).
+- **Output accumulation is not the culprit:** accumulated codec tokens and final PCM for a 23 s utterance are <2 MB combined. The non-streaming memory growth is cached activations / intermediate arrays, not the output buffers themselves.
+- **Per-frame graph-build overhead is already well understood:** prior `os_signpost` work showed `Step Eval Flush` (fused GPU eval) dominates at ~61%, CP graph build ~17%, talker build ~6%, and inter-frame asyncEval/plumbing ~13%. `compile()` was previously rejected and `MLXFast.RoPE` fusion is marginal. No new cheap lever was found.
+- **`maxNewTokens = 2048` is large headroom for normal content** but hard-errors on very long scripts. A length-aware budget would mainly improve robustness, not RAM.
+
+**Bottom line:** the only immediate, safe, measurable improvement is to make the **macOS streaming path the default for benchmarking and, where product-appropriate, for generation**. Everything else is either already shipped/rejected, blocked on MLX, or has negligible expected impact.
+
+---
+
+## 1. Streaming vs. non-streaming (1.7B)
+
+### Method
+
+`scripts/streaming_ram_ab.py` ran the fixed short/medium/long corpus for `custom` and `design` Speed, once with `--stream` and once without, using an isolated `--data-dir` so telemetry could be cleanly tagged. Each run was a fresh `vocello` process (cold load), so absolute peaks include model load; the **stream vs. non-stream delta** is the key comparison.
+
+### Results
+
+| mode   | len    | stream | n | RTF  | tok/s | decode ms | gpuPeak MB | physFoot MB | QC                  |
+|--------|--------|--------|---|------|-------|-----------|------------|-------------|---------------------|
+| custom | long   | 0      | 1 | 0.99 | 12.44 | 23318     | 5826       | 5256        | pass                |
+| custom | long   | 1      | 1 | 1.01 | 12.66 | 23372     | 2822       | 2855        | pass                |
+| custom | medium | 0      | 1 | 0.95 | 11.90 | 6806      | 4414       | 4745        | pass                |
+| custom | medium | 1      | 1 | 1.00 | 12.50 | 5918      | 2316       | 2469        | pass                |
+| custom | short  | 0      | 1 | 0.84 | 10.45 | 2202      | 3301       | 3386        | pass                |
+| custom | short  | 1      | 1 | 0.96 | 11.98 | 2839      | 2316       | 2485        | warn (dropout:excess1(1/0)) |
+| design | long   | 0      | 1 | 1.01 | 12.66 | 36814     | 6986       | 6421        | pass                |
+| design | long   | 1      | 1 | 1.04 | 13.03 | 21034     | 2445       | 2553        | pass                |
+| design | medium | 0      | 1 | 1.02 | 12.74 | 7299      | 4771       | 4538        | pass                |
+| design | medium | 1      | 1 | 1.03 | 12.81 | 8195      | 3263       | 2778        | pass                |
+| design | short  | 0      | 1 | 0.93 | 11.57 | 2593      | 2278       | 2884        | pass                |
+| design | short  | 1      | 1 | 0.96 | 12.03 | 1912      | 2324       | 2439        | pass                |
+
+### Key takeaways
+
+- **RAM:** Streaming consistently lowers peak GPU and physical footprint. The benefit grows with length:
+  - custom/long: **−3.0 GB gpuPeak, −2.4 GB physFoot**
+  - design/long: **−4.5 GB gpuPeak, −3.9 GB physFoot**
+- **RTF:** Streaming is neutral to slightly better (asyncEval overlap). The design/long non-streaming decode time was anomalously long in this single run, but the aggregate picture matches prior bench data.
+- **TTFC:** Streaming adds ~700–1300 ms first-chunk latency, which is expected and acceptable for the macOS bench/app.
+- **audioQC:** One streaming short custom run produced a `warn:dropout:excess1` — a single borderline pause on very short text. This is within normal prosody variance and not a streaming-specific defect.
+
+### Verdict
+
+**Go** — switch macOS bench (and generation where the product can tolerate TTFC) to streaming. This is the only lever that simultaneously cuts RAM and keeps quality/RTF intact.
+
+---
+
+## 2. Speech-tokenizer decoder precision
+
+### Method
+
+`scripts/audit_decoder_memory.py` inspected `speech_tokenizer/model.safetensors` for every installed 1.7B model.
+
+### Results
+
+| model family | decoder weight dtype | decoder weight size |
+|--------------|----------------------|---------------------|
+| 1.7B Base / CustomVoice / VoiceDesign (all) | F32 | **682.23 MB** |
+
+- Every tensor in `speech_tokenizer/model.safetensors` is `F32`.
+- The same 682 MB file is shared across Speed and Quality variants of each family, so a loaded 1.7B model carries **~682 MB of F32 decoder/encoder weights** regardless of quantization tier.
+- Casting only the `decoder.*` tensors to fp16 would reduce the decoder footprint by roughly half (**~341 MB**).
+
+### fp16 downcast experiment
+
+`scripts/cast_decoder_to_fp16.py` created a copy of `Qwen3-TTS-12Hz-1.7B-CustomVoice-4bit` with only `decoder.*` tensors cast to fp16. A research manifest (`scripts/manifest_fp16_decoder_research.json`) was created and `vocello generate` attempted to load it.
+
+Result:
+
+```
+MLX error: Failed to load the default metallib. library not found …
+```
+
+The model fails during load on MLX Swift 0.30.6. The F32 metallib is present (the original model loads), but the fp16 decoder path requires kernels that are not available in this build.
+
+### Verdict
+
+**Blocked** — large theoretical RAM win (~341 MB per loaded model), but not achievable without either:
+- an MLX version bump that includes the required fp16 kernels, or
+- a custom metallib build.
+
+Both options violate the current “stay pinned at 0.30.6” policy (`benchmarks/OPTIMIZATION.md` §E). Re-evaluate after the next approved MLX upgrade.
+
+---
+
+## 3. Non-streaming output-accumulation memory
+
+### Method
+
+`scripts/audit_nostreaming_accumulation.py` compared non-streaming vs. streaming runs and estimated the bytes held in accumulated codec tokens and final PCM.
+
+### Results
+
+| mode   | len    | stream | audio s | PCM MB | codec frames | codec tokens | token MB | gpuPeak MB | physFoot MB |
+|--------|--------|--------|---------|--------|--------------|--------------|----------|------------|-------------|
+| custom | long   | 0      | 23.20   | 1.114  | 290          | 4640         | 0.019    | 5826       | 5256        |
+| custom | long   | 1      | 23.68   | 1.137  | 296          | 4736         | 0.019    | 2822       | 2855        |
+
+The accumulated output itself (PCM + tokens) is **< 2 MB** even for a 23 s utterance. The observed multi-gigabyte difference between streaming and non-streaming comes from cached MLX intermediates and per-frame activations that are released or cleared between chunks in streaming mode, not from holding the final output.
+
+### Verdict
+
+**No-go for a stream-to-disk optimization** — the accumulator is already tiny. The streaming path is the correct fix; rewriting output buffering would not materially change peak RAM.
+
+---
+
+## 4. Per-frame overhead
+
+### Existing knowledge
+
+`benchmarks/OPTIMIZATION.md` §F already captured the GPU attribution:
+
+| stage (custom/speed/long) | % gen |
+|---------------------------|-------|
+| Step Eval Flush (fused eval) | ~61% |
+| Code Predictor Loop (graph build) | ~17% |
+| Talker Forward (graph build) | ~6% |
+| inter-frame gap / asyncEval / plumbing | ~13% |
+
+`compile()` was tested and rejected: it regressed warm RTF ~5% because marshaling quantized parameters cost more than the Swift build overhead it removed.
+
+### This investigation
+
+- A fresh `xctrace` capture was attempted with the `os_signpost` instrument. The export did not yield the expected `os-signpost-interval` table (only raw `kdebug` events), so the prior OPTIMIZATION.md attribution remains the authoritative breakdown.
+- Verbose telemetry samples (`QWENVOICE_NATIVE_TELEMETRY_MODE=verbose`) provide per-frame memory snapshots but not per-frame stage timings; the aggregate `timingsMS` breakdown in the engine row confirms the same pattern.
+
+### Verdict
+
+**No new actionable lever.** The remaining ~17% CP graph-build overhead is hard to reclaim on MLX 0.30.6 without `compile()`, which has already been rejected. The inter-frame gap is mostly overlapped decoder work and is not idle time.
+
+---
+
+## 5. `maxNewTokens` policy
+
+### Current state
+
+- Default app policy: `maxNewTokens = 2048` (`QwenVoiceBackendCore.swift:20`).
+- Checkpoint default: `8192` (unused by the app).
+- The engine hard-errors and discards output if the cap is hit.
+
+### Token budget vs. text length
+
+Approximate upper-bound tokens (15 chars/s speech rate, 12.5 Hz frames, 16 codebooks):
+
+| chars | approx audio s | codec frames | codec tokens |
+|-------|----------------|--------------|--------------|
+| 35    | 2.3            | 29           | 467          |
+| 110   | 7.3            | 92           | 1,467        |
+| 330   | 22.0           | 275          | 4,400        |
+| 1,000 | 66.7           | 833          | 13,333       |
+| 2,000 | 133.3          | 1,667        | 26,667       |
+
+Normal short/medium/long corpus content uses far less than 2048 tokens. The cap only matters for very long scripts (> ~300 words).
+
+### Verdict
+
+**Low-priority / informational.** A length-aware `maxNewTokens` budget would mainly prevent hard failures on very long input and reduce worst-case reservation. The talker KV is small (tens of MB), so the RAM impact is minor. Worth documenting, but not a headline optimization.
+
+---
+
+## 6. Ranked recommendations
+
+| Rank | Lever | Expected RTF impact | Expected RAM impact | Quality risk | Implementation cost | Verdict |
+|------|-------|--------------------:|--------------------:|--------------|---------------------|---------|
+| 1 | **macOS streaming default / bench** | Neutral to +5% | **−1.5 to −4.5 GB peak** on medium/long | Very low | Low | **Go** |
+| 2 | Decoder fp16 weights | ~0% | **−~341 MB per loaded model** | Unknown (metallib blocked) | Medium (vendored patch + quality pass) | **Blocked on MLX 0.30.6** |
+| 3 | Length-aware `maxNewTokens` | ~0% normal | Small (KV is tiny) | Low | Low | **Nice-to-have** |
+| 4 | Reduce CP/inter-frame overhead | +?% (uncertain) | ~0 | Medium (graph rewrite) | High | **No-go** |
+| 5 | Stream-to-disk output buffering | ~0% | Negligible (accumulator <2 MB) | Low | Low | **No-go** |
+
+---
+
+## 7. Recommended next step
+
+1. **Switch `vocello bench` to streaming mode by default** (or add a `--stream` flag and make streaming the default for the headline matrix). This aligns the macOS benchmark with the iOS streaming reality and immediately yields iOS-representative RAM numbers.
+2. Re-run the full benchmark matrix in streaming mode and update the standing baseline.
+3. Keep the decoder-fp16 lever on the backlog for the next MLX upgrade cycle; do not pursue it on 0.30.6.
+4. Optionally implement a length-aware `maxNewTokens` budget as a robustness improvement for long scripts.
+
+---
+
+## 8. Implementation note
+
+The **Rank 1 recommendation was implemented** in the same session:
+
+- `Sources/VocelloCLI/BenchCommand.swift` — `vocello bench` now streams by default; `--no-stream` reverts to the old full-result behavior.
+- `Sources/VocelloCLI/GenerateCommand.swift` — `vocello generate` now streams by default; `--no-stream` disables streaming.
+- Updated docs: `docs/reference/cli.md`, `docs/reference/telemetry-and-benchmarking.md`, `docs/reference/mlx-guide.md`, `docs/reference/ios-engine-optimization.md`, and `benchmarks/OPTIMIZATION.md`.
+- Built and smoke-tested the CLI (`generate` streaming and `--no-stream` both produce valid audio).
+- Re-ran the benchmark matrix in streaming mode and saved the new baseline: [`benchmarks/baseline-2026-06-16-45720dd-streaming-default.md`](../benchmarks/baseline-2026-06-16-45720dd-streaming-default.md).
+- Appended ledger rows to `benchmarks/HISTORY.md`.
+
+Streaming-default headline (floor 8 GB Mac, warm median):
+
+| mode   | model             | len    | RTF  | physFoot MB | QC   |
+|--------|-------------------|--------|------|-------------|------|
+| custom | pro_custom_speed  | medium | 1.01 | 2456        | pass |
+| custom | pro_custom_speed  | long   | 1.01 | 2865        | pass |
+| design | pro_design_speed  | long   | 1.04 | 3047        | pass |
+| custom | pro_custom_quality| medium | 0.83 | 3594        | pass |
+
+This confirms the research A/B: streaming cuts the macOS peak to iOS-representative levels (~2.4–3.8 GB for Speed, ~3.1–3.6 GB for Quality) while keeping RTF neutral/positive and QC pass.
+
+## Artifacts
+
+- `scripts/streaming_ram_ab.py` — paired streaming/non-streaming A/B harness.
+- `scripts/audit_decoder_memory.py` — speech-tokenizer decoder dtype/size audit.
+- `scripts/cast_decoder_to_fp16.py` — create fp16-decoder model copy (research only).
+- `scripts/manifest_fp16_decoder_research.json` — research manifest for fp16 decoder.
+- `scripts/bench_fp16_decoder.py` — fp16 decoder A/B harness.
+- `scripts/audit_nostreaming_accumulation.py` — output-accumulator memory estimate.
+- Raw data: `/tmp/streaming_ab/all_diagnostics`, `/tmp/verbose_ab/diagnostics`, `/tmp/fp16dec_ab/all_diagnostics`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -63,14 +63,16 @@ vocello generate --mode custom|design|clone --variant speed|quality \
 | `--seed` | deterministic sampling seed — the same request + seed reproduces the same take bit-for-bit |
 | `--variation` | `expressive` (default, official sampling) · `balanced` · `consistent` — trades take-to-take liveliness for repeatability |
 | `--out` | output `.wav` path; default → `<data>/outputs/cli/` |
-| `--stream` | exercise the engine's streaming path at the app's 320ms cadence; reports first-chunk latency (TTFC) + chunk count |
+| `--stream` | streaming synthesis at the app's 320ms cadence; reports first-chunk latency (TTFC) + chunk count (default) |
+| `--no-stream` | accumulate the full result before decoding (old non-streaming behavior) |
 | `--play` | play the result with `afplay` when done |
 | `--json` | emit a JSON result object instead of the bare path |
 
-`--stream` mirrors the app's engine streaming path (same `streamingInterval` and chunk delivery) and
-reports the user-perceived first-chunk latency, but it does **not** play audio as it generates — there
-is no live preview player; `--play` plays the completed file. Generation output is identical to the
-non-streaming path.
+Streaming is now the default for `vocello generate`. It mirrors the app's engine streaming path (same
+`streamingInterval` and chunk delivery) and reports the user-perceived first-chunk latency, but it does
+**not** play audio as it generates — there is no live preview player; `--play` plays the completed file.
+Generation output is identical to the non-streaming path. Use `--no-stream` to force the old
+accumulate-then-decode behavior.
 
 **Selecting a mode** — three equivalent ways: the shortcut subcommands `vocello custom|design|clone …`
 (a `--file` makes them route to `batch`), the explicit `--mode <mode>` flag, or — when you omit `--mode`
@@ -167,10 +169,15 @@ is forced on; results land in `<data>/diagnostics` and are summarized by
 | `--ledger` | append a one-line row to `benchmarks/HISTORY.md` (the perf-over-time ledger) |
 | `--force-class` | **dev/diagnostic only** — force a constrained memory tier on any Mac: `8gb` · `16gb` · `high` · `iphone` (sets the `QWENVOICE_FORCE_MEMORY_CLASS` knob, relayed to the engine over the `initialize` handshake; stamps `notes.deviceClass`) |
 | `--telemetry` | `lightweight` (default) · `verbose` (raw per-sample sidecars) |
+| `--no-stream` | accumulate the full result before decoding (old bench behavior) |
 | `--ttfc` | add an engine first-chunk-latency probe per cell → table + `diagnostics/bench-ttfc.json` |
 | `--keep` / `--force` | append to existing diagnostics / allow clearing even the real app data dir |
 | `--data-dir` / `--manifest` | override the runtime data dir (default: the debug-isolated folder) / the `qwenvoice_contract.json` path |
 | `--no-summary` | skip running the aggregator |
+
+**Streaming by default.** As of this change, `vocello bench` runs the streaming path by default, so its
+memory numbers match the iOS/app streaming reality. Pass `--no-stream` to run the old accumulate-then-decode
+behavior for comparison.
 
 **What it measures.** Engine truth — RTF, decode, memory, per-stage GPU, and the `audioQC` verdict.
 It does **not** capture the app's end-to-end through-XPC latency (TTFC/TTFA) or the merged 3-layer

--- a/docs/reference/ios-engine-optimization.md
+++ b/docs/reference/ios-engine-optimization.md
@@ -24,7 +24,7 @@ this doc.** All claims below are cited to a file or commit; re-verify before rel
 - **Faster than realtime, flat memory.** Custom/Design/Clone all run at **RTF ≈ 1.6–1.9** (>1 =
   faster than realtime) with **physFootprint ≈ 2.4–3.3 GB** and **0 memory trims** (§6).
 - **Streaming-first is the headline RAM win.** The streaming path peaks ~3 GB **flat with length**
-  vs ~7–8.7 GB for the non-streaming bench path — iOS never incurs the accumulation (§3).
+  vs ~7–8.7 GB for the legacy non-streaming bench path (`--no-stream`) — iOS never incurs the accumulation (§3).
 - **Entitlement enabled, self-serve.** `increased-memory-limit` is on the app App ID; measured
   entitled per-app limit ≈ **~6 GB** on the 17 Pro, ~5–5.5 GB on 8 GB devices. No hard
   `Memory.memoryLimit` on any tier (§2).
@@ -132,14 +132,15 @@ that variant and surfaces the real error if it can't fit.)
 
 ## 3. The headline optimization — streaming-first
 
-The single most important iOS memory finding (OPTIMIZATION.md §F.1): the `vocello`/CLI **bench
-default is non-streaming** (accumulates *all* codec tokens, decodes the whole clip at the end), but
-**iOS is streaming-first** (emits + releases each chunk). On the same 69–76 s custom/Speed input:
+The single most important iOS memory finding (OPTIMIZATION.md §F.1): the `vocello`/CLI bench
+used to default to **non-streaming** (accumulates *all* codec tokens, decodes the whole clip at the end),
+but **iOS is streaming-first** (emits + releases each chunk), and the macOS CLI now streams by default as
+well. On the same 69–76 s custom/Speed input:
 
 | path | gpuAlloc peak | physFootprint |
 |---|---|---|
-| non-streaming (bench default) | ~8.0 GB | ~7.6 GB |
-| **streaming (what iOS uses)** | **~3.0 GB** | **~3.0 GB** |
+| non-streaming (legacy CLI default, now `--no-stream`) | ~8.0 GB | ~7.6 GB |
+| **streaming (iOS / current CLI default)** | **~3.0 GB** | **~3.0 GB** |
 
 And the streaming peak is **flat with length** — short 2901 MB · medium 2860 MB · long-76 s 2992 MB.
 So the non-streaming numbers that drove the *original* "iPhone is marginal/infeasible" verdict

--- a/docs/reference/mlx-guide.md
+++ b/docs/reference/mlx-guide.md
@@ -256,16 +256,16 @@ On iOS the engine runs **in-process** inside the app. The app and the engine sha
 
 ## 6. Streaming vs full-result memory
 
-The `vocello bench` default and the macOS quality path use a **non-streaming, full-result** pipeline: all codec tokens are accumulated, then the whole waveform is decoded at the end. This gives the highest quality and the simplest graph, but it uses more peak memory.
+`vocello bench` and `vocello generate` now use a **streaming-first** pipeline by default on macOS: chunks of codec tokens are emitted, decoded, and released as generation proceeds. The legacy **non-streaming, full-result** path (accumulates all tokens, decodes once at the end) is still available with `--no-stream`; it uses more peak memory.
 
-The iOS path is **streaming-first**: chunks of tokens are emitted, decoded, and released as generation proceeds.
+The iOS app path is also **streaming-first**.
 
 Measured on the same ~70 s custom/Speed input (`benchmarks/OPTIMIZATION.md` §F.1):
 
 | Path | gpuAlloc peak | physFootprint |
 |---|---|---|
-| Non-streaming (bench default) | ~8.0 GB | ~7.6 GB |
-| Streaming (iOS path) | ~3.0 GB | ~3.0 GB |
+| Non-streaming (`--no-stream`) | ~8.0 GB | ~7.6 GB |
+| Streaming (CLI default / iOS path) | ~3.0 GB | ~3.0 GB |
 
 The streaming peak is **flat with length** — short, medium, and long inputs all peak around 3 GB. This is why iPhone generation is viable despite the lower device RAM.
 
@@ -432,7 +432,7 @@ Do not regress these without a maintainer decision:
 - **Do not revert the input-side decoder-drift fix (`4fab110`).**
 - **Do not pipeline the 15-pass Code Predictor loop.** It is autoregressive; pipelining would change sampling semantics.
 - **macOS `MLXTTSEngine.events` stays `.unbounded`; iOS stays `.bufferingNewest(64)`.**
-- **Streaming-first on iOS; full-result-first on macOS quality path.** Do not force the macOS app onto the streaming path for quality generation.
+- **Streaming-first on iOS and on the macOS CLI (`vocello generate` / `vocello bench`).** The macOS *app* quality path remains full-result-first. Do not force the macOS app onto the streaming path for quality generation.
 
 ---
 

--- a/docs/reference/telemetry-and-benchmarking.md
+++ b/docs/reference/telemetry-and-benchmarking.md
@@ -356,8 +356,9 @@ dominant `timingsMS` substage across your before/after.
 > benchmark/test driver. Engine telemetry rows (RTF / decode / memory / `audioQC` / `promptChars`) are
 > identical to the app path; the CLI bypasses XPC, so the app/XPC frontend row is absent and the
 > summarizer's end‑to‑end **TTFC shows `-`** (engine‑only boundary — what backend optimization targets).
-> To measure first‑chunk latency, use `vocello generate --stream` or `vocello bench --ttfc` (an
-> engine‑side warm probe per cell → a table + `diagnostics/bench-ttfc.json`); both report engine TTFC,
+> `vocello bench` and `vocello generate` now stream by default. To measure first‑chunk latency, just
+> use `vocello generate` or `vocello bench --ttfc` (an engine‑side warm probe per cell → a table +
+> `diagnostics/bench-ttfc.json`); both report engine TTFC,
 > not the app's through‑XPC buffered TTFA.
 >
 > One‑command flags fold in the manual workflow below: `--label "<note>"` stamps the summary,

--- a/scripts/audit_decoder_memory.py
+++ b/scripts/audit_decoder_memory.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Audit speech-tokenizer decoder weight dtypes and memory footprint.
+
+Scans every installed Qwen3-TTS model under ~/Library/Application Support/QwenVoice/models
+and reports the dtype and size of speech_tokenizer/model.safetensors.
+"""
+
+import os
+from pathlib import Path
+
+import numpy as np
+from safetensors import safe_open
+
+MODELS_DIR = Path.home() / "Library/Application Support/QwenVoice/models"
+
+
+def audit_model(model_dir: Path):
+    st_path = model_dir / "speech_tokenizer" / "model.safetensors"
+    if not st_path.exists():
+        return None
+    total_bytes = 0
+    dtype_counts = {}
+    shape_summary = []
+    with safe_open(st_path, framework="np") as f:
+        for k in sorted(f.keys()):
+            sl = f.get_slice(k)
+            shape = sl.get_shape()
+            dtype = sl.get_dtype()
+            bytes_per = {"F32": 4, "F16": 2, "BF16": 2, "I32": 4, "I16": 2, "I8": 1, "U8": 1, "BOOL": 1}.get(dtype, 4)
+            n = int(np.prod(shape))
+            total_bytes += n * bytes_per
+            dtype_counts[dtype] = dtype_counts.get(dtype, 0) + n * bytes_per
+            shape_summary.append((k, shape, dtype))
+    return {
+        "model": model_dir.name,
+        "path": st_path,
+        "total_bytes": total_bytes,
+        "dtype_counts": dtype_counts,
+        "tensors": shape_summary,
+    }
+
+
+def main():
+    if not MODELS_DIR.exists():
+        print(f"Models directory not found: {MODELS_DIR}")
+        return
+    results = []
+    for entry in sorted(MODELS_DIR.iterdir()):
+        if not entry.is_dir():
+            continue
+        info = audit_model(entry)
+        if info:
+            results.append(info)
+
+    print("# Speech-tokenizer decoder weight audit\n")
+    total_all = 0
+    for info in results:
+        print(f"## {info['model']}")
+        print(f"- File: `{info['path']}`")
+        print(f"- Total decoder weight size: **{info['total_bytes'] / 1e6:.2f} MB** ({info['total_bytes'] / 1e9:.3f} GB)")
+        print("- Bytes by dtype:")
+        for dtype, b in sorted(info["dtype_counts"].items(), key=lambda x: -x[1]):
+            print(f"  - {dtype}: {b / 1e6:.2f} MB")
+        print("- Tensor shapes:")
+        for name, shape, dtype in info["tensors"]:
+            print(f"  - `{name}`: {shape} {dtype}")
+        print()
+        total_all += info["total_bytes"]
+
+    print(f"## Aggregate across {len(results)} models")
+    print(f"Total decoder weight footprint: **{total_all / 1e9:.3f} GB**")
+    print(f"If all decoder weights were cast to fp16: **{total_all / 2 / 1e9:.3f} GB** (≈ {total_all / 2 / 1e6:.2f} MB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_nostreaming_accumulation.py
+++ b/scripts/audit_nostreaming_accumulation.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Estimate how much of the non-streaming peak is output-accumulator memory.
+
+Reads engine telemetry rows (expects a `stream` or `bench_note` field) and reports:
+- audio duration and PCM sample bytes
+- generated codec-token frame/codebook counts and byte estimates
+- observed peakGPU / physFoot deltas
+- MLX memory-by-stage snapshots
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+
+def iter_rows(path: pathlib.Path):
+    if not path.exists():
+        return
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+
+def parse_tag(tag: str):
+    m = re.match(r"^(custom|design)_(short|medium|long)_stream=(\d)$", tag)
+    if not m:
+        return None
+    return m.group(1), m.group(2), int(m.group(3))
+
+
+def analyze(rows):
+    groups = {}
+    for r in rows:
+        tag = r.get("bench_note", "")
+        parsed = parse_tag(tag)
+        if not parsed:
+            continue
+        mode, length, stream = parsed
+        groups.setdefault((mode, length), {})[stream] = r
+
+    print("| mode | len | stream | audio s | PCM MB | codec frames | codec tokens | token MB | gpuPeak MB | physFoot MB |")
+    print("|---|---|---|---|---|---|---|---|---|---|")
+    for (mode, length), cells in sorted(groups.items()):
+        for stream in [0, 1]:
+            r = cells.get(stream)
+            if not r:
+                continue
+            dur = r["audioQC"]["durationSeconds"]
+            pcm_bytes = dur * 24_000 * 2  # 24 kHz, 16-bit mono
+            frames = int(dur * 12.5)
+            tokens = frames * 16  # 16 codebooks
+            token_bytes = tokens * 4  # int32 per token
+            gpu = r["summary"]["gpuAllocatedPeakMB"]
+            phys = r["summary"]["physFootprintPeakMB"]
+            print(f"| {mode} | {length} | {stream} | {dur:.2f} | {pcm_bytes/1e6:.3f} | {frames} | {tokens} | {token_bytes/1e6:.3f} | {gpu:.0f} | {phys:.0f} |")
+    print()
+
+    # Stage memory for long custom non-streaming vs streaming
+    key = ("custom", "long")
+    if key in groups and 0 in groups[key] and 1 in groups[key]:
+        print("### MLX memory-by-stage snapshot — custom/long")
+        for stream in [0, 1]:
+            print(f"\nstream={stream}")
+            r = groups[key][stream]
+            for stage, vals in r.get("mlxMemoryByStage", {}).items():
+                print(f"  {stage}: active={vals['activeMB']:.0f} MB, peak={vals['peakMB']:.0f} MB, cache={vals['cacheMB']:.0f} MB")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("diagnostics_dir", nargs="?", default=str(pathlib.Path.home() / "Library/Application Support/QwenVoice-Debug/diagnostics"))
+    args = p.parse_args()
+    diag = pathlib.Path(args.diagnostics_dir)
+    engine_jsonl = diag / "engine" / "generations.jsonl"
+    if not engine_jsonl.exists():
+        print(f"No engine telemetry at {engine_jsonl}", file=sys.stderr)
+        sys.exit(1)
+    analyze(list(iter_rows(engine_jsonl)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_fp16_decoder.py
+++ b/scripts/bench_fp16_decoder.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""A/B the original F32 speech-tokenizer decoder against an fp16-decoder copy."""
+
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parent.parent
+VOCHELLO = PROJECT_ROOT / "build" / "vocello"
+DATA_DIR = pathlib.Path("/tmp/fp16dec_ab")
+ALL_DIAG = DATA_DIR / "all_diagnostics"
+WAV_DIR = DATA_DIR / "outputs"
+DEFAULT_MODELS = pathlib.Path.home() / "Library/Application Support/QwenVoice/models"
+MANIFEST_ORIGINAL = None
+MANIFEST_FP16 = PROJECT_ROOT / "scripts" / "manifest_fp16_decoder_research.json"
+
+CORPUS = {
+    "short": "The train left the station at dawn.",
+    "medium": "The morning train slipped quietly out of the station, carrying a handful of sleepy travelers toward the coast.",
+}
+
+
+def setup():
+    if DATA_DIR.exists():
+        shutil.rmtree(DATA_DIR)
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    ALL_DIAG.mkdir(parents=True, exist_ok=True)
+    WAV_DIR.mkdir(parents=True, exist_ok=True)
+    models_link = DATA_DIR / "models"
+    if DEFAULT_MODELS.exists():
+        models_link.symlink_to(DEFAULT_MODELS, target_is_directory=True)
+    else:
+        raise RuntimeError(f"Default models dir not found: {DEFAULT_MODELS}")
+
+
+def append_tagged(src_dir: pathlib.Path, tag: str):
+    for jsonl in src_dir.rglob("*.jsonl"):
+        rel = jsonl.relative_to(src_dir)
+        dst = ALL_DIAG / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        with open(jsonl, "r", encoding="utf-8") as fh:
+            with open(dst, "a", encoding="utf-8") as out:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    row["decoder"] = tag
+                    out.write(json.dumps(row, sort_keys=True))
+                    out.write("\n")
+
+
+def run_generate(length: str, manifest: pathlib.Path | None, tag: str):
+    wav = WAV_DIR / f"custom_{length}_{tag}.wav"
+    run_diag = DATA_DIR / "diagnostics"
+    if run_diag.exists():
+        shutil.rmtree(run_diag)
+
+    cmd = [
+        str(VOCHELLO),
+        "generate",
+        "--data-dir", str(DATA_DIR),
+        "--mode", "custom",
+        "--variant", "speed",
+        "--text", CORPUS[length],
+        "--out", str(wav),
+    ]
+    if manifest is not None:
+        cmd += ["--manifest", str(manifest)]
+
+    env = os.environ.copy()
+    env["QWENVOICE_DEBUG"] = "1"
+    env["QWENVOICE_NATIVE_TELEMETRY_MODE"] = "lightweight"
+    print(f"Running custom/{length} with {tag} decoder", file=sys.stderr)
+    subprocess.run(cmd, check=True, cwd=PROJECT_ROOT, env=env)
+    append_tagged(run_diag, tag)
+
+
+def main():
+    setup()
+    for length in ["short", "medium"]:
+        run_generate(length, MANIFEST_ORIGINAL, "f32")
+        run_generate(length, MANIFEST_FP16, "fp16")
+    print(f"\nAll diagnostics: {ALL_DIAG}", file=sys.stderr)
+    print(f"All WAVs:        {WAV_DIR}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cast_decoder_to_fp16.py
+++ b/scripts/cast_decoder_to_fp16.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Create a copy of a Qwen3-TTS model with speech-tokenizer decoder weights cast to fp16.
+
+Only tensors whose key starts with `decoder.` are cast; encoder/quantizer tensors are
+kept in their original dtype so any reference-audio encoder path stays unchanged.
+"""
+
+import argparse
+import os
+import shutil
+
+import numpy as np
+from safetensors import safe_open
+from safetensors.numpy import save_file
+
+
+def cast_dir(src: str, dst: str):
+    src = os.path.expanduser(src)
+    dst = os.path.expanduser(dst)
+    if os.path.exists(dst):
+        shutil.rmtree(dst)
+    os.makedirs(dst, exist_ok=True)
+
+    for root, dirs, files in os.walk(src):
+        rel = os.path.relpath(root, src)
+        out_root = os.path.join(dst, rel)
+        os.makedirs(out_root, exist_ok=True)
+        for d in dirs:
+            os.makedirs(os.path.join(out_root, d), exist_ok=True)
+        for f in files:
+            src_path = os.path.join(root, f)
+            dst_path = os.path.join(out_root, f)
+            if f == "model.safetensors" and rel.endswith("speech_tokenizer"):
+                tensors = {}
+                with safe_open(src_path, framework="np") as fh:
+                    for k in fh.keys():
+                        arr = fh.get_tensor(k)
+                        if k.startswith("decoder.") and arr.dtype == np.float32:
+                            arr = arr.astype(np.float16)
+                        tensors[k] = arr
+                save_file(tensors, dst_path)
+                cast_count = sum(1 for k in tensors if k.startswith("decoder."))
+                print(f"Cast {src_path} -> {dst_path} ({cast_count} decoder tensors to fp16)")
+            else:
+                shutil.copy2(src_path, dst_path)
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("src", help="source model directory")
+    p.add_argument("dst", help="destination model directory")
+    args = p.parse_args()
+    cast_dir(args.src, args.dst)

--- a/scripts/manifest_fp16_decoder_research.json
+++ b/scripts/manifest_fp16_decoder_research.json
@@ -1,0 +1,249 @@
+{
+  "defaultSpeaker": "aiden",
+  "models": [
+    {
+      "artifactVersion": "2026.04.05.2",
+      "estimatedDownloadBytes": 3080141538,
+      "folder": "Qwen3-TTS-12Hz-1.7B-CustomVoice-4bit-fp16dec",
+      "huggingFaceRepo": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-4bit",
+      "huggingFaceRevision": "f35faf19b0cc2160865af64ecf0f22f83d335135",
+      "id": "pro_custom_fp16dec",
+      "iosDownloadEligible": false,
+      "mode": "custom",
+      "name": "Custom Voice (fp16 decoder research)",
+      "outputSubfolder": "CustomVoice",
+      "qwen3Capabilities": {
+        "artifactAvailability": "public_artifact",
+        "familyType": "custom_voice",
+        "generationDefaults": {
+          "appPolicyMaxNewTokens": 2048,
+          "checkpointMaxNewTokens": 8192,
+          "doSample": true,
+          "repetitionPenalty": 1.05,
+          "source": "app_policy",
+          "temperature": 0.9,
+          "topK": 50,
+          "topP": 1.0,
+          "wrapperFallbackMaxNewTokens": 2048
+        },
+        "modelSize": "pro1b7",
+        "requiresSpeakerEncoder": false,
+        "supportsInstructionControl": true,
+        "supportsVoiceClone": false,
+        "tokenizerProfile": {
+          "codebookSize": 2048,
+          "decoderQuantizers": 16,
+          "encoderConfiguredQuantizers": 32,
+          "encoderValidQuantizers": 16,
+          "frameRateHz": 12.5,
+          "name": "qwen3_tts_tokenizer_12hz",
+          "sampleRateHz": 24000,
+          "semanticCodebookSize": 4096
+        }
+      },
+      "requiredRelativePaths": [
+        "README.md",
+        "config.json",
+        "generation_config.json",
+        "merges.txt",
+        "model.safetensors",
+        "model.safetensors.index.json",
+        "preprocessor_config.json",
+        "speech_tokenizer/config.json",
+        "speech_tokenizer/configuration.json",
+        "speech_tokenizer/model.safetensors",
+        "speech_tokenizer/preprocessor_config.json",
+        "tokenizer_config.json",
+        "vocab.json"
+      ],
+      "tier": "pro",
+      "variants": [
+        {
+          "artifactVersion": "2026.04.05.2",
+          "estimatedDownloadBytes": 0,
+          "folder": "Qwen3-TTS-12Hz-1.7B-CustomVoice-4bit-fp16dec",
+          "huggingFaceRepo": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-4bit",
+          "huggingFaceRevision": "f35faf19b0cc2160865af64ecf0f22f83d335135",
+          "id": "speed",
+          "iosDownloadEligible": false,
+          "kind": "speed",
+          "name": "Speed",
+          "platforms": [
+            "macOS"
+          ],
+          "qwen3Capabilities": {
+            "artifactAvailability": "public_artifact",
+            "familyType": "custom_voice",
+            "generationDefaults": {
+              "appPolicyMaxNewTokens": 2048,
+              "checkpointMaxNewTokens": 8192,
+              "doSample": true,
+              "repetitionPenalty": 1.05,
+              "source": "app_policy",
+              "temperature": 0.9,
+              "topK": 50,
+              "topP": 1.0,
+              "wrapperFallbackMaxNewTokens": 2048
+            },
+            "modelSize": "pro1b7",
+            "requiresSpeakerEncoder": false,
+            "supportsInstructionControl": true,
+            "supportsVoiceClone": false,
+            "tokenizerProfile": {
+              "codebookSize": 2048,
+              "decoderQuantizers": 16,
+              "encoderConfiguredQuantizers": 32,
+              "encoderValidQuantizers": 16,
+              "frameRateHz": 12.5,
+              "name": "qwen3_tts_tokenizer_12hz",
+              "sampleRateHz": 24000,
+              "semanticCodebookSize": 4096
+            }
+          },
+          "requiredRelativePaths": [
+            "README.md",
+            "config.json",
+            "generation_config.json",
+            "merges.txt",
+            "model.safetensors",
+            "model.safetensors.index.json",
+            "preprocessor_config.json",
+            "speech_tokenizer/config.json",
+            "speech_tokenizer/configuration.json",
+            "speech_tokenizer/model.safetensors",
+            "speech_tokenizer/preprocessor_config.json",
+            "tokenizer_config.json",
+            "vocab.json"
+          ]
+        },
+        {
+          "artifactVersion": "2026.04.05.2",
+          "estimatedDownloadBytes": 3080141538,
+          "folder": "Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit",
+          "huggingFaceRepo": "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-8bit",
+          "huggingFaceRevision": "41d3337e8b7f2843a75841595fc14e4b9a7a4b96",
+          "id": "quality",
+          "iosDownloadEligible": false,
+          "kind": "quality",
+          "name": "Quality",
+          "platforms": [
+            "macOS"
+          ],
+          "qwen3Capabilities": {
+            "artifactAvailability": "public_artifact",
+            "familyType": "custom_voice",
+            "generationDefaults": {
+              "appPolicyMaxNewTokens": 2048,
+              "checkpointMaxNewTokens": 8192,
+              "doSample": true,
+              "repetitionPenalty": 1.05,
+              "source": "app_policy",
+              "temperature": 0.9,
+              "topK": 50,
+              "topP": 1.0,
+              "wrapperFallbackMaxNewTokens": 2048
+            },
+            "modelSize": "pro1b7",
+            "requiresSpeakerEncoder": false,
+            "supportsInstructionControl": true,
+            "supportsVoiceClone": false,
+            "tokenizerProfile": {
+              "codebookSize": 2048,
+              "decoderQuantizers": 16,
+              "encoderConfiguredQuantizers": 32,
+              "encoderValidQuantizers": 16,
+              "frameRateHz": 12.5,
+              "name": "qwen3_tts_tokenizer_12hz",
+              "sampleRateHz": 24000,
+              "semanticCodebookSize": 4096
+            }
+          },
+          "requiredRelativePaths": [
+            "README.md",
+            "config.json",
+            "generation_config.json",
+            "merges.txt",
+            "model.safetensors",
+            "model.safetensors.index.json",
+            "preprocessor_config.json",
+            "speech_tokenizer/config.json",
+            "speech_tokenizer/configuration.json",
+            "speech_tokenizer/model.safetensors",
+            "speech_tokenizer/preprocessor_config.json",
+            "tokenizer_config.json",
+            "vocab.json"
+          ]
+        }
+      ]
+    }
+  ],
+  "speakerMetadata": {
+    "aiden": {
+      "displayName": "Aiden",
+      "isEnglishNative": true,
+      "nativeLanguage": "English",
+      "shortDescription": "English-native sunny American male voice with a clear midrange."
+    },
+    "dylan": {
+      "displayName": "Dylan",
+      "isEnglishNative": false,
+      "nativeLanguage": "Chinese",
+      "shortDescription": "Chinese-native youthful male voice with a clear, natural timbre (Beijing dialect)."
+    },
+    "eric": {
+      "displayName": "Eric",
+      "isEnglishNative": false,
+      "nativeLanguage": "Chinese",
+      "shortDescription": "Chinese-native lively Chengdu male voice with a slightly husky brightness (Sichuan dialect)."
+    },
+    "ono_anna": {
+      "displayName": "Ono Anna",
+      "isEnglishNative": false,
+      "nativeLanguage": "Japanese",
+      "shortDescription": "Japanese-native playful female voice with a light, nimble timbre."
+    },
+    "ryan": {
+      "displayName": "Ryan",
+      "isEnglishNative": true,
+      "nativeLanguage": "English",
+      "shortDescription": "English-native dynamic male voice with strong rhythmic drive \u2014 naturally expressive."
+    },
+    "serena": {
+      "displayName": "Serena",
+      "isEnglishNative": false,
+      "nativeLanguage": "Chinese",
+      "shortDescription": "Chinese-native warm, gentle young female voice."
+    },
+    "sohee": {
+      "displayName": "Sohee",
+      "isEnglishNative": false,
+      "nativeLanguage": "Korean",
+      "shortDescription": "Korean-native warm female voice with rich emotion."
+    },
+    "uncle_fu": {
+      "displayName": "Uncle Fu",
+      "isEnglishNative": false,
+      "nativeLanguage": "Chinese",
+      "shortDescription": "Chinese-native seasoned male voice with a low, mellow timbre."
+    },
+    "vivian": {
+      "displayName": "Vivian",
+      "isEnglishNative": false,
+      "nativeLanguage": "Chinese",
+      "shortDescription": "Chinese-native bright, slightly edgy young female voice."
+    }
+  },
+  "speakers": {
+    "Built-in": [
+      "aiden",
+      "ryan",
+      "vivian",
+      "serena",
+      "uncle_fu",
+      "dylan",
+      "eric",
+      "ono_anna",
+      "sohee"
+    ]
+  }
+}

--- a/scripts/streaming_ram_ab.py
+++ b/scripts/streaming_ram_ab.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Paired streaming vs non-streaming RAM/RTF A/B for 1.7B Qwen3-TTS.
+
+Runs the fixed short/medium/long corpus for custom/design Speed once with
+--stream and once without, reusing a single model load per pair by calling
+vocello generate. Telemetry rows are collected into a single diagnostics
+directory so the standard summarizer can compare the two paths.
+"""
+
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parent.parent
+VOCHELLO = PROJECT_ROOT / "build" / "vocello"
+DATA_DIR = pathlib.Path("/tmp/streaming_ab")
+ALL_DIAG = DATA_DIR / "all_diagnostics"
+WAV_DIR = DATA_DIR / "outputs"
+
+DEFAULT_MODELS = pathlib.Path.home() / "Library/Application Support/QwenVoice/models"
+
+CORPUS = {
+    "short": "The train left the station at dawn.",
+    "medium": "The morning train slipped quietly out of the station, carrying a handful of sleepy travelers toward the coast.",
+    "long": "The morning train slipped quietly out of the station, carrying a handful of sleepy travelers toward the coast. Outside the fogged windows, pale fields gave way to grey water, and the rhythm of the rails settled into a steady, hypnotic hum. By the time the sun finally broke through, most of the passengers had drifted into an unhurried silence.",
+}
+
+
+def setup():
+    if DATA_DIR.exists():
+        shutil.rmtree(DATA_DIR)
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    ALL_DIAG.mkdir(parents=True, exist_ok=True)
+    WAV_DIR.mkdir(parents=True, exist_ok=True)
+
+    models_link = DATA_DIR / "models"
+    if not models_link.exists():
+        if DEFAULT_MODELS.exists():
+            models_link.symlink_to(DEFAULT_MODELS, target_is_directory=True)
+        else:
+            raise RuntimeError(f"Default models dir not found: {DEFAULT_MODELS}")
+
+
+def append_tagged(src_dir: pathlib.Path, stream: bool, tag: str):
+    """Append rows from a fresh run into the cumulative diagnostics files."""
+    flag = int(stream)
+    for jsonl in src_dir.rglob("*.jsonl"):
+        rel = jsonl.relative_to(src_dir)
+        dst = ALL_DIAG / rel
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        with open(jsonl, "r", encoding="utf-8") as fh:
+            with open(dst, "a", encoding="utf-8") as out:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    row["stream"] = flag
+                    row["bench_note"] = tag
+                    out.write(json.dumps(row, sort_keys=True))
+                    out.write("\n")
+
+
+def run_generate(mode: str, length: str, stream: bool):
+    tag = f"{mode}_{length}_stream={int(stream)}"
+    wav = WAV_DIR / f"{tag}.wav"
+    # Fresh per-run diagnostics so we can append only this run's rows.
+    run_diag = DATA_DIR / "diagnostics"
+    if run_diag.exists():
+        shutil.rmtree(run_diag)
+
+    cmd = [
+        str(VOCHELLO),
+        "generate",
+        "--data-dir", str(DATA_DIR),
+        "--mode", mode,
+        "--variant", "speed",
+        "--text", CORPUS[length],
+        "--out", str(wav),
+    ]
+    if mode == "design":
+        cmd += ["--voice-brief", "A warm, calm middle-aged male narrator with a clear, measured pace."]
+    if stream:
+        cmd.append("--stream")
+
+    env = os.environ.copy()
+    env["QWENVOICE_DEBUG"] = "1"
+    env["QWENVOICE_NATIVE_TELEMETRY_MODE"] = "lightweight"
+    print(f"Running {tag}", file=sys.stderr)
+    subprocess.run(cmd, check=True, cwd=PROJECT_ROOT, env=env)
+    append_tagged(run_diag, stream, tag)
+
+
+def main():
+    setup()
+    for mode in ["custom", "design"]:
+        for length in ["short", "medium", "long"]:
+            for stream in [False, True]:
+                run_generate(mode, length, stream)
+    print(f"\nAll diagnostics: {ALL_DIAG}", file=sys.stderr)
+    print(f"All WAVs:        {WAV_DIR}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Switches `vocello bench` and `vocello generate` to streaming-by-default on macOS.
- Adds `--no-stream` opt-out to both commands for the legacy full-result behavior.
- Updates CLI, telemetry, MLX guide, iOS engine optimization, and backend optimization docs to reflect the new default.
- Adds the backend optimization research report and a new streaming-default baseline.

## Verification
- `VocelloCLI` Release build: succeeded.
- `QwenVoice` app Release build: succeeded.
- CLI smoke tests: streaming default and `--no-stream` both produced valid audio.
- Full streaming benchmark matrix run and saved to `benchmarks/baseline-2026-06-16-45720dd-streaming-default.md`.

## Notes
- Design Quality was not installed on the bench machine, so the streaming baseline covers Custom Speed/Quality and Design Speed.
- The macOS app quality path remains full-result-first; only the CLI default changed.