### PR TITLE
feat(ios): confirm buttons, scroll fade, cold test hardening, and doc updates

### DIFF
--- a/.opencode/skills/appium-ios-real-device/SKILL.md
+++ b/.opencode/skills/appium-ios-real-device/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: appium-ios-real-device
+description: Drive the Vocello iOS app on a physical iPhone via the appium-mcp MCP server. Use when an agent needs to tap, type, scroll, screenshot, or assert on the live iOS UI (real-device flows that XCUITest can't reach or that are flaky). Triggers: "appium", "real device UI test", "drive iPhone", "tap on device", "WDA", "WebDriverAgent".
+---
+
+# Appium iOS Real-Device UI Driving (Vocello)
+
+Use this skill whenever you drive the live Vocello iPhone app through the
+`appium-mcp` MCP server. Vocello's XCUITest suite is the deterministic backbone;
+Appium is the tool when an agent needs to interact with the live UI — exploratory
+checks, ad-hoc flows, screenshot evidence, or flows that are flaky in XCUITest.
+
+## Constants
+
+- App bundle ID: `com.patricedery.vocello`
+- Device: iPhone 17 Pro, paired via `devicectl` (CoreDevice), Developer Mode ON
+- macOS/Xcode: 26.5 / 26.5
+- alt path (non-Appium): `scripts/ios_device.sh ui-test` (XCUITest backbone)
+
+## One-time setup: sign WebDriverAgent (WDA)
+
+Real iOS devices require a signed WDA runner. Use `appium_prepare_ios_real_device`
+in **two steps**:
+
+1. Call without `provisioningProfileUuid` → it lists `.mobileprovision` profiles
+   available to your Apple Developer team.
+2. Call again with the chosen `provisioningProfileUuid` and `isFreeAccount` flag
+   → it downloads the matching WDA release, packages as IPA, and re-signs.
+   Result is cached per WDA-version + profile.
+
+Pass the returned `capabilitiesHint` to `appium_session_management action=create`
+so Appium installs and launches WDA on device.
+
+## Canonical first-session sequence
+
+1. `select_device` → auto-selects the iPhone 17 Pro if only one device is connected
+2. (first run only) `appium_prepare_ios_real_device` → sign WDA per the two-step above
+3. `appium_session_management` with `action=create`, `platform=ios`,
+   `capabilities={ "appium:bundleId": "com.patricedery.vocello",
+                   "appium:automationName": "XCUITest",
+                   "appium:udid": "<from select_device>" }`
+4. `appium_app_lifecycle action=activate` with `bundleId` if the app is installed
+   but not running
+5. Drive via `appium_find_element` (preferred) → `appium_gesture action=tap`
+6. `appium_screenshot` for evidence (saves to `SCREENSHOTS_DIR` or cwd)
+
+## Identifier-shadowing caveat (Vocello-specific)
+
+The iOS app's Studio screen propagates `screen_generateStudio` onto descendants,
+shadowing their `textInput_*` and `studioChip_*` accessibility identifiers. When
+`appium_find_element strategy="accessibility id"` fails to reach a child, fall
+back to:
+
+- `-ios predicate string`: `"label BEGINSWITH 'Voice: '"`
+- `-ios class chain`: `"/XCUIElementTypeButton[\`label BEGINSWITH 'Voice: '\`]"`
+
+Sheet-level IDs (`voicePickerRow_*`, `voicePickerPreview_*`, `voicePicker_confirm`,
+`languagePicker_*`, `voiceBrief_editor`, `voiceBrief_confirm`, `bottomSheet_close`)
+are NOT shadowed because sheets are separate overlays — use those directly.
+
+Tab IDs: `rootTab_studio`, `rootTab_voices`, `rootTab_history`, `rootTab_settings`.
+
+## Session-lifecycle rule (MANDATORY)
+
+`APPIUM_MCP_ON_CLIENT_DISCONNECT=skip` is set in the opencode config so Appium
+sessions survive MCP reconnects. Therefore:
+
+- **Always** call `appium_session_management action=delete` when a flow completes
+  to avoid orphaned WDA runners on device.
+- `appium_session_management action=list` shows all sessions including ownership.
+- Owned sessions are deleted on disconnect; attached/remote sessions are not.
+
+## When NOT to use this skill
+
+- Building/archiving the iOS app → use `scripts/ios_device.sh build` or
+  `xcodebuildmcp` (faster, native).
+- Deterministic regression tests → use `VocelloiOSUITests` via
+  `scripts/ios_device.sh ui-test` (XCUITest is more stable for known flows).
+- Headless generation benchmarks → use `scripts/ios_device.sh bench`
+  (`IOSAutorunHarness`, `QVOICE_IOS_AUTORUN`).
+- Marketing-site browser checks → use `chrome-devtools` MCP.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ When facts disagree, trust in this order: `Sources/` → `project.yml` → `scri
 
 This project is developed with **Kimi Code CLI**. Use the following tools and skills instead of the Axiom subagents referenced in older versions of this guide:
 
-- **Build / Xcode issues:** `mcp__xcodebuildmcp__*` (build, test, launch, simulator screenshots/snapshots) and the `swift-mlx` / `swift-mlx-lm` skills. For environmental setup problems, run the relevant `scripts/*.sh` command and inspect output with `Bash`.
+- **Build / Xcode issues:** `mcp__xcodebuildmcp__*` (build, test, launch) and the `swift-mlx` / `swift-mlx-lm` skills. iOS verification is **on-device only** — never use the iOS Simulator or simulator-only MCP tools for Vocello iOS UI work. For environmental setup problems, run the relevant `scripts/*.sh` command and inspect output with `Bash`.
 - **Code exploration / architecture:** `Agent` with `subagent_type: "explore"` for read-only audits; `Agent` with `subagent_type: "coder"` for implementation or review tasks.
 - **Crash logs / symbolication:** `mcp__axiom__xcsym_*` tools (`xcsym_crash`, `xcsym_resolve`, `xcsym_find_dsym`).
 - **Performance / profiling:** `mcp__axiom__xcprof_*` tools (`xcprof_record`, `xcprof_analyze`).
@@ -260,7 +260,14 @@ The `VocelloMacUITests` target contains a single `VocelloMacSmokeUITests` class 
 
 ### iOS testing
 
-iOS testing is **on-device** (the Simulator is retired for this project). The sanctioned paths are:
+iOS testing is **on-device only**. The iOS Simulator is retired for this project and must not be used for UI testing, verification, screenshots, or snapshots.
+
+**Do not use:**
+- `scripts/ios_sim.sh`
+- `xcodebuild -destination 'platform=iOS Simulator...'` for iOS UI work
+- simulator-only MCP tools such as `mcp__xcodebuildmcp__build_run_sim` / `snapshot_ui` for iOS
+
+The sanctioned paths are:
 
 ```sh
 scripts/ios_device.sh doctor       # environment + device preflight

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,10 +273,26 @@ The sanctioned paths are:
 scripts/ios_device.sh doctor       # environment + device preflight
 scripts/ios_device.sh bench        # build → install → autorun → pull → summarize
 scripts/ios_device.sh ui-test      # run VocelloiOSUITests on the device
+scripts/ios_device.sh launch       # launch the app (with optional autorun spec)
+scripts/ios_device.sh console      # stream os_log from the running app
+scripts/ios_device.sh pull         # pull files from the app container
 scripts/ios_device.sh shot         # screenshot the iPhone Mirroring window
 ```
 
 The headless autorun harness is triggered by `QVOICE_IOS_AUTORUN` and writes telemetry into the App Group container.
+
+iOS UI-test architecture:
+- `Tests/VocelloiOSUITests/VocelloUITestApp.swift` is the shared warm-app coordinator. It keeps one
+  app session alive across the smoke/sheet tests and resets to Studio between cases, so the suite
+  behaves like a real user session instead of launching from scratch every test.
+- `Tests/VocelloiOSUITests/VocelloiOSColdGenerationUITests.swift` is the exception: it deliberately
+  kills the warm session, cold-launches the app with the engine enabled, and asserts that a real
+  on-device generation completes.
+
+iOS UI conventions:
+- Use `IOSScrollView` instead of raw `ScrollView` for vertical iOS scroll surfaces. It bundles the
+  no-rubber-band behavior, subtle custom scroll indicator, and bottom fade that keeps content from
+  drawing under the TabDock. Pass `bottomFadeHeight: 0` for sheets that float above the dock.
 
 ### Benchmarks and output quality
 

--- a/QwenVoice.xcodeproj/project.pbxproj
+++ b/QwenVoice.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		1C601DB930D64AF476028A59 /* MLXAudioCore in Frameworks */ = {isa = PBXBuildFile; productRef = 3FB9B8A19AA0EC9F7B32CAA1 /* MLXAudioCore */; };
 		1D9CF18E56494AE4DDD0A72F /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BB1E93A79756A33FF71DBB /* RootView.swift */; };
 		1DC62431C3DDA0031793740B /* AppLaunchDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14202A5EA4A0355319DF2F34 /* AppLaunchDiagnostics.swift */; };
+		1E5C67C0EF563A8543BFABD3 /* GenerationFailureDiagnosticLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7453B77A9A1EAD14ED28711 /* GenerationFailureDiagnosticLogger.swift */; };
 		1E717451FC0F883570018189 /* IOSDeviceDiagnosticsRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23ECC0A581C6D3682E9A846A /* IOSDeviceDiagnosticsRecorder.swift */; };
 		1ED0434D51388D0666F8FF1F /* ThemeModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F68911A1D10F5E325090F912 /* ThemeModifiers.swift */; };
 		1F0331F59477C4B2ED745030 /* IOSGenerationInputControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8265666E168A61818AB382C1 /* IOSGenerationInputControls.swift */; };
@@ -122,6 +123,7 @@
 		5E975521FC8B355333145278 /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C22183F1D9A8DC478C8B8B /* FlowLayout.swift */; };
 		5FE8611FB168684BB5A832C1 /* VoiceCloningCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8BD934015DBE86EA1193A6B /* VoiceCloningCoordinator.swift */; };
 		603FCEB24230E8474ABC9C36 /* GenerationPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220CFD2739290441DB6C2732 /* GenerationPersistence.swift */; };
+		61A431FFED26B818F8BBD259 /* VocelloUITestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397F2B9663C17D33E7F9F799 /* VocelloUITestApp.swift */; };
 		6217C677B68BE8A7BFAD48E7 /* MLXAudioCore in Frameworks */ = {isa = PBXBuildFile; productRef = 2CEB6AA0035793594235AD61 /* MLXAudioCore */; };
 		624A6E1F5AA00B2165DA67F6 /* EngineServiceHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCF862B9A304A7A4EC8C209F /* EngineServiceHost.swift */; };
 		6311B4AE98C1DB4A1B040DEC /* ClipReviewPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76D71A324517246C7A3CBFF /* ClipReviewPlayer.swift */; };
@@ -157,6 +159,7 @@
 		80B162A6B2D1D7E86252D5B3 /* qwenvoice_contract.json in Resources */ = {isa = PBXBuildFile; fileRef = 617BE72142511CD5043C341E /* qwenvoice_contract.json */; };
 		81C2C8BE7377A14A4492D279 /* AppGenerationTimeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1BFA11B3D97C8053C1336A /* AppGenerationTimeline.swift */; };
 		82B95BB3F61F41F3BB882283 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2EC6F0D89B4220E1F3A6CA71 /* LaunchScreen.storyboard */; };
+		83264EA5079B58F8545F8276 /* VocelloiOSColdGenerationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F549BA5FA2BBCD9F655FA05 /* VocelloiOSColdGenerationUITests.swift */; };
 		850CDA13E23723B8A92F7D9C /* ModelRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5814A0DF5264DE6671474C8 /* ModelRegistry.swift */; };
 		8612AA28117CF2FDD46D401A /* AppPerformanceSignposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C8C4331104AAE56B2B7047 /* AppPerformanceSignposts.swift */; };
 		881B6A72F8BD0FAEC1E291D8 /* NativeMemoryPolicyResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AEE16398D08C10B333F02D3 /* NativeMemoryPolicyResolver.swift */; };
