### PR TITLE
Harden iOS benchmark result gating

### DIFF
--- a/scripts/test_check_ios_ui_benchmark.py
+++ b/scripts/test_check_ios_ui_benchmark.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -13,6 +14,7 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
 CHECK = ROOT / "scripts" / "check_ios_ui_benchmark.py"
+RUNNER = ROOT / "scripts" / "ui_test.sh"
 RUN_ID = "ios-ui-order-fixture"
 
 
@@ -102,6 +104,75 @@ class CheckIOSUIBenchmarkTests(unittest.TestCase):
 
         result = self.run_checker(self.expected_order, mark_warning)
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_audio_qc_failure_fails(self) -> None:
+        def mark_failure(rows: list[dict]) -> None:
+            rows[0]["audioQC"] = {
+                "verdict": "fail",
+                "flags": ["dropout:excess2(2/0)"],
+            }
+
+        result = self.run_checker(self.expected_order, mark_failure)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("audioQC failed", result.stdout + result.stderr)
+
+    def test_runner_does_not_mask_benchmark_gate_failure_in_or_list(self) -> None:
+        text = RUNNER.read_text(encoding="utf-8")
+        prefix = "validate_ios_benchmark() {\n"
+        start = text.index(prefix)
+        end = text.index("\n}\n", start) + 3
+        function = text[start:end]
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            scripts = root / "scripts"
+            output = root / "output"
+            scripts.mkdir()
+            output.mkdir()
+
+            pull = scripts / "ios_device.sh"
+            pull.write_text(
+                "#!/usr/bin/env bash\nmkdir -p \"$2/engine\"\n",
+                encoding="utf-8",
+            )
+            pull.chmod(0o755)
+            (scripts / "check_ios_ui_benchmark.py").write_text(
+                "print('fixture gate failure')\nraise SystemExit(7)\n",
+                encoding="utf-8",
+            )
+            (scripts / "summarize_generation_telemetry.py").write_text(
+                "from pathlib import Path\nPath(__file__).with_name('summarizer-ran').touch()\n",
+                encoding="utf-8",
+            )
+
+            shell = f"""
+set -euo pipefail
+ROOT_DIR={shlex.quote(str(root))}
+out={shlex.quote(str(output))}
+run_id=fixture-run
+modes=custom
+lengths=short
+warm=1
+label=fixture
+{function}
+if validate_ios_benchmark; then
+  touch "$out/passed"
+  exit 0
+else
+  exit $?
+fi
+"""
+            result = subprocess.run(
+                ["bash", "-c", shell],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertFalse((output / "passed").exists())
+            self.assertFalse((scripts / "summarizer-ran").exists())
+            self.assertIn("fixture gate failure", result.stdout + result.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/ui_test.sh
+++ b/scripts/ui_test.sh
@@ -276,12 +276,16 @@ validate_macos_benchmark() {
 validate_ios_benchmark() {
   local diagnostics="$out/diagnostics"
   rm -rf "$diagnostics"
-  "$ROOT_DIR/scripts/ios_device.sh" pull "$diagnostics" >/dev/null
-  python3 "$ROOT_DIR/scripts/check_ios_ui_benchmark.py" "$diagnostics" \
-    --run-id "$run_id" --modes "$modes" --lengths "$lengths" --warm "$warm" \
-    | tee "$out/benchmark-gate.txt"
+  "$ROOT_DIR/scripts/ios_device.sh" pull "$diagnostics" >/dev/null \
+    || return 1
+  if ! python3 "$ROOT_DIR/scripts/check_ios_ui_benchmark.py" "$diagnostics" \
+      --run-id "$run_id" --modes "$modes" --lengths "$lengths" --warm "$warm" \
+      | tee "$out/benchmark-gate.txt"; then
+    return 1
+  fi
   python3 "$ROOT_DIR/scripts/summarize_generation_telemetry.py" "$diagnostics" \
     --label "${label:-$run_id}" >"$out/telemetry-summary.txt" 2>&1 || true
+  return 0
 }
 
 if [[ "$platform" == "macos" ]]; then
@@ -338,7 +342,8 @@ else
   run_xcodebuild xcodebuild test \
     -project "$PROJECT" -scheme VocelloiOSUI -configuration Release \
     -destination "id=$device" -derivedDataPath "$IOS_DERIVED" \
-    -resultBundlePath "$result" -only-testing:"$only_test" \
+    -resultBundlePath "$result" -collect-test-diagnostics never \
+    -only-testing:"$only_test" \
     -allowProvisioningUpdates DEVELOPMENT_TEAM="$team" CODE_SIGN_STYLE=Automatic \
     || die "physical-iPhone XCUITest failed (see $out/xcodebuild.log)"
 


### PR DESCRIPTION
## What changed

- preserve failures from the physical-iPhone diagnostics pull and benchmark telemetry validator instead of allowing a later optional summary to mask them
- add regression coverage for an `audioQC=fail` row and for the Bash OR-list execution context that caused the false PASS
- disable Xcode's unrelated verbose device diagnostics collection so an already-completed UI run cannot block on an interactive password prompt

## Root cause

`validate_ios_benchmark` was called from an OR-list. Bash therefore suppressed `errexit` inside the function. A failing telemetry validator continued into an optional summarizer whose successful exit status made the function return success, after which `run.json` was incorrectly written as passed.

## Validation

- `python3 -m unittest scripts.test_check_ios_ui_benchmark`
- `scripts/check_test_workflows.sh`
- `./scripts/check_project_inputs.sh`
- physical-iPhone smoke PASS
- focused 4-take physical-iPhone benchmark PASS
- fresh ordered 29-take physical-iPhone benchmark PASS (29 unique rows, audio QC PASS, no crash delta)
- `scripts/ios_device.sh gate` PASS

UI evidence remains local and untracked; ordinary CI stays deterministic-only.