### PR TITLE
Add GitHub Sponsors and Ko-fi donation options

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 github: PowerBeef
+ko_fi: PowerBeef

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: PowerBeef

--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ stdout is machine-readable (an output path, or JSON with `--json`); progress not
   </tr>
 </table>
 
+## Support
+
+If Vocello is useful to you, consider [sponsoring development on GitHub](https://github.com/sponsors/PowerBeef).
+
 ## License
 
 Vocello is available under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <img src="https://img.shields.io/badge/Apple%20Silicon-required-111827?style=flat-square&logo=apple" alt="Apple Silicon">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue?style=flat-square" alt="License: MIT"></a>
   <a href="https://github.com/PowerBeef/QwenVoice/releases/tag/v2.1.0"><img src="https://img.shields.io/github/downloads/PowerBeef/QwenVoice/v2.1.0/total?label=2.1.0%20downloads&style=flat-square" alt="Downloads"></a>
+  <a href="https://github.com/sponsors/PowerBeef"><img src="https://img.shields.io/github/sponsors/PowerBeef?label=Sponsor&color=ea4aaa&style=flat-square" alt="Sponsor"></a>
 </p>
 
 <p align="center">
@@ -217,7 +218,12 @@ stdout is machine-readable (an output path, or JSON with `--json`); progress not
 
 ## Support
 
-If Vocello is useful to you, consider [sponsoring development on GitHub](https://github.com/sponsors/PowerBeef).
+If Vocello is useful to you, you can support development:
+
+- **[GitHub Sponsors](https://github.com/sponsors/PowerBeef)** — recurring or one-time sponsorship (GitHub account required; 100% goes to the maintainer).
+- **[Ko-fi](https://ko-fi.com/PowerBeef)** — quick one-time tip by card or PayPal (no account required).
+
+Maintainer setup checklist: [`docs/reference/donations-setup.md`](docs/reference/donations-setup.md).
 
 ## License
 

--- a/docs/reference/donations-setup.md
+++ b/docs/reference/donations-setup.md
@@ -1,0 +1,59 @@
+# Donations setup (maintainer checklist)
+
+Vocello exposes two donation paths for Canadian maintainers:
+
+| Platform | Audience | Fees (tips) | Payout |
+| --- | --- | --- | --- |
+| [GitHub Sponsors](https://github.com/sponsors/PowerBeef) | GitHub users | 0% platform fee (personal account) | Canadian bank via Stripe |
+| [Ko-fi](https://ko-fi.com/PowerBeef) | Everyone (guest checkout) | 0% platform fee on tips | Stripe and/or PayPal |
+
+Repo wiring is already in place:
+
+- `.github/FUNDING.yml` — GitHub **Sponsor** button on the repository
+- `README.md` — Support section and sponsor badge
+- `website/src/data/credits.js` — footer links on [vocello.vercel.app](https://vocello.vercel.app/)
+
+Complete the steps below on the `PowerBeef` accounts so those links accept payments.
+
+## 1. GitHub Sponsors (~15 minutes)
+
+1. Sign in as **PowerBeef** and open [github.com/sponsors](https://github.com/sponsors).
+2. Click **Get started** and create a sponsored developer profile.
+3. Enable **two-factor authentication** on the GitHub account if it is not already on.
+4. Add a short bio (what Vocello is, that it is local/open source on Apple Silicon).
+5. Create at least one sponsorship tier (a single **$5/month** tier plus a **custom amount** one-time option is enough to start).
+6. Connect payout details:
+   - **Country:** Canada
+   - **Bank:** Canadian chequing account (transit, institution, account number)
+   - **Tax:** submit **W-8BEN** when prompted (country of residence Canada; foreign tax ID = SIN)
+7. Submit the profile and wait for GitHub review if required.
+8. Verify: open [github.com/PowerBeef/QwenVoice](https://github.com/PowerBeef/QwenVoice) and confirm the **Sponsor** button appears in the sidebar.
+
+## 2. Ko-fi (~10 minutes)
+
+1. Sign up at [ko-fi.com](https://ko-fi.com) and claim the **`PowerBeef`** page URL (`ko-fi.com/PowerBeef`).
+2. Set display name to **Vocello** (or **PowerBeef / Vocello**).
+3. Add a one-line description, for example: *Local, private text-to-speech for Apple Silicon. Open source.*
+4. Under **Payment settings**, connect **Stripe** (recommended) and optionally **PayPal** for donors who prefer it.
+5. Complete Stripe identity verification with your Canadian bank details.
+6. Leave Ko-fi on the **free** plan unless you want Gold branding features; tips stay at 0% platform fee.
+7. Verify: open [ko-fi.com/PowerBeef](https://ko-fi.com/PowerBeef) in a private window and run a **$1 test tip** (refund yourself afterward if you like).
+
+## 3. After both are live
+
+- Merge the donations PR so `main` carries the updated `FUNDING.yml`, README, and website footer.
+- Redeploy the marketing site (Vercel auto-deploys on push to `main`).
+- Optional: mention support in the next GitHub Release notes.
+
+## Tax note (Canada)
+
+GitHub Sponsors and Ko-fi/Stripe do not withhold Canadian income tax. Track payouts for your own CRA reporting. GitHub Sponsors uses a U.S. W-8BEN for treaty purposes; Ko-fi payouts flow through Stripe/PayPal with their own tax forms.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| No **Sponsor** button on the repo | Confirm `FUNDING.yml` is on `main` and the GitHub Sponsors profile is **published**. |
+| Ko-fi link shows a generic landing page | The `PowerBeef` page is not claimed yet; finish Ko-fi signup with that username. |
+| Stripe asks for extra verification | Normal for first payout; allow 2–7 days. |
+| Donor cannot use PayPal on Ko-fi | Connect PayPal in Ko-fi payment settings, or point them to GitHub Sponsors instead. |

--- a/website/src/data/credits.js
+++ b/website/src/data/credits.js
@@ -9,3 +9,5 @@ export const CREDITS = [
 export const REPO = "https://github.com/PowerBeef/QwenVoice";
 export const RELEASE_LATEST = "https://github.com/PowerBeef/QwenVoice/releases/latest";
 export const RELEASE_V1 = "https://github.com/PowerBeef/QwenVoice/releases/tag/v1.2.3";
+export const SPONSOR_GITHUB = "https://github.com/sponsors/PowerBeef";
+export const SPONSOR_KOFI = "https://ko-fi.com/PowerBeef";

--- a/website/src/sections/Footer.jsx
+++ b/website/src/sections/Footer.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { REPO } from "../data/credits.js";
+import { REPO, SPONSOR_GITHUB, SPONSOR_KOFI } from "../data/credits.js";
 
 export const Footer = () => (
   <footer className="footer">
@@ -33,6 +33,13 @@ export const Footer = () => (
               <li><a href={`${REPO}/releases`} target="_blank" rel="noreferrer">Releases</a></li>
               <li><a href={`${REPO}/blob/main/docs/qwen_tone.md`} target="_blank" rel="noreferrer">Docs</a></li>
               <li><a href={`${REPO}/blob/main/LICENSE`} target="_blank" rel="noreferrer">MIT License</a></li>
+            </ul>
+          </div>
+          <div className="footer-col">
+            <h5>Support</h5>
+            <ul>
+              <li><a href={SPONSOR_GITHUB} target="_blank" rel="noreferrer">GitHub Sponsors</a></li>
+              <li><a href={SPONSOR_KOFI} target="_blank" rel="noreferrer">Ko-fi</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a dual donation path for Vocello (optimized for a Canadian maintainer and low-friction donors):

| Platform | Where it appears | Best for |
| --- | --- | --- |
| **GitHub Sponsors** | Repo Sponsor button, README badge + Support section, website footer | GitHub users (0% platform fee) |
| **Ko-fi** | `FUNDING.yml`, README, website footer | Quick one-time tips by card/PayPal (no account required) |

### Files changed

- **`.github/FUNDING.yml`** — `github: PowerBeef` + `ko_fi: PowerBeef`
- **`README.md`** — Sponsor badge, Support section with both links
- **`website/src/data/credits.js`** — `SPONSOR_GITHUB` / `SPONSOR_KOFI` constants
- **`website/src/sections/Footer.jsx`** — new Support column
- **`docs/reference/donations-setup.md`** — step-by-step maintainer checklist (Canada-specific: W-8BEN, Stripe/PayPal)

## Maintainer action required (~25 min)

I cannot create payment accounts on your behalf (banking, tax forms, and identity verification require your login). After merge, follow [`docs/reference/donations-setup.md`](docs/reference/donations-setup.md):

1. **GitHub Sponsors** — [github.com/sponsors](https://github.com/sponsors) → publish profile for `PowerBeef`
2. **Ko-fi** — claim [ko-fi.com/PowerBeef](https://ko-fi.com/PowerBeef) → connect Stripe (and optionally PayPal)

Until those accounts are live, the links will 404 or show placeholder pages. The repo wiring is ready once you finish signup.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41a41deb-2bb0-4fbc-840b-3f1c95de2f00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41a41deb-2bb0-4fbc-840b-3f1c95de2f00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