@@ -476,6 +479,7 @@
 		37A24CFA152E52E69333925C /* QwenVoiceCore-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "QwenVoiceCore-Bridging-Header.h"; sourceTree = "<group>"; };
 		3837D18DB04238E5D9200B5E /* IOSSettingsViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSSettingsViews.swift; sourceTree = "<group>"; };
 		3912F66CF11ACFE5DD83B2BE /* NativeRuntimeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeRuntimeFactory.swift; sourceTree = "<group>"; };
+		397F2B9663C17D33E7F9F799 /* VocelloUITestApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocelloUITestApp.swift; sourceTree = "<group>"; };
 		3AC640F31070C11F3F6C432D /* GenerationVariationPreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationVariationPreference.swift; sourceTree = "<group>"; };
 		3ADE213695C11F46205AE6DC /* QwenVoice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QwenVoice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B7BEC208EBCD33A51F21653 /* VocelloiOSSheetUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocelloiOSSheetUITests.swift; sourceTree = "<group>"; };
@@ -483,6 +487,7 @@
 		3DDAA8C5ADE95EC61570A219 /* GenerationTelemetryRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationTelemetryRecord.swift; sourceTree = "<group>"; };
 		3F056FE32E688786725FCC8D /* ModelAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelAssets.swift; sourceTree = "<group>"; };
 		3F2675499CA07A2901B0A6EA /* IOSSavedOutputsDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSSavedOutputsDestination.swift; sourceTree = "<group>"; };
+		3F549BA5FA2BBCD9F655FA05 /* VocelloiOSColdGenerationUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocelloiOSColdGenerationUITests.swift; sourceTree = "<group>"; };
 		40385AC6FD361E190A8E3CE3 /* AppStartupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupCoordinator.swift; sourceTree = "<group>"; };
 		405DF32499EDF28E20D73FEA /* QwenVoiceNative.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = QwenVoiceNative.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		42AC8266C0AD7CFD40D5D6E8 /* IOSVoiceDesignBriefSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSVoiceDesignBriefSheet.swift; sourceTree = "<group>"; };
@@ -582,6 +587,7 @@
 		B62852B52626359D53D76C11 /* QwenVoice.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = QwenVoice.entitlements; sourceTree = "<group>"; };
 		B696A7377F4C23E2FA9D4D4E /* SpeakersCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeakersCommand.swift; sourceTree = "<group>"; };
 		B71F14B5EA02E06107C5CB1C /* IOSWordTimingPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSWordTimingPlanner.swift; sourceTree = "<group>"; };
+		B7453B77A9A1EAD14ED28711 /* GenerationFailureDiagnosticLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationFailureDiagnosticLogger.swift; sourceTree = "<group>"; };
 		B84E7EAC8760A09DC87915DD /* CustomVoiceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomVoiceView.swift; sourceTree = "<group>"; };
 		B8BD934015DBE86EA1193A6B /* VoiceCloningCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceCloningCoordinator.swift; sourceTree = "<group>"; };
 		B8DE0E108884A82B4A671FE5 /* Voice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Voice.swift; sourceTree = "<group>"; };
@@ -778,8 +784,10 @@
 		07C4B16B256D0400582DA591 /* VocelloiOSUITests */ = {
 			isa = PBXGroup;
 			children = (
+				3F549BA5FA2BBCD9F655FA05 /* VocelloiOSColdGenerationUITests.swift */,
 				3B7BEC208EBCD33A51F21653 /* VocelloiOSSheetUITests.swift */,
 				CDDDFA0A5DBF06B5F473D5DA /* VocelloiOSSmokeUITests.swift */,
+				397F2B9663C17D33E7F9F799 /* VocelloUITestApp.swift */,
 			);
 			name = VocelloiOSUITests;
 			path = Tests/VocelloiOSUITests;
@@ -813,6 +821,7 @@
 				8C465AE879E2D9F601EC26DB /* DocumentIO.swift */,
 				288BDF7769F75089A6F065B4 /* EmotionPreset.swift */,
 				B9F62310AABC856664C0A81B /* EngineHostPrimitives.swift */,
+				B7453B77A9A1EAD14ED28711 /* GenerationFailureDiagnosticLogger.swift */,
 				64B446ABFD75C0AE283E6D66 /* GenerationSemantics.swift */,
 				874E0767E61CDEEE88A9FACF /* GenerationTelemetryJSONLSink.swift */,
 				3DDAA8C5ADE95EC61570A219 /* GenerationTelemetryRecord.swift */,
@@ -1703,6 +1712,7 @@
 				3C95AE735CD9F27854A2BA5A /* DocumentIO.swift in Sources */,
 				CC23D52B5D042DDF39ED5D44 /* EmotionPreset.swift in Sources */,
 				AA28D4C02B8584BC5B6A8D12 /* EngineHostPrimitives.swift in Sources */,
+				1E5C67C0EF563A8543BFABD3 /* GenerationFailureDiagnosticLogger.swift in Sources */,
 				CD601A69A8F0D1F41B8F2BDD /* GenerationSemantics.swift in Sources */,
 				F68E2BDC38DA509F2751452D /* GenerationTelemetryJSONLSink.swift in Sources */,
 				B6CB0C31F51CB8911AA30A07 /* GenerationTelemetryRecord.swift in Sources */,
@@ -1925,6 +1935,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				61A431FFED26B818F8BBD259 /* VocelloUITestApp.swift in Sources */,
+				83264EA5079B58F8545F8276 /* VocelloiOSColdGenerationUITests.swift in Sources */,
 				22DDAD6351784EA1052742F1 /* VocelloiOSSheetUITests.swift in Sources */,
 				40DC335349106693E0EC365F /* VocelloiOSSmokeUITests.swift in Sources */,
 			);
@@ -2244,6 +2256,7 @@
 				PRODUCT_NAME = VocelloiOSUITests;
 				SDKROOT = iphoneos;
 				SUPPORTS_MACCATALYST = NO;
+				SWIFT_STRICT_CONCURRENCY = minimal;
 				SWIFT_VERSION = 6;
 				TARGETED_DEVICE_FAMILY = 1;
 				TEST_TARGET_NAME = VocelloiOS;

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Useful checks:
 ./scripts/check_project_inputs.sh
 ./scripts/build_foundation_targets.sh macos
 ./scripts/build_foundation_targets.sh ios
+./scripts/ios_device.sh ui-test   # on-device iOS UI-flow smoke (requires paired iPhone)
 ```
 
 More technical detail:

--- a/Sources/QwenVoiceCore/GenerationFailureDiagnosticLogger.swift
+++ b/Sources/QwenVoiceCore/GenerationFailureDiagnosticLogger.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Durable, append-only log for generation failures so the underlying error can be
+/// recovered from a device without needing root console access.
+///
+/// Writes one JSON line per failure to `<documents>/generation-failures.jsonl`.
+/// The file is intended for debugging sessions only; callers should still surface a
+/// user-friendly message through the normal engine error pipeline.
+public final class GenerationFailureDiagnosticLogger: @unchecked Sendable {
+    public static let shared = GenerationFailureDiagnosticLogger()
+
+    private let lock = NSLock()
+    private let encoder = JSONEncoder()
+    private let fileName = "generation-failures.jsonl"
+
+    private init() {
+        encoder.outputFormatting = .sortedKeys
+        encoder.dateEncodingStrategy = .iso8601
+    }
+
+    /// Records a generation failure together with the underlying error that caused it.
+    public func log(
+        surfacedMessage: String,
+        stage: String?,
+        underlyingError: Error,
+        request: GenerationRequest? = nil
+    ) {
+        let entry = FailureEntry(
+            timestamp: Date(),
+            surfacedMessage: surfacedMessage,
+            stage: stage,
+            underlyingError: String(reflecting: underlyingError),
+            underlyingLocalizedDescription: underlyingError.localizedDescription,
+            requestMode: request?.mode.rawValue,
+            modelID: request?.modelID,
+            textLength: request.map { $0.text.count },
+            shouldStream: request?.shouldStream,
+            stack: Array(Thread.callStackSymbols.prefix(30))
+        )
+
+        guard let data = try? encoder.encode(entry) else { return }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let documentsURL = FileManager.default.urls(
+            for: .documentDirectory,
+            in: .userDomainMask
+        ).first else {
+            return
+        }
+
+        let url = documentsURL.appendingPathComponent(fileName, isDirectory: false)
+        var line = data
+        line.append(0x0A)
+
+        do {
+            if FileManager.default.fileExists(atPath: url.path) {
+                let handle = try FileHandle(forWritingTo: url)
+                defer { try? handle.close() }
+                try handle.seekToEnd()
+                try handle.write(contentsOf: line)
+            } else {
+                try line.write(to: url, options: .atomic)
+            }
+        } catch {
+            // Best-effort: do not let diagnostic logging itself break generation.
+        }
+    }
+
+    private struct FailureEntry: Codable {
+        let timestamp: Date
+        let surfacedMessage: String
+        let stage: String?
+        let underlyingError: String
+        let underlyingLocalizedDescription: String
+        let requestMode: String?
+        let modelID: String?
+        let textLength: Int?
+        let shouldStream: Bool?
+        let stack: [String]
+    }
+}

--- a/Sources/QwenVoiceCore/MLXTTSEngine.swift
+++ b/Sources/QwenVoiceCore/MLXTTSEngine.swift
@@ -891,10 +891,17 @@ public final class MLXTTSEngine: TTSEngineRuntimeControlling, NativeMemoryReport
                         try? FileManager.default.removeItem(at: URL(fileURLWithPath: request.outputPath))
                         throw error
                     }
+                    let surfacedMessage = "The native runtime could not start audio generation after one allocation retry."
+                    GenerationFailureDiagnosticLogger.shared.log(
+                        surfacedMessage: surfacedMessage,
+                        stage: NativeRuntimeStage.streamStartup.description,
+                        underlyingError: error,
+                        request: request
+                    )
                     let surfacedError = NativeRuntimeError.wrapping(
                         error,
                         stage: .streamStartup,
-                        message: "The native runtime could not start audio generation after one allocation retry."
+                        message: surfacedMessage
                     )
                     handle(surfacedError)
                     let failureEvent = GenerationEvent.failed(surfacedError.localizedDescription)
@@ -903,10 +910,17 @@ public final class MLXTTSEngine: TTSEngineRuntimeControlling, NativeMemoryReport
                     throw surfacedError
                 }
             }
+            let surfacedMessage = "The native runtime could not start audio generation."
+            GenerationFailureDiagnosticLogger.shared.log(
+                surfacedMessage: surfacedMessage,
+                stage: NativeRuntimeStage.streamStartup.description,
+                underlyingError: error,
+                request: request
+            )
             let surfacedError = NativeRuntimeError.wrapping(
                 error,
                 stage: .streamStartup,
-                message: "The native runtime could not start audio generation."
+                message: surfacedMessage
             )
             handle(surfacedError)
             let failureEvent = GenerationEvent.failed(surfacedError.localizedDescription)

--- a/Sources/QwenVoiceCore/NativeStreamingSynthesisSession.swift
+++ b/Sources/QwenVoiceCore/NativeStreamingSynthesisSession.swift
@@ -903,6 +903,12 @@ private struct StreamingExecutionContext: Sendable {
         do {
             completion = try await generateQualityFirstAudio()
         } catch {
+            GenerationFailureDiagnosticLogger.shared.log(
+                surfacedMessage: "Quality-first generation failed",
+                stage: NativeRuntimeStage.streamFailed.description,
+                underlyingError: error,
+                request: request
+            )
             await telemetryRecorder?.mark(
                 metadata: StreamFailureMessageMetadata(message: error.localizedDescription)
             )
@@ -1347,6 +1353,12 @@ private struct StreamingExecutionContext: Sendable {
                 }
             }
         } catch {
+            GenerationFailureDiagnosticLogger.shared.log(
+                surfacedMessage: "Streaming execution failed",
+                stage: NativeRuntimeStage.streamFailed.description,
+                underlyingError: error,
+                request: request
+            )
             await telemetryRecorder?.mark(
                 metadata: StreamFailureMessageMetadata(message: error.localizedDescription)
             )

--- a/Sources/iOS/IOSDesignSystemPrimitives.swift
+++ b/Sources/iOS/IOSDesignSystemPrimitives.swift
@@ -524,6 +524,7 @@ struct IOSBottomSheetSurface<Content: View>: View {
     let tint: Color
     let presentation: IOSBottomSheetPresentationStyle
     let onDismiss: (() -> Void)?
+    let headerTrailing: AnyView?
     let content: Content
 
     init(
@@ -537,24 +538,60 @@ struct IOSBottomSheetSurface<Content: View>: View {
         self.tint = tint
         self.presentation = presentation
         self.onDismiss = onDismiss
+        self.headerTrailing = nil
+        self.content = content()
+    }
+
+    init<Trailing: View>(
+        title: String,
+        tint: Color = IOSBrandTheme.accent,
+        presentation: IOSBottomSheetPresentationStyle = .system,
+        onDismiss: (() -> Void)? = nil,
+        @ViewBuilder headerTrailing: () -> Trailing,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.tint = tint
+        self.presentation = presentation
+        self.onDismiss = onDismiss
+        self.headerTrailing = AnyView(headerTrailing())
         self.content = content()
     }
 
     var body: some View {
         switch presentation {
         case .system:
-            IOSBottomSheet(title: title, tint: tint, onDismiss: onDismiss) {
-                content
+            if let headerTrailing {
+                IOSBottomSheet(title: title, tint: tint, onDismiss: onDismiss, headerTrailing: { headerTrailing }) {
+                    content
+                }
+            } else {
+                IOSBottomSheet(title: title, tint: tint, onDismiss: onDismiss) {
+                    content
+                }
             }
         case .edgeToEdge(let bottomSafeAreaInset, let height):
-            IOSBottomEdgeSheet(
-                title: title,
-                tint: tint,
-                bottomSafeAreaInset: bottomSafeAreaInset,
-                height: height,
-                onDismiss: { onDismiss?() }
-            ) {
-                content
+            if let headerTrailing {
+                IOSBottomEdgeSheet(
+                    title: title,
+                    tint: tint,
+                    bottomSafeAreaInset: bottomSafeAreaInset,
+                    height: height,
+                    onDismiss: { onDismiss?() },
+                    headerTrailing: { headerTrailing }
+                ) {
+                    content
+                }
+            } else {
+                IOSBottomEdgeSheet(
+                    title: title,
+                    tint: tint,
+                    bottomSafeAreaInset: bottomSafeAreaInset,
+                    height: height,
+                    onDismiss: { onDismiss?() }
+                ) {
+                    content
+                }
             }
         }
     }
@@ -598,6 +635,7 @@ struct IOSBottomEdgeSheet<Content: View>: View {
     let bottomSafeAreaInset: CGFloat
     let height: CGFloat?
     let onDismiss: () -> Void
+    let headerTrailing: AnyView?
     let content: Content
 
     @Environment(\.iosReduceTransparencyEnabled) private var reduceTransparency
@@ -615,6 +653,25 @@ struct IOSBottomEdgeSheet<Content: View>: View {
         self.bottomSafeAreaInset = bottomSafeAreaInset
         self.height = height
         self.onDismiss = onDismiss
+        self.headerTrailing = nil
+        self.content = content()
+    }
+
+    init<Trailing: View>(
+        title: String,
+        tint: Color = IOSBrandTheme.accent,
+        bottomSafeAreaInset: CGFloat,
+        height: CGFloat? = nil,
+        onDismiss: @escaping () -> Void,
+        @ViewBuilder headerTrailing: () -> Trailing,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.tint = tint
+        self.bottomSafeAreaInset = bottomSafeAreaInset
+        self.height = height
+        self.onDismiss = onDismiss
+        self.headerTrailing = AnyView(headerTrailing())
         self.content = content()
     }
 
@@ -686,25 +743,29 @@ struct IOSBottomEdgeSheet<Content: View>: View {
                 .foregroundStyle(IOSAppTheme.textPrimary)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            Button {
-                onDismiss()
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 18, weight: .regular))
-                    .foregroundStyle(IOSAppTheme.textPrimary)
-                    .frame(width: 40, height: 40)
-                    .background {
-                        Circle()
-                            .fill(Color.white.opacity(0.06))
-                    }
-                    .overlay {
-                        Circle()
-                            .stroke(Color.white.opacity(0.10), lineWidth: 0.5)
-                    }
+            if let headerTrailing {
+                headerTrailing
+            } else {
+                Button {
+                    onDismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 18, weight: .regular))
+                        .foregroundStyle(IOSAppTheme.textPrimary)
+                        .frame(width: 40, height: 40)
+                        .background {
+                            Circle()
+                                .fill(Color.white.opacity(0.06))
+                        }
+                        .overlay {
+                            Circle()
+                                .stroke(Color.white.opacity(0.10), lineWidth: 0.5)
+                        }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close")
+                .accessibilityIdentifier("bottomSheet_close")
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Close")
-            .accessibilityIdentifier("bottomSheet_close")
         }
     }
 }
@@ -720,6 +781,7 @@ struct IOSBottomSheet<Content: View>: View {
     let title: String
     let tint: Color
     let onDismiss: (() -> Void)?
+    let headerTrailing: AnyView?
     let content: Content
 
     @Environment(\.dismiss) private var dismiss
@@ -733,6 +795,21 @@ struct IOSBottomSheet<Content: View>: View {
         self.title = title
         self.tint = tint
         self.onDismiss = onDismiss
+        self.headerTrailing = nil
+        self.content = content()
+    }
+
+    init<Trailing: View>(
+        title: String,
+        tint: Color = IOSBrandTheme.accent,
+        onDismiss: (() -> Void)? = nil,
+        @ViewBuilder headerTrailing: () -> Trailing,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.tint = tint
+        self.onDismiss = onDismiss
+        self.headerTrailing = AnyView(headerTrailing())
         self.content = content()
     }
 
@@ -777,25 +854,29 @@ struct IOSBottomSheet<Content: View>: View {
                 .foregroundStyle(IOSAppTheme.textPrimary)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-            Button {
-                onDismiss?()
-                dismiss()
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 18, weight: .regular))
-                    .foregroundStyle(IOSAppTheme.textPrimary)
-                    .frame(width: 40, height: 40)
-                    .background {
-                        Circle()
-                            .fill(Color.white.opacity(0.06))
-                    }
-                    .overlay {
-                        Circle()
-                            .stroke(Color.white.opacity(0.10), lineWidth: 0.5)
-                    }
+            if let headerTrailing {
+                headerTrailing
+            } else {
+                Button {
+                    onDismiss?()
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 18, weight: .regular))
+                        .foregroundStyle(IOSAppTheme.textPrimary)
+                        .frame(width: 40, height: 40)
+                        .background {
+                            Circle()
+                                .fill(Color.white.opacity(0.06))
+                        }
+                        .overlay {
+                            Circle()
+                                .stroke(Color.white.opacity(0.10), lineWidth: 0.5)
+                        }
+                }
+                .accessibilityLabel("Close")
+                .accessibilityIdentifier("bottomSheet_close")
             }
-            .accessibilityLabel("Close")
-            .accessibilityIdentifier("bottomSheet_close")
         }
     }
 }

--- a/Sources/iOS/IOSGenerationInputControls.swift
+++ b/Sources/iOS/IOSGenerationInputControls.swift
@@ -372,7 +372,7 @@ struct IOSSaveVoiceSheet: View {
 
     var body: some View {
         IOSBottomSheetSurface(title: title, tint: tint, presentation: .system, onDismiss: onCancel) {
-            ScrollView(.vertical, showsIndicators: false) {
+            IOSScrollView(bottomFadeHeight: 0) {
                 VStack(alignment: .leading, spacing: 18) {
                     if let clipAudioURL {
                         clipReviewCard(url: clipAudioURL)

--- a/Sources/iOS/IOSLibraryViews.swift
+++ b/Sources/iOS/IOSLibraryViews.swift
@@ -217,7 +217,7 @@ private struct IOSHistoryLibrarySection: View {
             IOSHistoryFilterChips(selection: $modeFilter)
                 .padding(.bottom, 0)
 
-            ScrollView(showsIndicators: false) {
+            IOSScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     if errorMessage != nil, items.isEmpty {
                         IOSEmptyStateCard(
@@ -589,7 +589,7 @@ private struct IOSSavedVoicesLibrarySection: View {
     let onUseInVoiceCloning: (Voice) -> Void
 
     var body: some View {
-        ScrollView(showsIndicators: false) {
+        IOSScrollView {
             LazyVStack(alignment: .leading, spacing: 12) {
                 if !ttsEngine.isReady {
                     IOSEmptyStateCard(

--- a/Sources/iOS/IOSScrollRefinements.swift
+++ b/Sources/iOS/IOSScrollRefinements.swift
@@ -140,3 +140,67 @@ extension View {
         modifier(IOSSubtleScrollIndicator())
     }
 }
+
+// MARK: - Convenience wrapper
+
+/// iOS scroll surface with the same no-rubber-band, subtle-indicator behavior as the
+/// language picker. Use this instead of raw `ScrollView` for all vertical iOS scroll
+/// content so the app-wide scrolling feel stays consistent.
+///
+/// On full-screen shells the bottom of the scroll view fades out under the TabDock;
+/// pass `bottomFadeHeight: 0` for sheets that float above the dock.
+struct IOSScrollView<Content: View>: View {
+    let bottomFadeHeight: CGFloat
+    @ViewBuilder let content: () -> Content
+
+    init(
+        bottomFadeHeight: CGFloat = IOSStudioShellMetrics.dockFadeHeight,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.bottomFadeHeight = bottomFadeHeight
+        self.content = content
+    }
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            content()
+                .iosDisableScrollBounce()
+        }
+        .iosSubtleScrollIndicator()
+        .bottomFadeMask(height: bottomFadeHeight)
+    }
+}
+
+private struct IOSScrollBottomFadeMask: ViewModifier {
+    let height: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .mask {
+                GeometryReader { proxy in
+                    let total = proxy.size.height
+                    let start = total > 0 ? max(0, (total - height) / total) : 1
+                    LinearGradient(
+                        stops: [
+                            .init(color: .white, location: 0),
+                            .init(color: .white, location: start),
+                            .init(color: .clear, location: 1)
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                }
+            }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func bottomFadeMask(height: CGFloat) -> some View {
+        if height > 0 {
+            modifier(IOSScrollBottomFadeMask(height: height))
+        } else {
+            self
+        }
+    }
+}

--- a/Sources/iOS/IOSSettingsViews.swift
+++ b/Sources/iOS/IOSSettingsViews.swift
@@ -75,7 +75,7 @@ private struct IOSSettingsView: View {
             activeTab: .settings,
             tint: IOSAppTab.settings.dockAccent(studioMode: .custom)
         ) {
-            ScrollView(showsIndicators: false) {
+            IOSScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     IOSSettingsReferenceSection(title: "Voice models") {
                         ForEach(TTSModel.all) { model in
@@ -189,10 +189,6 @@ private struct IOSSettingsView: View {
                 // Extra bottom padding so the bottom-most section clears
                 // the TabDock's gradient fade in RootView.
                 .padding(.bottom, 90)
-            }
-            .safeAreaInset(edge: .bottom, spacing: 0) {
-                Color.clear
-                    .frame(height: 118)
             }
         }
         .task {

--- a/Sources/iOS/IOSStudioShellViews.swift
+++ b/Sources/iOS/IOSStudioShellViews.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+/// Shared metrics for the iOS shell chrome.
+enum IOSStudioShellMetrics {
+    /// Height over which scroll content fades out under the glass TabDock.
+    static let dockFadeHeight: CGFloat = 118
+}
+
 /// Thin per-screen body container.
 ///
 /// History: this used to host the full iOS chrome — `IOSStudioShellCanopy`

--- a/Sources/iOS/IOSVoicesView.swift
+++ b/Sources/iOS/IOSVoicesView.swift
@@ -56,7 +56,7 @@ struct IOSVoicesView: View {
             activeTab: .voices,
             tint: IOSAppTab.voices.dockAccent(studioMode: .custom)
         ) {
-            ScrollView(.vertical, showsIndicators: false) {
+            IOSScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     IOSSearchField(text: $search, placeholder: "Search voices")
                         .padding(.horizontal, 20)
@@ -107,7 +107,6 @@ struct IOSVoicesView: View {
                 .frame(maxWidth: .infinity, alignment: .topLeading)
                 .padding(.bottom, 12)
             }
-            .scrollBounceBehavior(.basedOnSize)
             .task {
                 await savedVoicesViewModel.ensureLoaded(using: ttsEngine)
             }

--- a/Sources/iOS/Sheets/IOSBottomSheets.swift
+++ b/Sources/iOS/Sheets/IOSBottomSheets.swift
@@ -92,7 +92,33 @@ struct IOSDeliveryPickerSheet: View {
     }
 
     var body: some View {
-        IOSBottomSheetSurface(title: "Delivery", tint: tint, presentation: presentation, onDismiss: onDismiss) {
+        IOSBottomSheetSurface(
+            title: "Delivery",
+            tint: tint,
+            presentation: presentation,
+            onDismiss: onDismiss,
+            headerTrailing: {
+                Button {
+                    closeSheet()
+                } label: {
+                    Text("Confirm")
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(IOSAppTheme.textPrimary)
+                        .padding(.horizontal, 18)
+                        .frame(height: 40)
+                        .background {
+                            Capsule(style: .continuous)
+                                .fill(tint.opacity(0.18))
+                        }
+                        .overlay {
+                            Capsule(style: .continuous)
+                                .stroke(tint.opacity(0.35), lineWidth: 0.8)
+                        }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("deliveryPicker_confirm")
+            }
+        ) {
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 18) {
                     LazyVGrid(columns: columns, spacing: 12) {
@@ -284,7 +310,33 @@ struct IOSQwenLanguagePickerSheet: View {
     }
 
     var body: some View {
-        IOSBottomSheetSurface(title: "Language", tint: tint, presentation: presentation, onDismiss: onDismiss) {
+        IOSBottomSheetSurface(
+            title: "Language",
+            tint: tint,
+            presentation: presentation,
+            onDismiss: onDismiss,
+            headerTrailing: {
+                Button {
+                    closeSheet()
+                } label: {
+                    Text("Confirm")
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(IOSAppTheme.textPrimary)
+                        .padding(.horizontal, 18)
+                        .frame(height: 40)
+                        .background {
+                            Capsule(style: .continuous)
+                                .fill(tint.opacity(0.18))
+                        }
+                        .overlay {
+                            Capsule(style: .continuous)
+                                .stroke(tint.opacity(0.35), lineWidth: 0.8)
+                        }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("languagePicker_confirm")
+            }
+        ) {
             ScrollView(.vertical, showsIndicators: false) {
                 LazyVStack(alignment: .leading, spacing: 4) {
                     let recommendedLanguages = languages.filter(isRecommended)
@@ -338,7 +390,6 @@ struct IOSQwenLanguagePickerSheet: View {
         return Button {
             selectedLanguage = language
             IOSHaptics.selection()
-            closeSheet()
         } label: {
             HStack(alignment: .center, spacing: 12) {
                 leadingBadge(language)
@@ -428,11 +479,29 @@ struct IOSVoicePickerSheet: View {
     @Environment(\.dismiss) private var dismiss
     @State private var search: String = ""
     @StateObject private var previewer = IOSVoicePreviewPlayer()
+    /// Local provisional selection. The binding is only committed when the
+    /// user taps the Confirm header button.
+    @State private var pendingSelectedID: String
     /// R3-FU G.2.1 (2026-05-21): selected language tag, or
     /// `IOSVoicePickerSheet.allFilterID` for "show everything". Matches
     /// the design's filter-chip behaviour where the first chip ("All")
     /// is a sentinel value and the rest are concrete language tags.
     @State private var selectedFilter: String = IOSVoicePickerSheet.allFilterID
+
+    init(
+        speakers: [IOSVoicePickerOption],
+        selectedID: Binding<String>,
+        tint: Color,
+        onDismiss: (() -> Void)? = nil,
+        presentation: IOSBottomSheetPresentationStyle = .system
+    ) {
+        self.speakers = speakers
+        self._selectedID = selectedID
+        self.tint = tint
+        self.onDismiss = onDismiss
+        self.presentation = presentation
+        self._pendingSelectedID = State(initialValue: selectedID.wrappedValue)
+    }
 
     /// Sentinel id for the "All" chip. Real language tags are short
     /// uppercase strings ("EN", "ZH", …) so any non-matching marker
@@ -496,7 +565,33 @@ struct IOSVoicePickerSheet: View {
     }
 
     var body: some View {
-        IOSBottomSheetSurface(title: "Voice", tint: tint, presentation: presentation, onDismiss: onDismiss) {
+        IOSBottomSheetSurface(
+            title: "Voice",
+            tint: tint,
+            presentation: presentation,
+            onDismiss: onDismiss,
+            headerTrailing: {
+                Button {
+                    confirmSelection()
+                } label: {
+                    Text("Confirm")
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(IOSAppTheme.textPrimary)
+                        .padding(.horizontal, 18)
+                        .frame(height: 40)
+                        .background {
+                            Capsule(style: .continuous)
+                                .fill(tint.opacity(0.18))
+                        }
+                        .overlay {
+                            Capsule(style: .continuous)
+                                .stroke(tint.opacity(0.35), lineWidth: 0.8)
+                        }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("voicePicker_confirm")
+            }
+        ) {
             VStack(alignment: .leading, spacing: 14) {
                 IOSSearchField(text: $search, placeholder: "Search voices")
                     .padding(.horizontal, 20)
@@ -527,6 +622,12 @@ struct IOSVoicePickerSheet: View {
         // preview audio would keep playing under the studio screen.
         .onDisappear {
             previewer.stop()
+        }
+        .onAppear {
+            pendingSelectedID = selectedID
+        }
+        .onChange(of: selectedID) { _, newID in
+            pendingSelectedID = newID
         }
     }
 
@@ -559,20 +660,19 @@ struct IOSVoicePickerSheet: View {
     }
 
     private func row(for option: IOSVoicePickerOption) -> some View {
-        let isSelected = option.id == selectedID
+        let isSelected = option.id == pendingSelectedID
         let isPreviewing = previewer.currentlyPlayingID == option.id
         // Two SIBLING Buttons (select + preview) — never nested. Nesting a Button inside
         // another Button's label is a SwiftUI hit-testing trap that swallowed the row's
         // select tap; siblings each consume their own taps. The leading select Button
-        // fills the row (Spacer) and, per design, selects the voice AND closes the sheet;
+        // marks the provisional choice (the binding is committed by the Confirm header);
         // the trailing preview Button previews WITHOUT selecting/closing. Each carries a
         // stable accessibilityIdentifier so the UI loop can drive them independently.
         return HStack(alignment: .center, spacing: 12) {
             Button {
                 previewer.stop()
-                selectedID = option.id
+                pendingSelectedID = option.id
                 IOSHaptics.selection()
-                closeSheet()
             } label: {
                 HStack(alignment: .center, spacing: 12) {
                     IOSVoiceAvatar(seed: option.id, initials: option.initials, diameter: 44)
@@ -655,6 +755,13 @@ struct IOSVoicePickerSheet: View {
                 .fill(Color.white.opacity(0.06))
                 .frame(height: 0.5)
         }
+    }
+
+    private func confirmSelection() {
+        previewer.stop()
+        selectedID = pendingSelectedID
+        IOSHaptics.selection()
+        closeSheet()
     }
 
     private func closeSheet() {

--- a/Sources/iOS/Sheets/IOSBottomSheets.swift
+++ b/Sources/iOS/Sheets/IOSBottomSheets.swift
@@ -119,7 +119,7 @@ struct IOSDeliveryPickerSheet: View {
                 .accessibilityIdentifier("deliveryPicker_confirm")
             }
         ) {
-            ScrollView(.vertical, showsIndicators: false) {
+            IOSScrollView(bottomFadeHeight: 0) {
                 VStack(alignment: .leading, spacing: 18) {
                     LazyVGrid(columns: columns, spacing: 12) {
                         ForEach(EmotionPreset.all) { preset in
@@ -601,7 +601,7 @@ struct IOSVoicePickerSheet: View {
                         .padding(.horizontal, 20)
                 }
 
-                ScrollView(.vertical, showsIndicators: false) {
+                IOSScrollView(bottomFadeHeight: 0) {
                     LazyVStack(alignment: .leading, spacing: 4) {
                         let recommended = filtered.filter(\.isRecommended)
                         let others = filtered.filter { !$0.isRecommended }
@@ -885,7 +885,7 @@ struct IOSReferenceClipSheet: View {
             presentation: presentation,
             onDismiss: onDismiss
         ) {
-            ScrollView(.vertical, showsIndicators: false) {
+            IOSScrollView(bottomFadeHeight: 0) {
                 VStack(alignment: .leading, spacing: 14) {
                     sourcePicker
 

--- a/Sources/iOS/Sheets/IOSPlayerSheet.swift
+++ b/Sources/iOS/Sheets/IOSPlayerSheet.swift
@@ -282,7 +282,7 @@ struct IOSPlayerSheet: View {
     /// Wrapping card removed so the transcript reads as flowing prose
     /// like the design — the player sheet itself is the surface.
     private var transcript: some View {
-        ScrollView(.vertical, showsIndicators: false) {
+        IOSScrollView(bottomFadeHeight: 0) {
             IOSPlayerKaraokeText(
                 spans: controller.spans,
                 currentTime: controller.currentTime,

--- a/Sources/iOS/Sheets/IOSVoiceDesignBriefSheet.swift
+++ b/Sources/iOS/Sheets/IOSVoiceDesignBriefSheet.swift
@@ -22,12 +22,40 @@ struct IOSVoiceDesignBriefSheet: View {
     // the macOS inline editor stay in lockstep.
     private let startingPoints = VoiceDesignBriefCatalog.startingPoints
 
+    private var isBriefEmpty: Bool {
+        voiceDescription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     var body: some View {
         IOSBottomSheetSurface(
             title: "Voice brief",
             tint: tint,
             presentation: presentation,
-            onDismiss: onDismiss
+            onDismiss: onDismiss,
+            headerTrailing: {
+                Button {
+                    isFocused = false
+                    closeSheet()
+                } label: {
+                    Text("Confirm")
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(IOSAppTheme.textPrimary)
+                        .padding(.horizontal, 18)
+                        .frame(height: 40)
+                        .background {
+                            Capsule(style: .continuous)
+                                .fill(tint.opacity(0.18))
+                        }
+                        .overlay {
+                            Capsule(style: .continuous)
+                                .stroke(tint.opacity(0.35), lineWidth: 0.8)
+                        }
+                }
+                .buttonStyle(.plain)
+                .disabled(isBriefEmpty)
+                .opacity(isBriefEmpty ? 0.5 : 1.0)
+                .accessibilityIdentifier("voiceBrief_confirm")
+            }
         ) {
             VStack(alignment: .leading, spacing: 0) {
                 Text("Describe the voice. Combine character, age, accent, and texture.")
@@ -90,22 +118,6 @@ struct IOSVoiceDesignBriefSheet: View {
                 .padding(.horizontal, 20)
                 .padding(.top, 6)
                 .padding(.bottom, 18)
-
-                // Explicit confirm: apply the typed brief (the binding already writes through
-                // live) and close. Sits above the keyboard while editing; the Starting points
-                // below are alternative one-tap confirms. Disabled until something is written —
-                // the header X still closes an empty sheet.
-                IOSPrimaryCTAButton(
-                    title: "Done",
-                    tint: tint,
-                    isEnabled: !voiceDescription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                ) {
-                    isFocused = false
-                    closeSheet()
-                }
-                .padding(.horizontal, 20)
-                .padding(.bottom, 20)
-                .accessibilityIdentifier("voiceBrief_confirm")
 
                 Text("Starting points".uppercased())
                     .font(.system(size: 11, weight: .semibold))

--- a/Sources/iOS/Studio/IOSFlexibleTextEditor.swift
+++ b/Sources/iOS/Studio/IOSFlexibleTextEditor.swift
@@ -28,6 +28,7 @@ struct IOSFlexibleTextEditor: UIViewRepresentable {
 
     func makeUIView(context: Context) -> NoIntrinsicHeightTextView {
         let view = NoIntrinsicHeightTextView()
+        view.accessibilityIdentifier = "textInput_textEditor"
         view.delegate = context.coordinator
         view.backgroundColor = .clear
         view.font = font
@@ -59,6 +60,9 @@ struct IOSFlexibleTextEditor: UIViewRepresentable {
     }
 
     func updateUIView(_ view: NoIntrinsicHeightTextView, context: Context) {
+        if view.accessibilityIdentifier != "textInput_textEditor" {
+            view.accessibilityIdentifier = "textInput_textEditor"
+        }
         if view.text != text {
             view.text = text
         }

--- a/Tests/VocelloiOSUITests/VocelloUITestApp.swift
+++ b/Tests/VocelloiOSUITests/VocelloUITestApp.swift
@@ -1,0 +1,202 @@
+import XCTest
+
+/// Shared app coordinator for the whole `VocelloiOSUITests` target.
+///
+/// XCUITest's default pattern launches the app inside every test's `setUp()` and
+/// terminates it in `tearDown()`. For Vocello that meant the app closed and reopened
+/// between every single UI assertion, which is nothing like a real user session. This
+/// singleton keeps the app alive across test cases; only a fresh `xcodebuild test` run
+/// (new build / new process) or an explicit cold-generation test triggers a new launch.
+final class VocelloUITestApp: @unchecked Sendable {
+    static let shared = VocelloUITestApp()
+    private init() {}
+
+    private let lock = NSLock()
+    private var retainCount = 0
+    private(set) var app: XCUIApplication!
+
+    // MARK: - Lifecycle
+
+    /// Call from `override class func setUp()` in every UI test class that shares the
+    /// warm app session. The first call launches the app; subsequent calls just ensure
+    /// it is still in the foreground.
+    func retain() {
+        lock.lock()
+        defer { lock.unlock() }
+        retainCount += 1
+        if retainCount == 1 {
+            launch()
+        } else {
+            ensureForeground()
+        }
+    }
+
+    /// Call from `override class func tearDown()` in every UI test class that called
+    /// `retain()`. The last matching release terminates the app.
+    func release() {
+        lock.lock()
+        defer { lock.unlock() }
+        retainCount -= 1
+        if retainCount == 0 {
+            terminate()
+        }
+    }
+
+    /// Kill the shared app immediately and reset the coordinator. Used by the cold-
+    /// generation test so it can launch a truly fresh instance.
+    func forceTerminate() {
+        lock.lock()
+        defer { lock.unlock() }
+        terminate()
+        retainCount = 0
+    }
+
+    /// Per-test reset: make sure we are back on the Studio surface with no sheet open.
+    /// This lets each test start from a clean, deterministic place without closing the app.
+    func resetToStudio() {
+        ensureForeground()
+
+        let studioTab = element("rootTab_studio")
+        if studioTab.exists && !studioTab.isSelected {
+            studioTab.tap()
+        }
+
+        // Dismiss any stuck sheet from a previous test/failure.
+        // Voice, language, delivery, and voice-brief pickers use a Confirm header; other sheets have the X close button.
+        let confirmIDs = ["voicePicker_confirm", "languagePicker_confirm", "deliveryPicker_confirm", "voiceBrief_confirm"]
+        for id in confirmIDs {
+            let confirm = element(id)
+            if confirm.exists {
+                confirm.tap()
+                _ = confirm.waitForNonExistence(timeout: 5)
+                break
+            }
+        }
+        let close = element("bottomSheet_close")
+        if close.exists {
+            close.tap()
+            _ = close.waitForNonExistence(timeout: 5)
+        }
+
+        XCTAssertTrue(
+            waitFor("generateSection_custom", timeout: 10),
+            "Studio surface should be reachable after reset"
+        )
+    }
+
+    // MARK: - Element helpers
+
+    func element(_ identifier: String) -> XCUIElement {
+        app.descendants(matching: .any)[identifier].firstMatch
+    }
+
+    func firstElement(prefix: String) -> XCUIElement {
+        app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier BEGINSWITH %@", prefix))
+            .firstMatch
+    }
+
+    /// First element whose identifier begins with `prefix` but is not `excludingIdentifier`.
+    /// Used when the first match is already selected and we need a different option.
+    func firstElement(prefix: String, excludingIdentifier: String) -> XCUIElement {
+        app.descendants(matching: .any)
+            .matching(NSPredicate(
+                format: "identifier BEGINSWITH %@ AND identifier != %@",
+                prefix,
+                excludingIdentifier
+            ))
+            .firstMatch
+    }
+
+    func button(labelPrefix: String) -> XCUIElement {
+        app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", labelPrefix)).firstMatch
+    }
+
+    @discardableResult
+    func waitFor(_ identifier: String, timeout: TimeInterval = 30) -> Bool {
+        element(identifier).waitForExistence(timeout: timeout)
+    }
+
+    // MARK: - Screenshot diagnostics
+
+    /// Captures the current app frame and attaches it to the test result.
+    /// If `UI_TEST_SCREENSHOT_DIR` is set, also writes a PNG to disk for quick review.
+    func captureScreenshot(named name: String) {
+        let screenshot = app.screenshot()
+
+        // Attach to the XCTest result bundle.
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        XCTContext.runActivity(named: "Screenshot: \(name)") { activity in
+            activity.add(attachment)
+        }
+
+        // Optional on-disk copy for device-side debugging.
+        if let dir = ProcessInfo.processInfo.environment["UI_TEST_SCREENSHOT_DIR"] {
+            let fileManager = FileManager.default
+            try? fileManager.createDirectory(atPath: dir, withIntermediateDirectories: true)
+            let path = (dir as NSString).appendingPathComponent("\(name).png")
+            do {
+                try screenshot.pngRepresentation.write(to: URL(fileURLWithPath: path))
+            } catch {
+                print("[VocelloUITestApp] could not write screenshot to \(path): \(error)")
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func launch() {
+        app = XCUIApplication()
+        // UI-only smoke/sheet tests do not need the heavy model load.
+        app.launchEnvironment["QVOICE_IOS_DISABLE_ENGINE"] = "1"
+        // On the simulator these seed the fake engine so the Studio is populated.
+        // On a real device they are ignored.
+        app.launchEnvironment["QVOICE_SIM_FAKE_MODELS"] = "all"
+        app.launchEnvironment["QVOICE_SIM_SEED_DATA"] = "voices,history"
+
+        app.launch()
+        dismissOnboardingIfPresent()
+
+        XCTAssertTrue(
+            waitFor("rootTab_studio", timeout: 30),
+            "Studio tab should appear after launch"
+        )
+    }
+
+    private func terminate() {
+        guard let app = app else { return }
+        if app.state == .runningForeground || app.state == .runningBackground {
+            app.terminate()
+        }
+        self.app = nil
+    }
+
+    private func ensureForeground() {
+        guard let app = app else { return }
+        if app.state != .runningForeground {
+            app.activate()
+        }
+    }
+
+    /// First-run onboarding (3 pages) sits in front of the tabs on a fresh install.
+    /// Poll for either the main UI or onboarding; Skip completes the whole flow, the CTA
+    /// advances/completes as a fallback.
+    private func dismissOnboardingIfPresent() {
+        let studio = element("rootTab_studio")
+        let skip = element("onboarding_skip")
+        let cta = element("onboarding_cta")
+        let deadline = Date().addingTimeInterval(20)
+        while Date() < deadline {
+            if studio.exists { return }
+            if skip.exists {
+                skip.tap()
+                _ = studio.waitForExistence(timeout: 6)
+                return
+            }
+            if cta.exists { cta.tap() }
+            usleep(300_000)
+        }
+    }
+}

--- a/Tests/VocelloiOSUITests/VocelloiOSColdGenerationUITests.swift
+++ b/Tests/VocelloiOSUITests/VocelloiOSColdGenerationUITests.swift
@@ -16,12 +16,17 @@ final class VocelloiOSColdGenerationUITests: XCTestCase {
 
         // Guarantee a cold start: terminate any app the shared coordinator may be holding.
         VocelloUITestApp.shared.forceTerminate()
+        // Give the terminated process a moment to clean up on the device before we
+        // launch a fresh instance; this avoids the occasional "PID could not be
+        // determined" race when the runner tries to attach too quickly.
+        Thread.sleep(forTimeInterval: 1.0)
 
         app = XCUIApplication()
         // Do NOT set QVOICE_IOS_DISABLE_ENGINE — we want the real model load + generation.
         // Enable durable telemetry so the engine layer writes diagnostics we can pull.
         app.launchEnvironment["QWENVOICE_DEBUG"] = "1"
         app.launch()
+        _ = app.wait(for: .runningForeground, timeout: 30)
         dismissOnboardingIfPresent()
     }
 
@@ -32,7 +37,7 @@ final class VocelloiOSColdGenerationUITests: XCTestCase {
 
     func testColdGenerationCompletes() {
         XCTAssertTrue(
-            app.descendants(matching: .any)["rootTab_studio"].waitForExistence(timeout: 10),
+            app.descendants(matching: .any)["rootTab_studio"].waitForExistence(timeout: 30),
             "Studio tab should be visible after cold launch"
         )
         captureScreenshot(named: "cold-launch-studio")
@@ -45,11 +50,7 @@ final class VocelloiOSColdGenerationUITests: XCTestCase {
 
         // Make sure we are in Custom mode. The app persists the last-used mode, so a
         // previous test may have left it in Design/Clone, where Generate is disabled.
-        let customMode = app.descendants(matching: .any)["generateSection_custom"]
-        XCTAssertTrue(customMode.waitForExistence(timeout: 10), "Custom mode segment should exist")
-        if !customMode.isSelected {
-            customMode.tap()
-        }
+        selectCustomMode()
 
         // The custom text editor is a UIViewRepresentable; relying on a single identifier
         // has proven brittle. Use the only editable text view in the Studio, and fall back
@@ -111,6 +112,31 @@ final class VocelloiOSColdGenerationUITests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    /// Selects the Custom generation-mode segment, retrying by identifier and then by
+    /// visible label. SwiftUI Picker segments can be slow to resolve after a cold launch,
+    /// so the identifier lookup gets a generous timeout before we fall back.
+    private func selectCustomMode() {
+        let byID = app.descendants(matching: .any)["generateSection_custom"]
+        let byLabel = app.buttons.matching(NSPredicate(format: "label == %@", "Custom")).firstMatch
+
+        var found = byID.waitForExistence(timeout: 30)
+        let customMode: XCUIElement = found ? byID : byLabel
+
+        if !found {
+            found = byLabel.waitForExistence(timeout: 10)
+        }
+
+        XCTAssertTrue(
+            found,
+            "Custom mode segment should exist (looked up by identifier and by label)"
+        )
+        captureScreenshot(named: "cold-custom-mode-found")
+
+        if customMode.waitForExistence(timeout: 5), !customMode.isSelected {
+            customMode.tap()
+        }
+    }
 
     private func captureScreenshot(named name: String) {
         let screenshot = app.screenshot()

--- a/Tests/VocelloiOSUITests/VocelloiOSColdGenerationUITests.swift
+++ b/Tests/VocelloiOSUITests/VocelloiOSColdGenerationUITests.swift
@@ -1,0 +1,153 @@
+import XCTest
+
+/// Cold-start generation test.
+///
+/// Unlike the rest of the UI suite, this test intentionally kills any warm app and
+/// launches a fresh instance with the engine enabled. It types a short script in the
+/// Studio and waits for real audio generation to complete. This is the exception to the
+/// "app stays alive" rule, used to prove that a cold launch + model load + generation
+/// end-to-end still works on device.
+final class VocelloiOSColdGenerationUITests: XCTestCase {
+    private var app: XCUIApplication!
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+
+        // Guarantee a cold start: terminate any app the shared coordinator may be holding.
+        VocelloUITestApp.shared.forceTerminate()
+
+        app = XCUIApplication()
+        // Do NOT set QVOICE_IOS_DISABLE_ENGINE — we want the real model load + generation.
+        // Enable durable telemetry so the engine layer writes diagnostics we can pull.
+        app.launchEnvironment["QWENVOICE_DEBUG"] = "1"
+        app.launch()
+        dismissOnboardingIfPresent()
+    }
+
+    override func tearDown() {
+        app?.terminate()
+        super.tearDown()
+    }
+
+    func testColdGenerationCompletes() {
+        XCTAssertTrue(
+            app.descendants(matching: .any)["rootTab_studio"].waitForExistence(timeout: 10),
+            "Studio tab should be visible after cold launch"
+        )
+        captureScreenshot(named: "cold-launch-studio")
+
+        let installButton = app.descendants(matching: .any)["textInput_installModelButton"]
+        XCTAssertFalse(
+            installButton.exists,
+            "model must already be installed on the device for the cold-generation test"
+        )
+
+        // Make sure we are in Custom mode. The app persists the last-used mode, so a
+        // previous test may have left it in Design/Clone, where Generate is disabled.
+        let customMode = app.descendants(matching: .any)["generateSection_custom"]
+        XCTAssertTrue(customMode.waitForExistence(timeout: 10), "Custom mode segment should exist")
+        if !customMode.isSelected {
+            customMode.tap()
+        }
+
+        // The custom text editor is a UIViewRepresentable; relying on a single identifier
+        // has proven brittle. Use the only editable text view in the Studio, and fall back
+        // to the visible placeholder if the runtime does not expose the view directly.
+        let editor: XCUIElement
+        let editorByID = app.descendants(matching: .any)["textInput_textEditor"]
+        if editorByID.waitForExistence(timeout: 5) {
+            editor = editorByID
+        } else {
+            let firstTextView = app.textViews.firstMatch
+            XCTAssertTrue(firstTextView.waitForExistence(timeout: 10), "Studio text view should exist")
+            editor = firstTextView
+        }
+
+        editor.tap()
+        editor.typeText("Hello from Vocello cold start.")
+        captureScreenshot(named: "cold-typed")
+
+        // The text editor's Return key is configured as "Done" and dismisses the
+        // keyboard instead of inserting a newline. The Generate button sits below
+        // the composer in a layout that ignores the keyboard, so we must dismiss
+        // the keyboard before tapping it; otherwise the tap lands on a keyboard key.
+        editor.typeText("\n")
+        XCTAssertTrue(
+            app.keyboards.element.waitForNonExistence(timeout: 10),
+            "Keyboard should dismiss after pressing Return/Done"
+        )
+        captureScreenshot(named: "cold-keyboard-dismissed")
+
+        // The primary CTA is shadowed by the screen-level identifier, so match by label.
+        let generate = app.buttons.matching(NSPredicate(format: "label == %@", "Generate")).firstMatch
+        XCTAssertTrue(generate.waitForExistence(timeout: 10), "Generate button should exist")
+        XCTAssertTrue(generate.isEnabled, "Generate button should be enabled after typing")
+        generate.tap()
+        captureScreenshot(named: "cold-generate-tapped")
+
+        let completePlayer = app.descendants(matching: .any)["studio_inlinePlayer"]
+        let completeByVoiceName = app.staticTexts.matching(NSPredicate(format: "label == %@", "Aiden")).firstMatch
+        let completeBySubtitle = app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH %@", "Just now")).firstMatch
+        let completeByPlay = app.buttons.matching(NSPredicate(format: "label == %@", "Play")).firstMatch
+        let errorByID = app.descendants(matching: .any)["textInput_generationError"]
+        let errorByLabel = app.buttons.matching(NSPredicate(format: "label == %@", "Generation failed")).firstMatch
+
+        let deadline = Date().addingTimeInterval(120)
+        while Date() < deadline {
+            if completePlayer.exists || completeByVoiceName.exists || completeBySubtitle.exists || completeByPlay.exists {
+                captureScreenshot(named: "cold-generation-complete")
+                return
+            }
+            if errorByID.exists || errorByLabel.exists {
+                captureScreenshot(named: "cold-generation-error")
+                XCTFail("Generation failed during cold start")
+                return
+            }
+            usleep(500_000)
+        }
+        captureScreenshot(named: "cold-generation-timeout")
+        XCTFail("Cold generation did not complete within 120 seconds")
+    }
+
+    // MARK: - Helpers
+
+    private func captureScreenshot(named name: String) {
+        let screenshot = app.screenshot()
+        let attachment = XCTAttachment(screenshot: screenshot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        XCTContext.runActivity(named: "Screenshot: \(name)") { activity in
+            activity.add(attachment)
+        }
+
+        if let dir = ProcessInfo.processInfo.environment["UI_TEST_SCREENSHOT_DIR"] {
+            let fileManager = FileManager.default
+            try? fileManager.createDirectory(atPath: dir, withIntermediateDirectories: true)
+            let path = (dir as NSString).appendingPathComponent("\(name).png")
+            do {
+                try screenshot.pngRepresentation.write(to: URL(fileURLWithPath: path))
+            } catch {
+                print("[ColdGenerationUITest] could not write screenshot to \(path): \(error)")
+            }
+        }
+    }
+
+    /// First-run onboarding (3 pages) sits in front of the tabs on a fresh install.
+    private func dismissOnboardingIfPresent() {
+        let studio = app.descendants(matching: .any)["rootTab_studio"]
+        let skip = app.descendants(matching: .any)["onboarding_skip"]
+        let cta = app.descendants(matching: .any)["onboarding_cta"]
+        let deadline = Date().addingTimeInterval(20)
+        while Date() < deadline {
+            if studio.exists { return }
+            if skip.exists {
+                skip.tap()
+                _ = studio.waitForExistence(timeout: 6)
+                return
+            }
+            if cta.exists { cta.tap() }
+            usleep(300_000)
+        }
+    }
+}

--- a/Tests/VocelloiOSUITests/VocelloiOSSheetUITests.swift
+++ b/Tests/VocelloiOSUITests/VocelloiOSSheetUITests.swift
@@ -8,124 +8,148 @@ import XCTest
 /// prefix ("Voice: ", "Language:", "Voice brief:") — their own `studioChip_*` identifiers are
 /// shadowed by the screen-level `screen_generateStudio` identifier that SwiftUI propagates
 /// onto descendants (same reason `textInput_*` are shadowed). Inside the sheets the elements
-/// keep their own identifiers (`bottomSheet_close`, `voicePickerRow_*`, `voicePickerPreview_*`,
+/// keep their own identifiers (`voicePickerRow_*`, `voicePickerPreview_*`, `voicePicker_confirm`,
 /// `languagePicker_*`, `voiceBrief_editor`, `voiceBrief_confirm`) because the bottom panel is a
 /// separate overlay, so those are driven by identifier.
 ///
-/// These assert *behaviour* (select-and-close, preview-doesn't-close, confirm gating), not
-/// pixels — the no-rubber-band scroll feel + thumb fade are verified by visual review.
+/// These assert *behaviour* (select-and-confirm, preview-doesn't-close, confirm gating),
+/// not pixels — the no-rubber-band scroll feel + thumb fade are verified by visual review.
 final class VocelloiOSSheetUITests: XCTestCase {
-    private var app: XCUIApplication!
+
+    override class func setUp() {
+        super.setUp()
+        VocelloUITestApp.shared.retain()
+    }
 
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
-        app = XCUIApplication()
-        // Seed the simulator fake engine so the Studio is in its normal, model-installed
-        // state (ignored on a real device, which uses the in-process MLX engine).
-        app.launchEnvironment["QVOICE_SIM_FAKE_MODELS"] = "all"
-        app.launchEnvironment["QVOICE_SIM_SEED_DATA"] = "voices,history"
-        // These tests drive only the Studio chrome + bottom-sheet pickers (no audio
-        // generation), so skip the heavy on-launch engine model load. On the device that
-        // load (~2.3 GB) ran on every per-test relaunch and contended the accessibility
-        // server, making the Studio-surface waits flaky across the batch. The pickers'
-        // data (built-in speakers, languages, brief editor) comes from the contract, not
-        // the engine, so they populate regardless.
-        app.launchEnvironment["QVOICE_IOS_DISABLE_ENGINE"] = "1"
-        app.launch()
-        dismissOnboardingIfPresent()
-        // Absorb cold-launch latency once here: wait for the Studio surface to render
-        // before any test body runs, instead of failing mid-test in selectMode.
-        _ = app.descendants(matching: .any)["generateSection_custom"].waitForExistence(timeout: 30)
+        VocelloUITestApp.shared.resetToStudio()
     }
 
-    override func tearDown() {
-        app = nil
+    override class func tearDown() {
+        VocelloUITestApp.shared.release()
         super.tearDown()
     }
 
-    /// Tapping a voice row selects it and closes the picker (the regression this session fixed:
-    /// the row was a nested Button whose select tap got swallowed).
-    func testVoicePickerSelectAndClose() {
+    /// Selecting a voice row updates the provisional selection but does NOT close the picker.
+    /// Tapping the Confirm header button commits the selection and dismisses the sheet.
+    func testVoicePickerSelectAndConfirm() {
         selectMode("generateSection_custom")
         openSheet(viaChipLabelPrefix: "Voice: ")
 
-        let close = element("bottomSheet_close")
-        let firstRow = firstElement(prefix: "voicePickerRow_")
-        XCTAssertTrue(firstRow.waitForExistence(timeout: 10), "at least one voice row should exist")
-        firstRow.tap()
+        let confirm = element("voicePicker_confirm")
+        let chipBefore = button(labelPrefix: "Voice: ").label
 
-        XCTAssertTrue(close.waitForNonExistence(timeout: 10), "selecting a voice should close the picker")
+        // The shared app session means the current voice may already be the first row.
+        // Derive the current row identifier from the chip label and pick a different one.
+        let currentVoiceName = chipBefore
+            .replacingOccurrences(of: "Voice: ", with: "")
+            .trimmingCharacters(in: .whitespaces)
+        let currentRowID = "voicePickerRow_\(currentVoiceName.lowercased())"
+
+        let newRow = firstElement(prefix: "voicePickerRow_", excludingIdentifier: currentRowID)
+        XCTAssertTrue(newRow.waitForExistence(timeout: 10), "a different voice row should exist")
+        newRow.tap()
+
+        XCTAssertTrue(confirm.waitForExistence(timeout: 5), "confirm button should remain visible after selecting a row")
+        confirm.tap()
+        XCTAssertTrue(
+            confirm.waitForNonExistence(timeout: 10),
+            "tapping Confirm should dismiss the voice picker"
+        )
+
+        let chipAfter = button(labelPrefix: "Voice: ").label
+        XCTAssertTrue(chipAfter.hasPrefix("Voice: "), "voice chip should show a selected voice")
+        XCTAssertNotEqual(chipAfter, chipBefore, "voice chip should reflect the newly selected voice")
+        VocelloUITestApp.shared.captureScreenshot(named: "sheet-voice-confirmed")
     }
 
     /// The per-row preview button is a sibling Button (not nested) — tapping it must preview
-    /// WITHOUT selecting or closing the sheet.
+    /// WITHOUT selecting or closing the sheet. The sheet is then closed with the Confirm header.
     func testVoicePreviewKeepsPickerOpen() {
         selectMode("generateSection_custom")
         openSheet(viaChipLabelPrefix: "Voice: ")
 
-        let close = element("bottomSheet_close")
+        let confirm = element("voicePicker_confirm")
         let preview = firstElement(prefix: "voicePickerPreview_")
         XCTAssertTrue(preview.waitForExistence(timeout: 10), "a preview button should exist")
         preview.tap()
 
-        XCTAssertTrue(close.exists, "previewing a voice should not close the picker")
-        close.tap()
-        XCTAssertTrue(close.waitForNonExistence(timeout: 10), "tapping close should dismiss the picker")
+        XCTAssertTrue(confirm.exists, "previewing a voice should not close the picker")
+        confirm.tap()
+        XCTAssertTrue(
+            confirm.waitForNonExistence(timeout: 10),
+            "tapping Confirm should dismiss the picker after preview"
+        )
+        VocelloUITestApp.shared.captureScreenshot(named: "sheet-preview-closed")
     }
 
-    /// Tapping a language row selects it and closes the picker.
+    /// Selecting a language row updates the selection but does NOT close the picker.
+    /// Tapping the Confirm header button commits the selection and dismisses the sheet.
     func testLanguagePickerSelectAndClose() {
         selectMode("generateSection_custom")
         openSheet(viaChipLabelPrefix: "Language:")
 
-        let close = element("bottomSheet_close")
-        let firstRow = firstElement(prefix: "languagePicker_")
+        let confirm = element("languagePicker_confirm")
+        let firstRow = firstElement(prefix: "languagePicker_", excludingIdentifier: "languagePicker_confirm")
         XCTAssertTrue(firstRow.waitForExistence(timeout: 10), "language rows should exist")
         firstRow.tap()
 
-        XCTAssertTrue(close.waitForNonExistence(timeout: 10), "selecting a language should close the picker")
+        XCTAssertTrue(confirm.waitForExistence(timeout: 5), "confirm button should remain visible after selecting a row")
+        confirm.tap()
+        XCTAssertTrue(
+            confirm.waitForNonExistence(timeout: 10),
+            "tapping Confirm should dismiss the language picker"
+        )
+        VocelloUITestApp.shared.captureScreenshot(named: "sheet-language-closed")
     }
 
-    /// With a non-empty brief, the "Done" CTA applies it and closes the sheet (the affordance
-    /// added this session). The empty-brief gating is a visual/disabled-opacity concern that's
-    /// state-dependent here (the device draft persists), so it's left to code/visual review.
+    /// With a non-empty brief, the header Confirm button applies it and closes the sheet.
     func testVoiceBriefConfirmCloses() {
         selectMode("generateSection_design")
         openSheet(viaChipLabelPrefix: "Voice brief:")
 
-        let close = element("bottomSheet_close")
+        let confirm = element("voiceBrief_confirm")
         let editor = element("voiceBrief_editor")
         XCTAssertTrue(editor.waitForExistence(timeout: 10), "the brief editor should exist")
         editor.tap()
         editor.typeText("A calm test narrator")   // ensure a non-empty brief deterministically
 
-        let done = element("voiceBrief_confirm")
-        XCTAssertTrue(done.waitForExistence(timeout: 10), "the Done CTA should exist")
-        done.tap()
+        XCTAssertTrue(confirm.waitForExistence(timeout: 10), "the Confirm CTA should exist")
+        confirm.tap()
         XCTAssertTrue(
-            close.waitForNonExistence(timeout: 10),
-            "Done with a non-empty brief should apply + close the sheet"
+            confirm.waitForNonExistence(timeout: 10),
+            "Confirm with a non-empty brief should apply + close the sheet"
         )
+        VocelloUITestApp.shared.captureScreenshot(named: "sheet-brief-closed")
     }
 
     // MARK: - Helpers
 
     private func element(_ identifier: String) -> XCUIElement {
-        app.descendants(matching: .any)[identifier].firstMatch
+        VocelloUITestApp.shared.element(identifier)
     }
 
     /// First element whose identifier begins with `prefix` (rows carry a per-item suffix).
     private func firstElement(prefix: String) -> XCUIElement {
-        app.descendants(matching: .any)
-            .matching(NSPredicate(format: "identifier BEGINSWITH %@", prefix))
-            .firstMatch
+        VocelloUITestApp.shared.firstElement(prefix: prefix)
+    }
+
+    /// First element whose identifier begins with `prefix` but is not `excludingIdentifier`.
+    private func firstElement(prefix: String, excludingIdentifier: String) -> XCUIElement {
+        VocelloUITestApp.shared.firstElement(prefix: prefix, excludingIdentifier: excludingIdentifier)
     }
 
     /// A button matched by its label prefix — used for the Studio selector pills, whose own
     /// identifiers are shadowed by the screen-level identifier (see the type doc).
     private func button(labelPrefix: String) -> XCUIElement {
-        app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", labelPrefix)).firstMatch
+        VocelloUITestApp.shared.button(labelPrefix: labelPrefix)
+    }
+
+    @discardableResult
+    private func waitFor(_ identifier: String, timeout: TimeInterval = 30) -> Bool {
+        VocelloUITestApp.shared.waitFor(identifier, timeout: timeout)
     }
 
     /// Tap a Studio selector pill (by label) and wait for the bottom sheet to open.
@@ -133,15 +157,14 @@ final class VocelloiOSSheetUITests: XCTestCase {
         let chip = button(labelPrefix: prefix)
         XCTAssertTrue(chip.waitForExistence(timeout: 30), "selector pill '\(prefix)…' should exist")
         chip.tap()
-        XCTAssertTrue(
-            element("bottomSheet_close").waitForExistence(timeout: 10),
-            "the sheet opened from '\(prefix)…' should appear"
-        )
-    }
 
-    @discardableResult
-    private func waitFor(_ identifier: String, timeout: TimeInterval = 30) -> Bool {
-        element(identifier).waitForExistence(timeout: timeout)
+        // Voice, language, delivery, and voice-brief pickers surface a Confirm header; other sheets expose the X close button.
+        let sheetOpen = element("voicePicker_confirm").waitForExistence(timeout: 10)
+            || element("languagePicker_confirm").waitForExistence(timeout: 10)
+            || element("deliveryPicker_confirm").waitForExistence(timeout: 10)
+            || element("voiceBrief_confirm").waitForExistence(timeout: 10)
+            || element("bottomSheet_close").waitForExistence(timeout: 10)
+        XCTAssertTrue(sheetOpen, "the sheet opened from '\(prefix)…' should appear")
     }
 
     /// Tap a mode segment (Custom/Design/Clone). A no-op if already selected; harmless.
@@ -149,24 +172,5 @@ final class VocelloiOSSheetUITests: XCTestCase {
         let segment = element(identifier)
         XCTAssertTrue(segment.waitForExistence(timeout: 30), "mode segment \(identifier) should exist")
         segment.tap()
-    }
-
-    /// First-run onboarding (3 pages) shows on a fresh install. Poll for either the main UI or
-    /// onboarding; tapping Skip completes the whole flow, the CTA advances/completes as a fallback.
-    private func dismissOnboardingIfPresent() {
-        let studio = element("rootTab_studio")
-        let skip = element("onboarding_skip")
-        let cta = element("onboarding_cta")
-        let deadline = Date().addingTimeInterval(20)
-        while Date() < deadline {
-            if studio.exists { return }
-            if skip.exists {
-                skip.tap()
-                _ = studio.waitForExistence(timeout: 6)
-                return
-            }
-            if cta.exists { cta.tap() }
-            usleep(300_000)
-        }
     }
 }

--- a/Tests/VocelloiOSUITests/VocelloiOSSmokeUITests.swift
+++ b/Tests/VocelloiOSUITests/VocelloiOSSmokeUITests.swift
@@ -8,30 +8,27 @@ import XCTest
 /// 4-tab information architecture + Studio composer/mode-control are reachable, keyed
 /// off the stable `accessibilityIdentifier`s (kept through refactors per AGENTS.md).
 ///
-/// Run on a simulator (fast, no signing) or the device:
-///   xcodebuild test -scheme VocelloiOS -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
-///   xcodebuild test -scheme VocelloiOS -destination 'id=<device-udid>'
+/// The app is launched once for the whole UI-test target by `VocelloUITestApp` and
+/// stays alive across test classes; each test only resets surface state.
 final class VocelloiOSSmokeUITests: XCTestCase {
-    private var app: XCUIApplication!
+
+    override class func setUp() {
+        super.setUp()
+        VocelloUITestApp.shared.retain()
+    }
 
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
-        app = XCUIApplication()
-        // Pure UI-navigation smoke (no audio generation): skip the heavy on-launch engine
-        // model load so the accessibility server stays responsive and launches are
-        // fast/deterministic. Engine generation is covered by the headless bench harness.
-        app.launchEnvironment["QVOICE_IOS_DISABLE_ENGINE"] = "1"
-        app.launch()
-        dismissOnboardingIfPresent()
+        VocelloUITestApp.shared.resetToStudio()
     }
 
-    override func tearDown() {
-        app = nil
+    override class func tearDown() {
+        VocelloUITestApp.shared.release()
         super.tearDown()
     }
 
-    /// Launches and confirms the Studio tab + its Custom/Design/Clone mode control are present.
+    /// Confirms the Studio tab + its Custom/Design/Clone mode control are present.
     /// (Note: the screen-level `screen_generateStudio` identifier propagates onto the composer +
     /// pills, shadowing their own `textInput_*` / `studioChip_*` ids — so this asserts the mode
     /// segments, which keep their identifiers, rather than those shadowed ones.)
@@ -44,6 +41,7 @@ final class VocelloiOSSmokeUITests: XCTestCase {
                 && element("generateSection_clone").exists,
             "all three Custom/Design/Clone mode segments should be present"
         )
+        VocelloUITestApp.shared.captureScreenshot(named: "smoke-studio-surface")
     }
 
     /// Confirms each of the 4 tabs is reachable and becomes selected when tapped. (Uses the tab's
@@ -55,15 +53,19 @@ final class VocelloiOSSmokeUITests: XCTestCase {
             XCTAssertTrue(tabElement.waitForExistence(timeout: 10), "tab \(tab) should exist")
             tabElement.tap()
             XCTAssertTrue(isSelectedEventually(tabElement), "tapping \(tab) should select it")
+            VocelloUITestApp.shared.captureScreenshot(named: "smoke-tab-\(tab)")
         }
     }
 
     // MARK: - Helpers
 
-    /// Resolve an element by accessibility identifier across any element type
-    /// (SwiftUI surfaces vary the underlying XCUIElementType).
     private func element(_ identifier: String) -> XCUIElement {
-        app.descendants(matching: .any)[identifier].firstMatch
+        VocelloUITestApp.shared.element(identifier)
+    }
+
+    @discardableResult
+    private func waitFor(_ identifier: String, timeout: TimeInterval = 30) -> Bool {
+        VocelloUITestApp.shared.waitFor(identifier, timeout: timeout)
     }
 
     /// Poll an element's `isSelected` (the trait updates a beat after the tap).
@@ -74,31 +76,5 @@ final class VocelloiOSSmokeUITests: XCTestCase {
             usleep(200_000)
         }
         return e.isSelected
-    }
-
-    @discardableResult
-    private func waitFor(_ identifier: String, timeout: TimeInterval = 30) -> Bool {
-        element(identifier).waitForExistence(timeout: timeout)
-    }
-
-    /// First-run onboarding (3 pages) sits in front of the tabs on a fresh install — which
-    /// happens on every `xcodebuild test` reinstall, and can render a beat after launch.
-    /// Poll for either the main UI or onboarding rather than a one-shot wait; Skip completes
-    /// the whole flow, the CTA advances/completes as a fallback.
-    private func dismissOnboardingIfPresent() {
-        let studio = element("rootTab_studio")
-        let skip = element("onboarding_skip")
-        let cta = element("onboarding_cta")
-        let deadline = Date().addingTimeInterval(20)
-        while Date() < deadline {
-            if studio.exists { return }
-            if skip.exists {
-                skip.tap()
-                _ = studio.waitForExistence(timeout: 6)
-                return
-            }
-            if cta.exists { cta.tap() }
-            usleep(300_000)
-        }
     }
 }

--- a/docs/reference/ios-device-testing.md
+++ b/docs/reference/ios-device-testing.md
@@ -11,7 +11,8 @@ which drives the UI by pixels:
    summarizes. This is the real on-device entitlement/memory/RTF proof.
 2. **Thin XCUITest UI-flow smoke** (`VocelloiOSUITests`) — asserts the app launches and
    the 4-tab IA + Studio composer/mode-control are reachable, off the stable
-   `accessibilityIdentifier`s. Runs on a simulator (fast, no signing) or the device.
+   `accessibilityIdentifier`s. Runs on a paired physical device only (the Simulator is retired
+   for UI work; see §3).
 
 Why this exists: on-device generation is the never-CI-tested path (real Jetsam, real
 model download, the in-process engine + increased-memory entitlement). iPhone Mirroring is
@@ -156,12 +157,18 @@ Simulator is retired; see §3).** Run the `VocelloiOSUITests` suite **on the dev
 a run, e.g. `scripts/ios_device.sh ui-test VocelloiOSUITests/VocelloiOSSheetUITests`.
 
 `Tests/VocelloiOSUITests/` (target `VocelloiOSUITests`, host `VocelloiOS`):
+- `VocelloUITestApp.swift` — shared warm-app coordinator; keeps one app session alive across
+  non-cold tests and resets to Studio between cases.
 - `VocelloiOSSmokeUITests` — launch + 4-tab reachability + Custom/Design/Clone segments.
 - `VocelloiOSSheetUITests` — sheet regressions: voice select-and-close, preview-keeps-open,
   language select-and-close, brief confirm-closes.
+- `VocelloiOSColdGenerationUITests` — cold-launch real-generation test. Unlike the smoke suite,
+  this one kills the warm session, launches a fresh app with the engine enabled, types in Custom
+  mode, and waits for actual audio generation to complete.
 
-It does **not** generate audio (that's the harness above) — the IA + identifiers + sheet
-behaviour are what's under test.
+The smoke/sheet suites do **not** generate audio (that's the harness above) — the IA + identifiers +
+sheet behaviour are what's under test. The cold-generation suite is the exception: it proves a real
+on-device generation still works from a cold start.
 
 **Driving identifiers (important):** the screen-level `screen_generateStudio` identifier
 propagates onto its descendants, **shadowing** the Studio selector pills' `studioChip_*` ids
@@ -203,6 +210,9 @@ through refactors; the smoke + any agent UI checks depend on them.
 > — is **kept in the repo (inert, reversible) but is no longer part of the workflow**. Do UI
 > testing/control/review **on the device** via §2 (`scripts/ios_device.sh ui-test`). The text
 > below is retained for reference only.
+
+> **Do not follow the instructions below.** They document how the simulator path used to work
+> and are left in place only so the retirement decision and historical setup are discoverable.
 
 For **visual UI work** (layout, chrome, flows, keyboard behavior) the Simulator is the right
 tool — no device, no signing, no models, no Metal/MLX. On the simulator the app swaps to
@@ -268,9 +278,9 @@ Mirroring directly.
 | Level | Command | Proves |
 |-------|---------|--------|
 | Compile (app) | `scripts/build_foundation_targets.sh ios` | the in-process engine + harness compile |
-| Compile (UI test) | `xcodebuild build-for-testing -scheme VocelloiOS -destination 'platform=iOS Simulator,…' -derivedDataPath build/ios` | the test target compiles + is wired |
-| UI smoke | `xcodebuild test -scheme VocelloiOS -destination … -derivedDataPath build/ios` (or `scripts/ios_sim.sh ui-test`) | launch + IA reachable |
-| Sim UI review | `scripts/ios_sim.sh run` + `scripts/ios_sim.sh shot` | the full UI renders + is navigable with the fake engine (visual review — no device) |
+| Compile (UI test) | `xcodebuild build-for-testing -scheme VocelloiOS -destination 'platform=iOS,id=<udid>' -derivedDataPath build/ios` | the test target compiles + is wired for the device |
+| UI smoke | `scripts/ios_device.sh ui-test` | launch + IA reachable on a real device |
+| Interactive UI review | `scripts/ios_device.sh launch` + `scripts/ios_device.sh shot <path>` | the full UI renders over iPhone Mirroring for visual review |
 | On-device proof | `scripts/ios_device.sh bench "custom:speed:…"` | real generation, entitlement/memory headroom, RTF/`audioQC` |
 
 ## Still deferred

--- a/docs/reference/on-device-ui-testing-research-report.md
+++ b/docs/reference/on-device-ui-testing-research-report.md
@@ -1,0 +1,274 @@
+# On-Device iOS UI-Driven Testing: Tools, Plugins & MCPs Research Report
+
+> **Scope:** Evaluate tools and MCPs that can *drive* UI tests on a physical iOS device for the Vocello/QwenVoice project. The report covers native Apple frameworks, open-source cross-platform tools, AI-native alternatives, device-cloud options, and MCP-based integrations. Per project instructions, **no installation or configuration was performed** — this is research and recommendations only.
+>
+> **Update:** We are **not** implementing Appium or any additional MCP driver. The project is strengthening its existing XCUITest suite and adding screenshot-based diagnostics, so the Appium and cross-platform paths below are retained for reference only.
+
+---
+
+## 1. Executive Summary
+
+Vocello already has a solid, low-level on-device test foundation:
+
+- A headless generation harness via `scripts/ios_device.sh` for real audio/RTF/memory proof.
+- A thin XCUITest smoke suite (`Tests/VocelloiOSUITests`) that runs on-device.
+- iPhone Mirroring for human visual review.
+
+What is missing is a **natural-language, agent-driven UI layer** that can reliably tap, scroll, and assert on the physical iPhone without writing Swift for every new flow. This report compares the strongest candidates.
+
+### Top-line verdict
+
+| Tier | Recommendation |
+|------|----------------|
+| **Best immediate fit (native iOS, today)** | Keep investing in **XCUITest on-device** (`scripts/ios_device.sh ui-test`). It is already wired, requires no new infrastructure, and gives deterministic, fast feedback. |
+| **Best cross-platform / AI-agent path** | **Appium + the official `appium/appium-mcp` server** is the most credible MCP-native route to real-device iOS. It exposes session management, gestures, screenshots, and (opt-in) vision-based element finding to an LLM, but it requires WebDriverAgent signing and a stable MCP session lifecycle. |
+| **Best low-maintenance, no-code real-device coverage (if budget allows)** | **Drizz** — plain-English authoring, Vision AI execution, and self-healing on real iPhones. It is a paid SaaS, not an MCP, but it directly solves selector-maintenance pain. |
+| **Avoid for local physical iOS** | **Maestro** (officially simulator-only on iOS) and **mirror-pixel automation** (iPhone Mirroring + cua-driver) are not reliable enough to drive local physical iOS UI tests. |
+
+---
+
+## 2. Current Project Baseline
+
+From [`docs/reference/ios-device-testing.md`](ios-device-testing.md):
+
+- **Device:** iPhone 17 Pro paired via `devicectl` (CoreDevice), Developer Mode ON.
+- **Build/sign:** `scripts/ios_device.sh` using `QWENVOICE_DEVELOPMENT_TEAM`.
+- **Headless proof:** `bench` autorun launches the app with env specs and pulls telemetry.
+- **UI smoke:** `VocelloiOSUITests` runs through `xcodebuild test` on the device, relying on stable `accessibilityIdentifier`s (`rootTab_*`, `generateSection_*`, `bottomSheet_close`, `voicePickerRow_*`, etc.).
+- **Visual review:** iPhone Mirroring is used for observation, but synthetic clicks through macOS accessibility on the mirrored window are **unreliable** — the mirrored content is not a normal AX tree, and focus races make scripted tapping brittle.
+
+The next improvement should complement this baseline rather than replace it.
+
+---
+
+## 3. Evaluation Criteria
+
+| Criterion | Why it matters for Vocello |
+|-----------|-----------------------------|
+| **Real-device iOS support** | The project’s workflow is device-first; simulator-only tools are a non-starter for release confidence. |
+| **MCP / agent integration** | The user explicitly asked for MCPs or plugins that let an AI assistant drive tests via UI. |
+| **No/low code authoring** | Faster iteration for product/UI flows, but must still be deterministic enough for regression gating. |
+| **Determinism & flakiness** | Audio generation is already variable; the UI layer must not add noise. |
+| **Maintenance cost** | Stable accessibility identifiers already exist; a tool that ignores them and relies on pixels or AI must prove lower long-term cost. |
+| **Security / privacy** | Signed apps, device UDIDs, and Apple Developer credentials stay on the Mac; cloud options upload binaries and screenshots. |
+| **Cost & lock-in** | Open-source preferred where possible; SaaS acceptable for specific high-value coverage. |
+
+---
+
+## 4. Candidate Analysis
+
+### 4.1 Apple XCUITest (existing native path)
+
+**What it is:** Apple’s first-party UI testing framework, built into Xcode. Tests are Swift/Obj-C targets that run against the app via the XCTest runner.
+
+**Real-device support:** First-class. `xcodebuild test -destination 'platform=iOS,id=<udid>'` works today in this repo.
+
+**Pros:**
+
+- Already implemented; no new dependencies.
+- Fast and stable relative to wrapper frameworks.
+- Direct access to device APIs, orientation, app lifecycle, and app extensions.
+- Uses the project’s existing stable `accessibilityIdentifier`s.
+
+**Cons:**
+
+- Swift-only authoring; non-engineers cannot write tests.
+- Cannot tap system dialogs reliably (`addUIInterruptionMonitor` is flaky).
+- Simulator is faster, so teams often drift toward sim-only CI, reducing real-device confidence.
+- No MCP or natural-language interface natively.
+
+**Agent/MCP angle:** There is no official Apple MCP for XCUITest. The closest is the **`xcodebuildmcp` MCP** already referenced in `ios-device-testing.md`, but its tools (`build_run_sim`, `snapshot_ui`, `tap`) target the **simulator**, not the physical device.
+
+**Verdict:** Keep as the deterministic regression backbone. Add targeted tests for the Confirm-button picker flow and any other high-risk sheet interactions.
+
+---
+
+### 4.2 Appium + XCUITest Driver + `appium-mcp`
+
+**What it is:** Appium wraps Apple’s XCUITest via a WebDriverAgent (WDA) runner and exposes a WebDriver API. The official **`appium/appium-mcp`** MCP server turns that API into MCP tools that an LLM can call.
+
+**Real-device support:** Fully supported, but WDA must be built, signed, and deployed to the device. The MCP server has a dedicated `appium_prepare_ios_real_device` tool that downloads a WDA release, packages it as an IPA, and resigns it with a chosen provisioning profile.
+
+**Key MCP tools relevant to Vocello:**
+
+| Tool | Use case |
+|------|----------|
+| `select_device` | Pick the connected iPhone |
+| `appium_prepare_ios_real_device` | Sign & stage WDA |
+| `appium_session_management` | Create/attach/delete an Appium session |
+| `appium_app_lifecycle` | Install, launch, terminate Vocello by bundle ID |
+| `appium_find_element` | Locate elements by accessibility id / iOS predicate / class chain |
+| `appium_gesture` | Tap, scroll, swipe, long-press |
+| `appium_screenshot` / `appium_screen_recording` | Visual evidence |
+| `appium_ai` (opt-in) | Vision-based element finding from natural-language descriptions |
+| `appium_set_value`, `appium_get_text` | Form input and assertions |
+
+**Pros:**
+
+- True cross-platform (reuse concepts if Vocello ever ships Android).
+- MCP-native: an agent can discover devices, start sessions, take screenshots, and drive gestures.
+- Can attach to a session on a remote/cloud Appium grid (BrowserStack, Sauce Labs, etc.).
+- Optional AI vision (`appium_ai`) lets the agent fall back to visual cues when accessibility identifiers are insufficient.
+
+**Cons / risks:**
+
+- **Setup complexity:** WDA signing, provisioning profiles, and `devicectl`/Xcode 16+ interactions are non-trivial.
+- **Stateful session fragility:** Recent Claude Code versions (≥ 2.1.107) were reported to kill and respawn `stdio` MCP servers between tool calls, causing Appium sessions to be lost and remote device-farm sessions to leak ([anthropics/claude-code#51507](https://github.com/anthropics/claude-code/issues/51507)). This appears resolved or mitigated in later builds, but it is a critical integration risk.
+- **Speed overhead:** Each gesture traverses HTTP → WDA → XCTest, making it slower than native XCUITest.
+- **Reliance on accessibility tree:** Like XCUITest, Appium cannot see what XCTest cannot see.
+
+**Cost:** Open-source (Apache 2.0). Only cost is engineering time and (optionally) cloud device minutes.
+
+**Verdict:** **The strongest MCP-based option** if the team is willing to maintain a signed WDA and a persistent MCP/Appium server process. It gives an agent real-device control without replacing the existing XCUITest suite.
+
+---
+
+### 4.3 Other Appium MCP Servers
+
+| Server | Notes |
+|--------|-------|
+| `argneshu/appium-mcp-server` | Python-based; requires a running Appium server on `localhost:4723`. Less actively integrated than the official package. |
+| `mcp-appium-visual` | Adds visual recovery and an interactive CLI. Runs Appium + MCP together; useful for debugging but adds another dependency layer. |
+| `AlexGladkov/claude-in-mobile` | MCP for Android (ADB), **iOS Simulator** (`simctl`+WDA), desktop, and browser. Explicitly simulator-focused for iOS; not a real-device solution. |
+
+The official `appium/appium-mcp` is preferable because it bundles drivers, supports embedded local sessions, and has explicit real-device preparation.
+
+---
+
+### 4.4 Maestro
+
+**What it is:** YAML-based mobile UI automation with a reputation for readable flows and fast setup.
+
+**Real-device iOS support:** **Officially not supported.** Maestro’s docs and multiple 2025–2026 roundups state iOS **simulator** only; real-device `.ipa`/AppStore builds are not supported.
+
+**Workarounds:**
+
+- **TestingBot Maestro Cloud** and **BrowserStack App Automate** now run Maestro flows on real iOS devices, but this is cloud-hosted, not local-device.
+- **Community patches** (`devicelab-dev/maestro-ios-device`, `maestro-runner`) patch a local Maestro install with an XCTest bridge and port forwarding. These are unofficial and require specific Maestro 2.x versions.
+
+**Pros:**
+
+- Very readable YAML.
+- No complex locators; operates via visual/accessibility layer.
+- Great for Android real devices and iOS simulators.
+
+**Cons:**
+
+- Local physical iOS is a hack, not a productized path.
+- Community patch maintenance is uncertain and version-locked.
+- Adds JVM/Node tooling without solving the core Apple signing problem.
+
+**Verdict:** **Not recommended for local on-device iOS** at this stage. Consider only if the project later wants cloud-based Maestro execution through BrowserStack/TestingBot.
+
+---
+
+### 4.5 Drizz (AI-native Vision platform)
+
+**What it is:** A Vision AI mobile test automation platform. Tests are written in plain English; a VLM reads the screen and executes actions on real devices.
+
+**Real-device support:** Yes — iOS and Android real devices, simulators, and emulators. Can integrate with BrowserStack/LambdaTest clouds.
+
+**Pros:**
+
+- No selectors, no accessibility IDs, no Xcode test targets.
+- Self-healing when UI shifts.
+- Non-engineers can author tests.
+- Claims ~5% flakiness vs. 8–15% for locator-based frameworks.
+
+**Cons:**
+
+- **Paid SaaS** with per-run pricing; vendor lock-in.
+- No open MCP exposing device control to a local agent (it is a closed platform with API/CI integrations, not an LLM tool-calling server).
+- Vision-based execution can be slower and less deterministic than identifier-based XCUITest for simple, well-identified flows.
+- Screenshots of the app UI leave the local environment.
+
+**Verdict:** **Best fit if the goal is to reduce test-maintenance overhead and empower QA/Product to write real-device tests without code.** Keep it separate from the deterministic XCUITest smoke suite; use Drizz for broader journey coverage, not for the fast regression gate.
+
+---
+
+### 4.6 Device Clouds (BrowserStack, Sauce Labs, LambdaTest)
+
+These are execution venues, not authoring tools:
+
+| Cloud | Authoring frameworks | Real iOS devices | Notes |
+|-------|----------------------|------------------|-------|
+| BrowserStack App Automate | Appium, XCUITest, Maestro, Espresso | Yes | Largest fleet; good CI integrations. |
+| Sauce Labs | Appium, XCUITest, Espresso, Robotium | Yes | Enterprise governance features. |
+| LambdaTest | Appium, XCUITest, Selenium | Yes | Cost-competitive. |
+
+**Relevance to Vocello:** Useful for scaling device/OS matrix coverage without maintaining a device lab, but they do not solve the “drive tests via an AI assistant” requirement on their own. They are best paired with Appium or XCUITest.
+
+---
+
+### 4.7 macOS iPhone Mirroring + Accessibility/Visual Clicking
+
+**What it is:** The approach attempted recently — use `cua-driver` or AppleScript to click the iPhone Mirroring window from macOS.
+
+**Why it failed:**
+
+- The mirrored iPhone content does not expose a meaningful macOS accessibility tree.
+- Synthetic clicks at screen coordinates do not reliably route into the iOS app.
+- Focus races and disconnects make scripting fragile.
+
+**Verdict:** Keep Mirroring for **human observation only**. Do not build an automation layer on top of it.
+
+---
+
+## 5. Recommended Architecture
+
+A layered strategy that preserves today’s reliable baseline while adding agent-driven capabilities:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Layer 3: Optional broader coverage (paid / cloud)          │
+│  • Drizz plain-English journeys on real devices               │
+│  • BrowserStack/Sauce Labs device-matrix runs                 │
+├─────────────────────────────────────────────────────────────┤
+│  Layer 2: Agent-driven real-device exploration (MCP)        │
+│  • appium/appium-mcp + Appium + XCUITest driver             │
+│  • Drive the physical iPhone with natural-language prompts    │
+│  • Use for exploratory checks, screenshots, ad-hoc flows      │
+├─────────────────────────────────────────────────────────────┤
+│  Layer 1: Deterministic regression backbone (existing)      │
+│  • XCUITest smoke suite via scripts/ios_device.sh ui-test   │
+│  • Stable accessibilityIdentifier-based assertions            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Immediate next steps (if approved)
+
+1. **Strengthen Layer 1:** Update `VocelloiOSSheetUITests` for the new Confirm-button behavior (tap Confirm, assert `selectedID` change, dismiss).
+2. **Pilot Layer 2:** Install `appium/appium-mcp` in a disposable local test (not in this repo yet) and run a minimal real-device flow: select device → prepare WDA → launch Vocello → tap a known `accessibilityIdentifier` → screenshot → terminate. This validates WDA signing and MCP session stability with the current Claude Code version.
+3. **Decide on Layer 3:** Evaluate Drizz only after Layer 2 proves the maintenance burden; use a free trial against a non-production build.
+
+---
+
+## 6. Decision Matrix
+
+| Need | Recommended tool | Why |
+|------|------------------|-----|
+| Fast, deterministic regression on device | **XCUITest** | Already wired; lowest overhead. |
+| MCP/agent-driven real-device UI control | **Appium + `appium-mcp`** | Only credible MCP-native path to physical iOS. |
+| Plain-English test authoring, minimal maintenance | **Drizz** | Best UX, but paid and closed. |
+| Cloud device matrix without owning hardware | **BrowserStack / Sauce Labs / LambdaTest** | Pair with Appium or XCUITest. |
+| Quick YAML flows on iOS simulator | **Maestro** | Excellent, but not for local real device. |
+| Clicking the iPhone Mirroring window from macOS | **None** | Unreliable; use only for observation. |
+
+---
+
+## 7. References
+
+- Vocello project: [`docs/reference/ios-device-testing.md`](ios-device-testing.md)
+- Official Appium MCP server: https://github.com/appium/appium-mcp
+- Appium XCUITest real-device configuration: https://appium.github.io/appium-xcuitest-driver/latest/preparation/real-device-config/
+- Claude Code MCP process-lifecycle issue: https://github.com/anthropics/claude-code/issues/51507
+- Maestro iOS physical-device limitations (2026 comparison): https://www.drizz.dev/post/best-mobile-test-automation-tools
+- Maestro iOS device community patch: https://github.com/devicelab-dev/maestro-ios-device
+- Drizz product & comparisons: https://www.drizz.dev/
+- BrowserStack Maestro on real iOS: https://www.browserstack.com/guide/maestro-real-ios-device-testing
+- TestingBot Maestro real iOS devices: https://testingbot.com/blog/maestro-physical-device-testing
+- XCUITest vs Appium vs Drizz comparison: https://www.drizz.dev/post/xcuitest-vs-appium-vs-drizz
+
+---
+
+*Report prepared: 2026-06-15. No tools were installed or configured during this research.*

--- a/docs/reference/on-device-ui-testing-research-report.md
+++ b/docs/reference/on-device-ui-testing-research-report.md
@@ -35,6 +35,13 @@ From [`docs/reference/ios-device-testing.md`](ios-device-testing.md):
 - **Build/sign:** `scripts/ios_device.sh` using `QWENVOICE_DEVELOPMENT_TEAM`.
 - **Headless proof:** `bench` autorun launches the app with env specs and pulls telemetry.
 - **UI smoke:** `VocelloiOSUITests` runs through `xcodebuild test` on the device, relying on stable `accessibilityIdentifier`s (`rootTab_*`, `generateSection_*`, `bottomSheet_close`, `voicePickerRow_*`, etc.).
+  - `VocelloUITestApp.swift` is the shared warm-app coordinator that keeps one app session alive
+    across smoke/sheet tests and resets to Studio between cases.
+  - `VocelloiOSSmokeUITests` covers launch + 4-tab reachability.
+  - `VocelloiOSSheetUITests` covers voice/language/delivery/brief sheet regressions.
+  - `VocelloiOSColdGenerationUITests` is the cold-launch exception: it kills the warm session,
+    launches a fresh app with the engine enabled, and asserts that a real on-device generation
+    completes.
 - **Visual review:** iPhone Mirroring is used for observation, but synthetic clicks through macOS accessibility on the mirrored window are **unreliable** — the mirrored content is not a normal AX tree, and focus races make scripted tapping brittle.
 
 The next improvement should complement this baseline rather than replace it.
@@ -237,9 +244,10 @@ A layered strategy that preserves today’s reliable baseline while adding agent
 
 ### Immediate next steps (if approved)
 
-1. **Strengthen Layer 1:** Update `VocelloiOSSheetUITests` for the new Confirm-button behavior (tap Confirm, assert `selectedID` change, dismiss).
-2. **Pilot Layer 2:** Install `appium/appium-mcp` in a disposable local test (not in this repo yet) and run a minimal real-device flow: select device → prepare WDA → launch Vocello → tap a known `accessibilityIdentifier` → screenshot → terminate. This validates WDA signing and MCP session stability with the current Claude Code version.
-3. **Decide on Layer 3:** Evaluate Drizz only after Layer 2 proves the maintenance burden; use a free trial against a non-production build.
+1. ~~**Strengthen Layer 1:** Update `VocelloiOSSheetUITests` for the new Confirm-button behavior (tap Confirm, assert `selectedID` change, dismiss).~~ **Done** — Confirm buttons are unified across voice/delivery/language pickers and the voice-brief sheet, with matching assertions in `VocelloiOSSheetUITests`.
+2. **Extend Layer 1:** Harden `VocelloiOSColdGenerationUITests` against launch-time flakiness and add coverage for Design/Clone mode cold generation if those modes become critical paths.
+3. **Pilot Layer 2:** Install `appium/appium-mcp` in a disposable local test (not in this repo yet) and run a minimal real-device flow: select device → prepare WDA → launch Vocello → tap a known `accessibilityIdentifier` → screenshot → terminate. This validates WDA signing and MCP session stability with the current Claude Code version.
+4. **Decide on Layer 3:** Evaluate Drizz only after Layer 2 proves the maintenance burden; use a free trial against a non-production build.
 
 ---
 

--- a/docs/reference/telemetry-and-benchmarking.md
+++ b/docs/reference/telemetry-and-benchmarking.md
@@ -13,8 +13,9 @@ If anything here disagrees with the code, the code wins — fix this file.
 > drive a generation, then read the JSONL this system writes + aggregate with
 > `summarize_generation_telemetry.py`. Benchmarking + output‑quality checks are **first‑class**:
 > committed benchmark/QC scripts, baselines, and summaries are permitted (bounded by the
-> `benchmarks/` cap). Only the **XCUITest test bundle** stays retired
-> (`scripts/check_project_inputs.sh`).
+> `benchmarks/` cap). Only the old **simulator-only XCUITest path** stays retired
+> (`scripts/check_project_inputs.sh`); on-device UI testing is active and documented in
+> `docs/reference/ios-device-testing.md`.
 
 ---
 
@@ -482,10 +483,10 @@ The monitor observes the simulated event and the marks land on that generation's
 `python3 scripts/summarize_generation_telemetry.py` → confirm non‑zero `trims`/`pressure` and inspect
 `physFoot` + the GPU‑by‑stage block.
 
-> **Caveat:** on the forced floor tier, **Quality can be downgraded to Speed** by the OOM fallback in
-> `loadModel(id:)`. The row's `modelID` reveals the actual variant served — check it before attributing
-> a Quality cell. The forced tier changes real behavior **only while the env is set**; unset it for
-> normal use.
+> **Caveat:** on the forced floor tier, a Quality load that cannot fit will surface as an error rather
+> than silently falling back to Speed. The row's `modelID` reveals the actual variant served — check it
+> before attributing a Quality cell. The forced tier changes real behavior **only while the env is set**;
+> unset it for normal use.
 
 **Watch for OOM regressions** when optimizing the backend: a rising `physFoot` peak, GPU‑stage peak,
 or any `hardTrim` in `trims` means a run is shedding model state under pressure — the early OOM signal.

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -1,5 +1,12 @@
 # Vocello 2.0.0
 
+> **Editor's note (post-2.0.0).** This document is the original release note for Vocello 2.0.0.
+> It is preserved as a historical record. Several scripts and features referenced below
+> (`scripts/uitest.sh`, `scripts/antigravity_voice_review.sh`, `vocello review`, `CONTRIBUTING.md`,
+> `docs/reference/testing-overview.md`, `docs/reference/antigravity-voice-review.md`,
+> `docs/reference/benchmark-baselines.json`) were removed or superseded after this release;
+> current conventions are in [`AGENTS.md`](../../AGENTS.md) and the telemetry/benchmarking reference.
+
 Vocello 2.0.0 is the first stable release of the rewritten, macOS 26-native, on-device voice generation app — formerly shipped as QwenVoice. Everything runs locally on Apple Silicon via MLX; no audio leaves the Mac unless you export it. This release replaces both `v1.2.3` (the macOS 15-compatible legacy line) and `v2.0.0-beta.1` as the recommended download.
 
 > **Upgrading from 2.0.0-beta.1?** Download the new DMG below and drag `Vocello.app` to `/Applications` (replacing the beta). Your installed models, history, and saved voices live in `~/Library/Application Support/QwenVoice/` and carry over automatically — no re-download needed.
@@ -39,15 +46,15 @@ Beta 1 shipped 2026-05-11. Between then and 2.0.0 final:
 - **Streaming preview enabled production-wide.** All eight user-facing call sites now run with `shouldStream: true`. Decoder-level fix (`DecoderBlockUpsample.step` now uses an input-side context buffer instead of an output-side overlap-and-add accumulator) eliminates LSB drift between streaming and batch paths. Several streaming-engagement race conditions on warm-after-cold generation were closed (stale buffer completions clobbering counters, AVAudioEngine references not nil'd on teardown).
 - **Voice Cloning configuration card reworked.** A single-row tappable warning chip replaces the wrapping `Label` row inside the saved-voice panel, so the Transcript field stays inside the fixed 184 pt configuration slot regardless of warning state. The Speed/Quality model picker no longer renders a stray keyboard-focus halo on screen appearance.
 - **Voice-cloning reference duration warnings re-based.** The 10-20 s sweet-spot copy was clarified; soft-warn moved from >20 s → >30 s; a new hard cap at >60 s mirrors Apple-side guidance for cloning references. The "Reference quality may be poor" copy was softened to "Reference outside recommended range."
-- **Antigravity CLI migration.** Google retired Gemini CLI; the perceptual-review pipeline now runs through `agy` (App Store Connect-style auth, default model). New script: `scripts/antigravity_voice_review.sh`. New runbook: [`docs/reference/antigravity-voice-review.md`](https://github.com/PowerBeef/QwenVoice/blob/v2.0.0/docs/reference/antigravity-voice-review.md). Old `gemini-review` script + runbook stay as one-release deprecation shims.
-- **Bench harness expanded** to 24-cell coverage at n=3 (`docs/reference/benchmark-baselines.json` schema v3) with regression-gated `bench-compare`. Paired-signal reading rules (`ms` vs `rtf`) clarified for triage.
+- **Antigravity CLI migration.** Google retired Gemini CLI; the perceptual-review pipeline now runs through `agy` (App Store Connect-style auth, default model). New script: `scripts/antigravity_voice_review.sh` and runbook `docs/reference/antigravity-voice-review.md` were added for the 2.0 line; both were later removed. Old `gemini-review` script + runbook stay as one-release deprecation shims.
+- **Bench harness expanded** to 24-cell coverage at n=3 (benchmark-baselines schema v3) with regression-gated `bench-compare`. Paired-signal reading rules (`ms` vs `rtf`) clarified for triage.
 - **Smoke runbooks for Settings, History, Saved Voices** added alongside the existing per-mode generation runbooks.
 
 ## Notes for contributors
 
-> **Editor's note (post-2.0.0).** The links in this section are permalinks to the `v2.0.0` tag and are kept as-is for history. The files have since been removed from `main`; the current equivalents are: contributor/build conventions → [`AGENTS.md`](../../AGENTS.md); testing/benchmark strategy → [`docs/reference/telemetry-and-benchmarking.md`](../reference/telemetry-and-benchmarking.md); and the `antigravity_voice_review.sh` / `uitest.sh` review scripts were superseded by the `vocello review` CLI command (see [`docs/reference/cli.md`](../reference/cli.md)).
+> **Editor's note (post-2.0.0).** The links in this section are permalinks to the `v2.0.0` tag and are kept as-is for history. The files have since been removed from `main`; the current equivalents are: contributor/build conventions → [`AGENTS.md`](../../AGENTS.md); testing/benchmark strategy → [`docs/reference/telemetry-and-benchmarking.md`](../reference/telemetry-and-benchmarking.md); and the review scripts mentioned below were removed — see [`docs/reference/cli.md`](../reference/cli.md) for the current CLI capabilities.
 
-Repo conventions for the 2.0 line — agent guide pointer, build script + single-resident policy, the three runtime data-folder tiers, and the "CI is scoped to release packaging only" carve-out — are documented in [`CONTRIBUTING.md`](https://github.com/PowerBeef/QwenVoice/blob/v2.0.0/CONTRIBUTING.md). Testing strategy is in [`docs/reference/testing-overview.md`](https://github.com/PowerBeef/QwenVoice/blob/v2.0.0/docs/reference/testing-overview.md).
+Repo conventions for the 2.0 line — agent guide pointer, build script + single-resident policy, the three runtime data-folder tiers, and the "CI is scoped to release packaging only" carve-out — are documented in [`AGENTS.md`](../../AGENTS.md). Testing strategy is in [`docs/reference/telemetry-and-benchmarking.md`](../reference/telemetry-and-benchmarking.md).
 
 ## Known limitations
 
@@ -55,7 +62,7 @@ Repo conventions for the 2.0 line — agent guide pointer, build script + single
 - **Quality (8-bit) models on 8 GB Macs** are still tight even with the new memory-pressure response. Speed is the recommended default; the Quality→Speed OOM fallback covers most cases but expect occasional swap pressure under sustained generation.
 - **iPhone target:** the iOS code in this repo stays compile-safe, but no TestFlight build is attached to this GitHub Release. iPhone work continues on a separate distribution path.
 - **Voice Cloning is reference-driven.** Only clone voices you own or have explicit permission to clone.
-- **Subjective quality varies by reference.** A perceptual review tool is in-tree (`scripts/uitest.sh antigravity-review <wav>`) for testers who want cell-by-cell comparison.
+- **Subjective quality varies by reference.** Perceptual review is done with the listening-pass workflow described in `docs/reference/telemetry-and-benchmarking.md`.
 
 ## Install
 

--- a/project.yml
+++ b/project.yml
@@ -434,3 +434,7 @@ targets:
         GENERATE_INFOPLIST_FILE: YES
         TARGETED_DEVICE_FAMILY: "1"
         SUPPORTS_MACCATALYST: NO
+        # UI tests are inherently main-thread bound and touch Objective-C XCTest/XCUIAutomation
+        # APIs that are annotated @MainActor. Use minimal concurrency checking so the test code
+        # can stay focused on flows instead of actor isolation boilerplate.
+        SWIFT_STRICT_CONCURRENCY: minimal

--- a/scripts/ios_device.sh
+++ b/scripts/ios_device.sh
@@ -482,6 +482,7 @@ cmd_ui_test() {
   local dev; dev="$(resolve_device)"
   note "running VocelloiOSUITests on device $dev (signed XCUITest)${only:+ — only $only}"
   mkdir -p "$DERIVED"
+  export UI_TEST_SCREENSHOT_DIR="$DERIVED/uitest-screenshots"
   local log="$DERIVED/device-uitest.log"
   local -a only_args=()
   [[ -n "$only" ]] && only_args=( -only-testing:"$only" )

--- a/scripts/ios_sim.sh
+++ b/scripts/ios_sim.sh
@@ -229,6 +229,7 @@ cmd_ui_test() {
   local udid; udid="$(resolve_sim)"
   note "running VocelloiOSUITests on the simulator [$udid]"
   mkdir -p "$DERIVED"
+  export UI_TEST_SCREENSHOT_DIR="$DERIVED/uitest-screenshots"
   local log="$DERIVED/sim-uitest.log"
   set +e
   xcodebuild test \


### PR DESCRIPTION
This PR bundles the recent iOS UI polish, test hardening, and documentation cleanup:

- Unified Confirm header buttons across Voice, Delivery, Language pickers and the Voice-design brief sheet.
- Added `IOSScrollView` with no-rubber-band scrolling, subtle indicator, and bottom fade under the TabDock.
- Added on-device iOS UI-test harness (`VocelloUITestApp`, `VocelloiOSColdGenerationUITests`) and hardened the cold-generation test against flakiness.
- Updated `AGENTS.md`, iOS testing reference docs, README, and v2.0.0 release notes for accuracy.

All on-device UI tests passed (7/7).