### PR TITLE
Refresh README and contribution guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to Vocello
+
+Thank you for helping improve Vocello. This guide is the human contribution path. Repository automation and Codex tasks use the additional durable instructions in [`AGENTS.md`](AGENTS.md).
+
+## Before starting
+
+- Use an Apple Silicon Mac with Xcode 26.
+- Read the current checkpoint in [`docs/development-progress.md`](docs/development-progress.md).
+- Check existing [issues](https://github.com/PowerBeef/QwenVoice/issues) and pull requests before starting overlapping work.
+- Keep changes focused. Do not mix unrelated refactors into a bug fix or feature.
+
+Models, a physical iPhone, and UI automation are not required for ordinary source changes. They are needed only for the explicit model or frontend acceptance lane being exercised.
+
+## Build and verify
+
+Repository scripts are the authoritative interface:
+
+```sh
+./scripts/regenerate_project.sh        # required after project.yml changes
+./scripts/check_project_inputs.sh
+scripts/macos_test.sh test
+./scripts/build.sh build
+./scripts/build_foundation_targets.sh ios
+```
+
+The final four deterministic commands are sufficient for ordinary pull requests. Run only the checks relevant to the files you changed, then state exactly what you ran in the pull request.
+
+The Xcode project is generated from [`project.yml`](project.yml). Never edit `QwenVoice.xcodeproj/project.pbxproj` directly. Native output belongs under the paths declared by [`config/build-output-policy.json`](config/build-output-policy.json); do not add another DerivedData root or a `.build` directory inside vendored source.
+
+## Platform and UI rules
+
+- macOS and iOS application UI acceptance uses XCUITest only.
+- iOS runtime and UI work uses a paired physical iPhone. Simulator is not supported for Vocello.
+- UI suites run only when frontend acceptance is explicitly needed:
+
+```sh
+scripts/ui_test.sh macos smoke
+scripts/ui_test.sh ios smoke
+```
+
+- Preserve stable accessibility identifiers on real visible controls.
+- Do not add hidden test routes, seeded production UI, invisible markers, fixed-coordinate actions, or fixed sleeps.
+
+See [`docs/reference/testing-runbook.md`](docs/reference/testing-runbook.md) for platform lanes and prerequisites.
+
+## Source and documentation expectations
+
+- Code and machine-readable contracts take precedence over prose.
+- Update relevant documentation in the same change when behavior, public facts, commands, platform support, models, or test contracts change.
+- Keep dependencies pinned. MLX dependency changes require the backend review and benchmark process in [`.agents/backend-mlx.md`](.agents/backend-mlx.md).
+- Do not commit prompts, transcripts, usernames, device identifiers, absolute paths, secrets, raw telemetry, WAV evidence, screenshots from test results, traces, or `.xcresult` bundles.
+- Successful benchmark runners publish only their compact privacy-safe record. They never commit or push it automatically.
+
+## Pull request checklist
+
+- [ ] The change has one clear purpose.
+- [ ] `project.yml` was regenerated if needed.
+- [ ] Relevant deterministic checks pass.
+- [ ] Public facts and active documentation match the implementation.
+- [ ] No generated build output or private evidence is tracked.
+- [ ] The pull request explains test coverage and any intentionally deferred device, model, or UI acceptance.
+
+For architecture and ownership, use [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) and the [role playbooks](.agents/). Security-sensitive reports should use GitHub's [private security advisory form](https://github.com/PowerBeef/QwenVoice/security/advisories/new).

--- a/README.md
+++ b/README.md
@@ -1,252 +1,156 @@
 <h1 align="center">Vocello</h1>
 
 <p align="center">
-  A local, private voice studio for Apple Silicon. Write a script, shape how the voice should sound, and generate speech right on your device — no cloud, no account, no per-line meter.<br>
-  <strong>On your Mac today · iPhone arriving soon.</strong>
+  A local, private voice studio for Apple Silicon. Write a script, choose or shape a voice, and generate speech on your device with native Swift and MLX.<br>
+  <strong>Available for Mac. The iPhone app is implemented and awaiting public distribution.</strong>
 </p>
 
 <p align="center">
   <a href="https://vocello.vercel.app/"><img src="https://img.shields.io/badge/Website-vocello.vercel.app-7b61ff?style=flat-square&logo=vercel" alt="Website"></a>
   <a href="https://github.com/PowerBeef/QwenVoice/releases/tag/v2.1.0"><img src="https://img.shields.io/badge/Vocello-2.1.0-7b61ff?style=flat-square" alt="Vocello 2.1.0"></a>
-  <img src="https://img.shields.io/badge/macOS-26%2B-111827?style=flat-square&logo=apple" alt="macOS 26+">
-  <img src="https://img.shields.io/badge/iPhone-arriving%20soon-7b61ff?style=flat-square&logo=apple" alt="iPhone — arriving soon">
-  <img src="https://img.shields.io/badge/Apple%20Silicon-required-111827?style=flat-square&logo=apple" alt="Apple Silicon">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue?style=flat-square" alt="License: MIT"></a>
-  <a href="https://github.com/PowerBeef/QwenVoice/releases/tag/v2.1.0"><img src="https://img.shields.io/github/downloads/PowerBeef/QwenVoice/v2.1.0/total?label=2.1.0%20downloads&style=flat-square" alt="Downloads"></a>
+  <img src="https://img.shields.io/badge/macOS-26%2B-111827?style=flat-square&logo=apple" alt="macOS 26 or newer">
+  <img src="https://img.shields.io/badge/iPhone-distribution%20pending-7b61ff?style=flat-square&logo=apple" alt="iPhone distribution pending">
+  <img src="https://img.shields.io/badge/Apple%20Silicon-required-111827?style=flat-square&logo=apple" alt="Apple Silicon required">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue?style=flat-square" alt="MIT License"></a>
 </p>
 
 <div align="center">
 
-![Vocello banner with abstract voice waves and the Vocello logo](https://vocello.vercel.app/assets/readme-banner.png)
+![Vocello banner with abstract voice waves and the Vocello logo](docs/readme_banner_vocello.png)
 
 </div>
 
-<p align="center"><em>Formerly QwenVoice — now Vocello 2.1.</em></p>
+<p align="center">
+  <a href="https://github.com/PowerBeef/QwenVoice/releases/download/v2.1.0/Vocello-macos26.dmg"><strong>Download Vocello 2.1.0 for macOS 26+</strong></a><br>
+  <a href="https://github.com/PowerBeef/QwenVoice/releases/tag/v2.1.0">Release details</a> · <a href="docs/releases/v2.1.0.md">What is new</a> · <a href="https://github.com/PowerBeef/QwenVoice/releases">All releases</a>
+</p>
 
-**Contents:** [Get Vocello](#get-vocello) · [Why Vocello](#why-vocello) · [Workflows](#three-voice-workflows) · [Install](#install-macos) · [System requirements](#system-requirements) · [Privacy](#local-first-privacy) · [Build from source](#build-from-source) · [Development](#development-checkpoint) · [CLI](#command-line-tool-vocello) · [iPhone](#-vocello-for-iphone--arriving-soon) · [Contributing](#contributing) · [License](#license)
+## What Vocello does
 
-**Releases:** [v2.1.0 (latest)](https://github.com/PowerBeef/QwenVoice/releases/tag/v2.1.0) · [All releases](https://github.com/PowerBeef/QwenVoice/releases) · [What's new in 2.1.0](docs/releases/v2.1.0.md)
+- **Custom Voice:** choose one of nine built-in Qwen3 speakers, then set language and delivery.
+- **Voice Design:** describe a voice in plain language and generate it from that brief.
+- **Voice Cloning:** record or import a reference you have permission to use, transcribe it locally, and save it to your voice library.
+- **Private generation:** after model installation, scripts, reference clips, history, and generated audio stay in local app storage unless you export them.
+- **Ten languages:** Chinese, English, Japanese, Korean, German, French, Russian, Portuguese, Spanish, and Italian, with automatic detection or an explicit language choice.
+- **Local history and playback:** replay, search, export, or delete past generations without an account or a per-line subscription meter.
 
----
+## Voice workflows
 
-- 🎙️ **Three ways to make a voice** — pick a built-in speaker, describe one in plain language, or clone a reference clip you have rights to (record it in the app, or import a file).
-- 🔒 **Private by default** — after a one-time model download, every line renders on your device. No scripts uploaded, no audio sent to a cloud service.
-- ⚡ **Responsive, native Swift + MLX** — local generation on supported Apple Silicon Macs, down to 8 GB. No Python runtime, no bundled weights, no cloud queue.
-- 🌍 **Speaks ten languages** — with automatic language detection, ten delivery styles, and reproducible takes.
-
-## Get Vocello
-
-| Platform | Build | Notes |
-| --- | --- | --- |
-| **macOS 26+** (Apple Silicon) | **Vocello 2.1.0** — [Download DMG](https://github.com/PowerBeef/QwenVoice/releases/tag/v2.1.0) | Signed, notarized, stable. Double-click to open. |
-| **macOS 15** | QwenVoice 1.2.3 — [Download legacy](https://github.com/PowerBeef/QwenVoice/releases/tag/v1.2.3) | Legacy build. No 2.x backport planned. |
-| **iPhone** (iOS 26+, Apple Silicon) | **Arriving soon** | The same on-device engine; ships via App Store / TestFlight (not GitHub Releases). |
-
-## Why Vocello
-
-- **Private by default.** After models are installed, generation runs locally. Your scripts, history, recorded clips, and generated audio stay in local app storage unless you choose to export them.
-- **Responsive native generation on supported Apple Silicon.** The Swift + MLX engine needs no Python runtime, bundled weights, or cloud queue. Performance varies by mode, text length, model state, and hardware; the canonical engineering record is tracked rather than generalized into a universal marketing claim.
-- **Ten languages, auto-detected.** Chinese, English, Japanese, Korean, German, French, Russian, Portuguese, Spanish, and Italian. The language selector shows the language detected from your script (`Language · Auto`) and lets you pin a specific one.
-- **Ten delivery styles with intensity.** Neutral, Happy, Sad, Angry, Fearful, Surprised, Whisper, Dramatic, Calm, and Excited — each at subtle, normal, or strong intensity, plus a free-text custom tone when you want to describe the delivery in your own words.
-- **A real voice library.** Record a reference clip with your Mac's microphone (or import one), let it transcribe on-device, save the result, and reuse it. Voice Design results can be saved and re-used for cloning, and the speaker and language pickers surface recommendations that follow the language you're writing in.
-- **Reproducible takes.** A variation control (Expressive, Balanced, Consistent) trades take-to-take variety against stability, every generation records its sampling seed, and multi-line batches share one seed so a batch reads as a single consistent performance.
-- **No subscription meter.** Download the models you want, then generate on your own hardware without paying per line or waiting on a cloud queue.
-
-## Three voice workflows
-
-| | |
+| Voice Design | Voice Cloning |
 | --- | --- |
-| ![Custom Voice screen](https://vocello.vercel.app/assets/screens/custom-voice.png)<br><br>**Custom Voice**<br>Pick one of nine built-in Qwen3 speaker presets, choose a delivery style and intensity, and generate a clean spoken line. The fastest path when you want a consistent voice right away. | ![Voice Design screen](https://vocello.vercel.app/assets/screens/voice-design.png)<br><br>**Voice Design**<br>Describe the voice you want in plain language — character, age, accent, texture — then write the script. Vocello shapes the take from that brief, and you can save the result to reuse later. |
-| ![Voice Cloning screen](https://vocello.vercel.app/assets/screens/voice-cloning.png)<br><br>**Voice Cloning**<br>Record a short reference clip with your Mac's microphone, or import one (WAV, MP3, AIFF, M4A, FLAC, OGG, or WebM). The transcript can auto-fill with on-device transcription. Only clone voices you own or have permission to use. | ![Model downloads settings screen](https://vocello.vercel.app/assets/screens/model-downloads.png)<br><br>**Model downloads**<br>Install and manage the Speed and Quality package for each voice mode from Settings. Generation screens own the Speed/Quality choice while you write. |
+| ![Vocello Voice Design screen](docs/screenshots/vocello-voice-design.png) | ![Vocello Voice Cloning screen](docs/screenshots/vocello-voice-cloning.png) |
+| Describe character, age, accent, texture, and delivery. Save a successful design as a reusable voice reference. | Record in the app or import WAV, MP3, AIFF, M4A, FLAC, OGG, or WebM. Only clone voices you own or are authorized to use. |
 
-## More in the app
+Custom Voice and Voice Design support ten delivery styles at subtle, normal, or strong intensity, plus a free-text delivery description. Voice Cloning follows the reference voice and does not expose delivery controls.
 
-| | |
+| Models | History |
 | --- | --- |
-| ![The delivery presets menu open, showing ten styles](https://vocello.vercel.app/assets/screens/delivery-presets.png)<br><br>**Delivery presets**<br>Ten expressive styles — from Whisper and Calm to Dramatic and Excited — each with a subtle / normal / strong intensity, or describe a custom tone in your own words. | ![The History screen listing past generations](https://vocello.vercel.app/assets/screens/history.png)<br><br>**History &amp; library**<br>Every generation is saved locally with its mode, voice, and length. Replay it, save it to your voice library, export the audio, or search back through past takes. Clear-all lets you keep the audio files or delete them too. |
+| ![Vocello model download settings](docs/screenshots/vocello-model-downloads.png) | ![Vocello History screen](docs/screenshots/vocello-history.png) |
+| Install and manage the available model package for each voice mode from Settings. | Generations remain local and can be replayed, searched, exported, or removed. |
 
-## Install (macOS)
+## Install on Mac
 
-1. Download [`Vocello-macos26.dmg`](https://github.com/PowerBeef/QwenVoice/releases/tag/v2.1.0).
+1. Download [`Vocello-macos26.dmg`](https://github.com/PowerBeef/QwenVoice/releases/download/v2.1.0/Vocello-macos26.dmg).
 2. Open the DMG and drag `Vocello.app` to `/Applications`.
-3. Open Vocello.
-4. Go to **Settings → Model downloads** and install the voice models you want (the recommended Speed packages are ~7 GB total).
-5. Generate from Custom Voice, Voice Design, or Voice Cloning.
+3. Open Vocello, then install models from **Settings > Model downloads**.
+4. Generate from Custom Voice, Voice Design, or Voice Cloning.
 
-No Python setup or local server is required — install the app, download models from Settings, and generate locally.
+The current DMG is signed with an Apple Developer ID certificate, notarized, and stapled. No Python runtime or local server is required. The attached [`release-metadata.txt`](https://github.com/PowerBeef/QwenVoice/releases/download/v2.1.0/release-metadata.txt) records source and toolchain provenance.
 
-The DMG is signed with an Apple Developer ID certificate and notarized with a stapled ticket, so the first launch opens with a double-click (no right-click bypass). To verify:
+Upgrading from Vocello 2.0 does not require reinstalling models. Application data remains under `~/Library/Application Support/QwenVoice/`.
 
-```sh
-xcrun stapler validate Vocello-macos26.dmg                           # "The validate action worked!"
-spctl -a -vvv --type open --context context:primary-signature Vocello-macos26.dmg   # accepted, source=Notarized Developer ID
-```
+## System requirements and model variants
 
-A `release-metadata.txt` (commit SHA, Xcode version, SDK, marketing version, build number) is attached to the same release for build provenance.
+| Platform | Support | Model variants | Public status |
+| --- | --- | --- | --- |
+| Mac | macOS 26.0 or newer, Apple Silicon, 8 GB RAM minimum | Speed (4-bit) and Quality (8-bit) | Vocello 2.1.0 is available now |
+| iPhone | iPhone 15 Pro or newer, iOS 26.0 or newer | Speed (4-bit) | App implemented; public distribution pending |
 
-> **Upgrading from 2.0?** Replace `Vocello.app` with the new build. Your installed models, history, and saved voices live in `~/Library/Application Support/QwenVoice/` and carry over — no re-download needed.
+Speed is the recommended default and uses less memory. Quality is a Mac-only option for machines with more headroom. The three recommended Mac Speed packages total about 7 GB.
 
-## System requirements
+Support floors and benchmark machines are different facts. Canonical evidence is produced on a Mac mini M2 with 8 GB and an iPhone 17 Pro. The current clean Mac record found that selected warm Custom medium and long cells reached approximately realtime, while Design, Clone, short, and cold cells remained below it. See the [tracked benchmark record](benchmarks/runs/ui-generation/macos-xcui-benchmark-20260713-185716-7f12cd35.json) for the exact matrix and conditions.
 
-- **macOS 26.0+** on an Apple Silicon Mac — available now.
-- **iPhone 15 Pro or newer (iOS 26.0+)** — arriving soon via App Store / TestFlight.
-- **8 GB RAM minimum** (16 GB+ recommended for Quality variants and heavy batches).
-- Voice models installed from **Settings → Model downloads**.
+Macs on macOS 15 can use the legacy [QwenVoice 1.2.3 release](https://github.com/PowerBeef/QwenVoice/releases/tag/v1.2.3). No Vocello 2.x backport is planned.
 
-**Speed** models are smaller 4-bit packages for faster startup and lower memory use, and are the recommended default. **Quality** models are larger 8-bit packages for devices with more headroom. In the current clean canonical Mac mini M2 8 GB record, selected warm Custom medium/long cells reached approximately realtime while Design, Clone, short, and cold cells remained below it; see the [tracked record](benchmarks/runs/ui-generation/macos-xcui-benchmark-20260713-185716-7f12cd35.json).
+## Variation and reproducibility
 
-Vocello 2.1.0 is the current stable macOS release. For macOS 15, use [QwenVoice v1.2.3](https://github.com/PowerBeef/QwenVoice/releases/tag/v1.2.3); no 2.x backport is planned. Every macOS GitHub Release ships a notarized, stapled, Developer ID–signed DMG — a normal double-click install with no Gatekeeper workarounds.
-
-Support floors and benchmark machines are different facts. Minimum support is an Apple Silicon Mac
-with 8 GB or an iPhone 15 Pro or newer. Canonical performance evidence uses a Mac mini M2 with 8 GB
-and an iPhone 17 Pro. Any additional tested hardware must be backed by a tracked or explicitly
-referenced validation record.
+The Expressive, Balanced, and Consistent variation settings trade take-to-take variety against stability. Multi-line batches share one seed so their lines form a consistent performance. CLI and benchmark callers can provide an explicit seed for reproducible evidence. Ordinary interactive generations are not presented as seed-replayable takes.
 
 ## Local-first privacy
 
 - Speech generation runs locally after models are installed.
-- Generated audio, recorded reference clips, and history stay in local app storage unless you export them.
-- Model downloads come from Hugging Face when you install a voice model.
-- Recording a reference clip and transcript auto-fill ask for the **Microphone** and **Speech Recognition** permissions on first use. Both run entirely on your Mac — recognition is on-device only, and nothing is sent to Apple or anyone else. (Transcript auto-fill additionally requires Siri to be enabled, a macOS requirement; the app explains this and links the right Settings pane.)
+- Generated audio, recorded references, transcripts, saved voices, and history remain in local app storage unless you export them.
+- Model installation downloads pinned model artifacts from Hugging Face.
+- Reference recording requests microphone access. Transcript auto-fill requests Speech Recognition access and uses on-device recognition with the required system language assets.
 - Voice cloning should only be used with voices you own or have permission to use.
+
+Storage locations and deletion behavior are documented in [`docs/reference/privacy-storage.md`](docs/reference/privacy-storage.md).
+
+## Vocello for iPhone
+
+| | |
+| --- | --- |
+| ![Vocello Studio running on iPhone](docs/screenshots/vocello-ios-studio.png) | The iPhone app uses the same local Qwen3-TTS and MLX foundation with an iPhone-specific in-process runtime. It provides Custom Voice, Voice Design, Voice Cloning, recording and Files import, local history, and the memory-conscious Speed models. On-device generation, physical-iPhone XCUITest, and an optional signed archive/TestFlight lane are implemented. Public distribution still requires the maintainer-owned App Store Connect release process. The fresh full multilingual physical-iPhone acceptance run remains an engineering checkpoint, not a claim that blocks ordinary development or packaging. |
+
+Current implementation and acceptance status: [`docs/development-progress.md`](docs/development-progress.md).
 
 ## Build from source
 
-The `main` branch contains the current Vocello codebase (macOS app, iPhone app, and the `vocello` CLI). The stable macOS release is tagged [`v2.1.0`](https://github.com/PowerBeef/QwenVoice/releases/tag/v2.1.0) ([release notes](docs/releases/v2.1.0.md)).
-
-**Requires Xcode 26** on macOS 26+ (Apple Silicon) to build from source.
-
-Vocello's engine is **native Swift + MLX** — no Python, no bundled weights. On macOS it runs **out-of-process** in an isolated XPC service; on iPhone it runs **in-process**, fully on-device. Architecture, engine invariants, and release policy live in [`AGENTS.md`](AGENTS.md) and [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+Building requires Xcode 26 on an Apple Silicon Mac running macOS 26 or newer.
 
 ```sh
 git clone https://github.com/PowerBeef/QwenVoice.git
 cd QwenVoice
 ./scripts/regenerate_project.sh
-open QwenVoice.xcodeproj
+./scripts/build.sh build
 ```
 
-The Xcode project is generated from [`project.yml`](project.yml) (edit it, not the `.xcodeproj`, then rerun `regenerate_project.sh`). SPM dependencies — MLX, Swift HuggingFace, GRDB, and the vendored mlx-audio — are deliberately **pinned to exact versions** for backend determinism; bumping them follows a benchmark-gated process documented in [`.agents/backend-mlx.md`](.agents/backend-mlx.md).
+Repository scripts are the authoritative build and test interface. `project.yml` generates the Xcode project, so edit it instead of the generated project file. To work in Xcode after generation, open `QwenVoice.xcodeproj`.
 
-Generated output is owned by [`config/build-output-policy.json`](config/build-output-policy.json),
-not by individual scripts. This contract governs native repository output under `build/`;
-`website/dist/` is Vite-owned website deployment output. Local development reuses exactly two persistent platform Xcode caches
-under `build/cache/xcode/`, one shared Xcode package checkout, and the dedicated vendored SwiftPM
-cache. Temporary builds live under `build/scratch/`, local evidence and current symbols under
-`build/artifacts/`, and release products under `build/dist/`. The public `build/Vocello.app` and
-`build/vocello` paths are symlinks to the current canonical macOS products, not duplicate copies.
-Do not add an ad hoc DerivedData root or allow a `.build` directory below the vendored source.
+Generated native output is governed by [`config/build-output-policy.json`](config/build-output-policy.json): persistent platform caches live under `build/cache/`, temporary builds under `build/scratch/`, evidence and current symbols under `build/artifacts/`, and distribution products under `build/dist/`. Do not introduce another DerivedData root or a vendored `.build` directory.
 
-Inventory and cleanup are explicit and bounded:
-
-```sh
-python3 scripts/build_output_policy.py status       # sizes, owners, and reclaimable bytes
-python3 scripts/build_output_policy.py validate     # manifest, references, symlinks, docs, and symbol identity
-scripts/clean_build_caches.sh                       # read-only inventory
-scripts/clean_build_caches.sh --routine --dry-run   # preview scratch/evidence pruning
-scripts/clean_build_caches.sh --routine             # preserve canonical caches, app, symbols, dist, models, history
-```
-
-Use `--aggressive`, `--prune-ui-results`, `--dist`, `--models`, `--external-xcode --yes`, or
-`--clobber --yes` only for the cleanup class named by the option. Full ownership and retention
-semantics are generated from the manifest in
-[`docs/reference/privacy-storage.md`](docs/reference/privacy-storage.md).
-
-Useful checks:
+The ordinary deterministic checks are:
 
 ```sh
 ./scripts/check_project_inputs.sh
-./scripts/build_foundation_targets.sh macos
+scripts/macos_test.sh test
+./scripts/build.sh build
 ./scripts/build_foundation_targets.sh ios
-scripts/macos_test.sh models ensure   # explicit repair/bootstrap only when visible Settings readiness fails
-scripts/macos_test.sh test            # deterministic Core + XPC + Qwen3 runtime tests (no UI)
-scripts/ui_test.sh macos smoke        # explicit XCUITest acceptance only
-scripts/ui_test.sh macos benchmark
-scripts/macos_test.sh gate            # deterministic macOS platform gate
-scripts/ui_test.sh ios smoke          # paired physical iPhone only
-scripts/ui_test.sh ios benchmark
-scripts/ios_device.sh lang-bench --subset quick --label "lang-quick"  # language hint + output bench
-scripts/ios_device.sh device-state      # physical-device reachability/unlock/interference probe
-scripts/ios_device.sh gate              # physical-device deterministic/runtime gate
 ```
 
-Testing runbook: [`docs/reference/testing-runbook.md`](docs/reference/testing-runbook.md). XCUITest
-is the sole autonomous app UI driver: native macOS and a paired physical iPhone only. Smoke and
-benchmark lanes are explicit frontend acceptance work.
+These checks are sufficient for normal commits, pull requests, and merges. XCUITest is explicit frontend acceptance: native macOS or a paired physical iPhone, never Simulator. Models, a phone, and UI evidence are not prerequisites for sharing development work.
 
-Commits, pushes, pull requests, and ordinary merges use deterministic verification only. Missing
-models, physical-device, or XCUITest evidence never blocks preserving or sharing development work.
-Frontend lanes run only for explicit acceptance. Their absence never blocks release packaging,
-signing, notarization, artifact upload, a macOS package, or an iOS archive/TestFlight build.
+Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) for the human contribution flow. Maintainers and Codex tasks should also read [`AGENTS.md`](AGENTS.md). Deeper references:
 
-More technical detail:
+- [`docs/development-progress.md`](docs/development-progress.md): current implementation checkpoint and open acceptance work
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md): runtime topology and engine invariants
+- [`docs/project-map.html`](docs/project-map.html): interactive feature, target, dependency, and workflow map
+- [`docs/reference/testing-runbook.md`](docs/reference/testing-runbook.md): deterministic and explicit frontend test lanes
+- [`docs/reference/benchmarking-procedure.md`](docs/reference/benchmarking-procedure.md): benchmark protocol and PASS-only publication
 
-- [`docs/development-progress.md`](docs/development-progress.md) — active maintainer checkpoint: completed transition, verified acceptance evidence, and the Codex reinstall/resume sequence
-- [`docs/project-map.html`](docs/project-map.html) — canonical interactive project map: features, targets, dependencies, flows, source ownership, contracts, and development routes
-- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — architecture reference: runtime design, engine invariants, and request lifecycles
-- [`AGENTS.md`](AGENTS.md) — repo guide: build, architecture, engine invariants, dependency pinning, release policy, conventions
-- [`docs/reference/cli.md`](docs/reference/cli.md) — the headless `vocello` command-line tool
-- [`docs/reference/privacy-storage.md`](docs/reference/privacy-storage.md) — local storage and deletion details
+## Command-line tool
 
-## Development checkpoint
-
-The repository uses one XCUITest stack for native macOS and the paired physical iPhone.
-Deterministic tests are the development, CI, and packaging requirement; smoke and benchmark UI
-results are produced only for explicitly requested frontend acceptance. Maintainers and new Codex
-sessions should start with [`AGENTS.md`](AGENTS.md), then follow the exact checkpoint and
-resume sequence in [`docs/development-progress.md`](docs/development-progress.md).
-
-## Command-line tool (`vocello`)
-
-Vocello ships a headless command-line tool, `vocello`, built from source alongside the app (it is not part of the app download). It drives the same local Swift + MLX engine in-process — no Python, no bundled weights — and serves two roles: scriptable local generation from the terminal, and the deterministic driver for the perf/quality benchmarks. Models install via the app (Settings → Model downloads) or `vocello models install <id>` into the shared `~/Library/Application Support/QwenVoice/models` store. For macOS test fixtures, use `scripts/macos_test.sh models ensure` only as explicit repair/bootstrap; UI generation lanes require visible Settings readiness and never invoke it automatically.
+The source tree also builds `vocello`, a headless interface to the same local Swift and MLX engine. It is not included in the app download.
 
 ```sh
-./scripts/build.sh cli                 # build build/vocello
-build/vocello <command> [options]      # run it (runs in place)
-```
-
-| Command | What it does |
-| --- | --- |
-| `generate` | Synthesize one clip (Custom Voice / Voice Design / Voice Cloning); supports `--stream`, `--json`, and piped stdin. |
-| `custom` / `design` / `clone` | Shortcuts for `generate --mode …` (also pick the mode interactively, or list them with `modes`). |
-| `batch` | Synthesize many clips from a file with a single model load. |
-| `voices` | List, enroll, or delete saved clone voices. |
-| `speakers` | List the built-in Custom Voice speakers. |
-| `models` | List/status/install models (`models install <id>` for headless download). |
-| `bench` | Drive the perf/quality matrix and aggregate the results. |
-
-```sh
-# Generate a clip (mode shortcut), or pipe a script in
-build/vocello custom --variant speed --text "The train left at dawn."
-echo "Hello there." | build/vocello generate --variant speed --stream --json
-
-# Discover modes/speakers/models, then bulk synth (one model load)
+./scripts/build.sh cli
 build/vocello modes
 build/vocello speakers list
 build/vocello models list
-build/vocello models install pro_custom_speed   # optional; or use the app / macos_test.sh models ensure
-build/vocello batch --file lines.txt --mode custom --variant speed --out-dir /tmp/batch
+build/vocello custom --variant speed --text "The train left at dawn."
+echo "Hello there." | build/vocello generate --variant speed --stream --json
 ```
 
-stdout is machine-readable (an output path, or JSON with `--json`); progress notes go to stderr. Full reference: [`docs/reference/cli.md`](docs/reference/cli.md).
-
-## 📱 Vocello for iPhone — arriving soon
-
-| | |
-| --- | --- |
-| ![Vocello running on iPhone — the Studio screen with Custom / Design / Clone modes](https://vocello.vercel.app/assets/screens/ios-studio.png) | Vocello is coming to iPhone — the **same local, private engine**, running **fully on-device** on Apple Silicon. Write a script, pick or describe a voice, and generate speech without a cloud round-trip, exactly like the Mac app. Record a Clone reference on-device or import WAV, MP3, AIFF, or M4A audio from Files; an adjacent transcript sidecar can prefill enrollment, and the saved voice opens directly in Clone.<br><br>**On-device generation and the optional signed archive/TestFlight CI lane are implemented.** Public distribution still needs maintainer-owned Apple credentials, the App Store Connect record and metadata, and submission. No public release date yet.<br><br>This is what the native Swift + MLX rebuild was for: replacing the old bundled Python runtime with an engine that runs entirely on-device — the only way to bring Vocello to iPhone.<br><br>**Want to follow along?** Star ⭐ and watch 👀 the repo for updates. |
+The CLI supports single generation, mode shortcuts, batches, saved voices, speaker and model discovery, model installation, and benchmark matrices. Standard output is machine-readable; progress is written to standard error. See [`docs/reference/cli.md`](docs/reference/cli.md).
 
 ## Contributing
 
-- **Report bugs or request features:** [GitHub Issues](https://github.com/PowerBeef/QwenVoice/issues)
-- **Build, test, and architecture:** [`AGENTS.md`](AGENTS.md) (Workflows + Commands; testing in [`docs/reference/testing-runbook.md`](docs/reference/testing-runbook.md))
-- **Release QA checklist:** [`docs/reference/macos-release-qa.md`](docs/reference/macos-release-qa.md)
+- Read [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening a change.
+- Report bugs and request features through [GitHub Issues](https://github.com/PowerBeef/QwenVoice/issues).
+- Security-sensitive reports should use GitHub's [private security advisory form](https://github.com/PowerBeef/QwenVoice/security/advisories/new).
 
-**Social preview (maintainers):** upload [`docs/social_preview.png`](docs/social_preview.png) under GitHub → **Settings → General → Social preview** so link cards use the Vocello artwork.
-
-## License
+## License and acknowledgements
 
 Vocello is available under the [MIT License](LICENSE).
 
-## Built on
-
-Vocello builds on [Qwen3-TTS](https://github.com/QwenLM/Qwen3-TTS), [mlx-audio](https://github.com/Blaizzy/mlx-audio), [MLX](https://github.com/ml-explore/mlx), and [GRDB.swift](https://github.com/groue/GRDB.swift).
+The project builds on [Qwen3-TTS](https://github.com/QwenLM/Qwen3-TTS), [MLX](https://github.com/ml-explore/mlx), [mlx-audio-swift](https://github.com/Blaizzy/mlx-audio-swift), and [GRDB.swift](https://github.com/groue/GRDB.swift). Vocello owns a selective Swift runtime fork derived from `mlx-audio-swift` v0.1.2; the exact baseline, retained surfaces, semantic changes, and removal criteria are tracked in [`third_party_patches/mlx-audio-swift/UPSTREAM.md`](third_party_patches/mlx-audio-swift/UPSTREAM.md) and [`PATCHES.json`](third_party_patches/mlx-audio-swift/PATCHES.json).

--- a/config/documentation-contract.json
+++ b/config/documentation-contract.json
@@ -18,7 +18,7 @@
       "authority": "repository guidance",
       "audience": "contributors and users",
       "reviewTriggers": ["release facts", "workflow changes", "platform support"],
-      "paths": ["AGENTS.md", "README.md", "PRODUCT.md", ".agents/*.md", "website/AGENTS.md", "website/DESIGN.md", "website/PRODUCT.md", "website/README.md"]
+      "paths": ["AGENTS.md", "README.md", "CONTRIBUTING.md", "PRODUCT.md", ".agents/*.md", "website/AGENTS.md", "website/DESIGN.md", "website/PRODUCT.md", "website/README.md"]
     },
     {
       "id": "architecture",

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,6 +18,7 @@ Review when: release facts; workflow changes; platform support.
 - [`.agents/release-qa-engineer.md`](../.agents/release-qa-engineer.md)
 - [`.agents/website-engineer.md`](../.agents/website-engineer.md)
 - [`AGENTS.md`](../AGENTS.md)
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md)
 - [`PRODUCT.md`](../PRODUCT.md)
 - [`README.md`](../README.md)
 - [`website/AGENTS.md`](../website/AGENTS.md)

--- a/scripts/documentation_contract.py
+++ b/scripts/documentation_contract.py
@@ -52,7 +52,13 @@ def documentation_groups(root: Path) -> list[dict]:
 def active_markdown_paths(root: Path) -> list[Path]:
     if not (root / CONTRACT_PATH).is_file():
         # Small fixture fallback. Production inventory is always manifest-owned.
-        candidates = [root / "AGENTS.md", root / "README.md", root / "PRODUCT.md", root / "website/AGENTS.md"]
+        candidates = [
+            root / "AGENTS.md",
+            root / "README.md",
+            root / "CONTRIBUTING.md",
+            root / "PRODUCT.md",
+            root / "website/AGENTS.md",
+        ]
         candidates.extend((root / ".agents").glob("*.md"))
         candidates.extend((root / "docs/reference").glob("*.md"))
         return sorted(
@@ -309,14 +315,68 @@ def validate_facts(root: Path) -> list[str]:
         errors.append("public stable Mac release is missing from README or website copy")
     if public["ios"]["minimumDevice"] not in readme:
         errors.append("README minimum iPhone support differs from public-product-facts")
-    website_pending = any(phrase in website.lower() for phrase in ("arriving soon", "not public yet", "public distribution is not"))
-    if "arriving soon" not in readme.lower() or not website_pending:
+    pending_phrases = (
+        "arriving soon",
+        "distribution pending",
+        "not public yet",
+        "public distribution is not",
+        "awaiting public distribution",
+    )
+    readme_pending = any(phrase in readme.lower() for phrase in pending_phrases)
+    website_pending = any(phrase in website.lower() for phrase in pending_phrases)
+    if not readme_pending or not website_pending:
         errors.append("public iPhone distribution-pending status is missing from README or website")
     progress = (root / "docs/development-progress.md").read_text(encoding="utf-8")
     if benchmark_baseline_status(root, "macos") and "clean canonical macOS schema-v2 baseline exists" not in progress:
         errors.append("docs/development-progress.md: tracked history has a clean canonical macOS baseline but the checkpoint does not")
     if not benchmark_baseline_status(root, "ios") and "clean canonical iPhone schema-v2 baseline remains pending" not in progress:
         errors.append("docs/development-progress.md: iPhone clean canonical status must remain pending")
+    return errors
+
+
+def validate_readme_public_contract(root: Path) -> list[str]:
+    """Keep the GitHub landing page aligned with public product contracts."""
+    readme_path = root / "README.md"
+    if not readme_path.is_file():
+        return ["README.md: public product page is missing"]
+    readme = readme_path.read_text(encoding="utf-8")
+    public = load_json(root / PUBLIC_FACTS_PATH)
+    version = public["stableMacRelease"]["version"]
+    tag = public["stableMacRelease"]["tag"]
+    direct_dmg = (
+        "https://github.com/PowerBeef/QwenVoice/releases/download/"
+        f"{tag}/Vocello-macos26.dmg"
+    )
+    errors: list[str] = []
+    rejected = {
+        r"(?i)every generation records its sampling seed":
+            "interactive generations cannot be described as universally seed-replayable",
+        r"(?i)exactly like the Mac app":
+            "iPhone copy must preserve its platform-specific runtime and model-variant differences",
+        r"https://vocello\.vercel\.app/assets/screens/":
+            "README product screenshots must use repository-versioned assets",
+        r"(?i)social preview \(maintainers\)":
+            "repository administration instructions do not belong on the public product page",
+    }
+    for pattern, message in rejected.items():
+        if re.search(pattern, readme):
+            errors.append(f"README.md: {message}")
+    if direct_dmg not in readme:
+        errors.append(f"README.md: stable {version} install CTA must link directly to the DMG asset")
+    if "[mlx-audio-swift](https://github.com/Blaizzy/mlx-audio-swift)" not in readme:
+        errors.append("README.md: acknowledgements must identify the actual mlx-audio-swift upstream")
+    if not re.search(r"(?is)\|\s*Mac\s*\|[^\n]+Speed \(4-bit\) and Quality \(8-bit\)", readme):
+        errors.append("README.md: Mac model availability must state Speed and Quality")
+    if not re.search(r"(?is)\|\s*iPhone\s*\|[^\n]+\|\s*Speed \(4-bit\)\s*\|", readme):
+        errors.append("README.md: iPhone model availability must state Speed only")
+    if not re.search(r"(?i)Voice Cloning[^\n]+does not expose delivery controls", readme):
+        errors.append("README.md: delivery controls must be scoped away from Voice Cloning")
+    local_assets = set(re.findall(r"\]\((docs/(?:screenshots/[^)]+|readme_banner_vocello\.png))\)", readme))
+    if len(local_assets) < 5:
+        errors.append("README.md: expected repository-versioned banner and product screenshots are missing")
+    for asset in local_assets:
+        if not (root / asset).is_file():
+            errors.append(f"README.md: missing repository-versioned product asset {asset}")
     return errors
 
 
@@ -411,6 +471,7 @@ def validate(root: Path) -> list[str]:
     errors.extend(validate_retired_harness_terms(root, paths))
     errors.extend(validate_documented_subcommands(root, paths))
     errors.extend(validate_facts(root))
+    errors.extend(validate_readme_public_contract(root))
     errors.extend(validate_website_copy(root))
     errors.extend(validate_historical_banners(root))
     errors.extend(validate_index(root))

--- a/scripts/tests/test_documentation_contract.py
+++ b/scripts/tests/test_documentation_contract.py
@@ -159,6 +159,51 @@ class DocumentationContractTests(unittest.TestCase):
         source.write_text('const copy = "Responsive native generation";\n', encoding="utf-8")
         self.assertEqual(DOCUMENTATION.validate_website_copy(self.root), [])
 
+    def test_readme_public_contract_rejects_claim_and_asset_drift(self) -> None:
+        self.write(
+            "config/public-product-facts.json",
+            json.dumps(
+                {
+                    "stableMacRelease": {"version": "2.1.0", "tag": "v2.1.0"},
+                }
+            ),
+        )
+        stale = self.write(
+            "README.md",
+            "Every generation records its sampling seed.\n\n"
+            "The iPhone works exactly like the Mac app.\n\n"
+            "![Screen](https://vocello.vercel.app/assets/screens/custom-voice.png)\n",
+        )
+        errors = DOCUMENTATION.validate_readme_public_contract(self.root)
+        self.assertGreaterEqual(len(errors), 8)
+        self.assertTrue(any("seed-replayable" in error for error in errors))
+        self.assertTrue(any("repository-versioned" in error for error in errors))
+
+        for relative in (
+            "docs/readme_banner_vocello.png",
+            "docs/screenshots/voice-design.png",
+            "docs/screenshots/voice-cloning.png",
+            "docs/screenshots/models.png",
+            "docs/screenshots/history.png",
+        ):
+            self.write(relative, "fixture")
+        stale.write_text(
+            "[Download](https://github.com/PowerBeef/QwenVoice/releases/download/v2.1.0/Vocello-macos26.dmg)\n\n"
+            "| Platform | Support | Model variants | Status |\n"
+            "| --- | --- | --- | --- |\n"
+            "| Mac | supported | Speed (4-bit) and Quality (8-bit) | available |\n"
+            "| iPhone | supported | Speed (4-bit) | pending |\n\n"
+            "Voice Cloning follows its reference and does not expose delivery controls.\n\n"
+            "[mlx-audio-swift](https://github.com/Blaizzy/mlx-audio-swift)\n\n"
+            "![Banner](docs/readme_banner_vocello.png)\n"
+            "![Design](docs/screenshots/voice-design.png)\n"
+            "![Clone](docs/screenshots/voice-cloning.png)\n"
+            "![Models](docs/screenshots/models.png)\n"
+            "![History](docs/screenshots/history.png)\n",
+            encoding="utf-8",
+        )
+        self.assertEqual(DOCUMENTATION.validate_readme_public_contract(self.root), [])
+
     def test_historical_snapshot_may_retain_retired_terminology(self) -> None:
         active = self.write("README.md", "Computer Use is an old harness.\n")
         self.assertTrue(DOCUMENTATION.validate_retired_harness_terms(self.root, [active]))


### PR DESCRIPTION
## Summary

- rewrite the GitHub landing page around accurate product, platform, privacy, model, and benchmark facts
- link the primary install action directly to the notarized Vocello 2.1.0 DMG
- remove stale screenshot references and use repository-versioned product artwork
- add a human-focused contribution guide and include it in the generated documentation index
- add regression checks for seed, iPhone parity, model-variant, vendor-attribution, screenshot, and download-link drift
- update the repository social preview with the checked-in Vocello artwork

## Impact

The public repository page is shorter and clearer for users while preserving scripts-first onboarding for contributors. The README now distinguishes Mac and iPhone capabilities and no longer overstates seed replayability, delivery control, or platform parity.

## Verification

- `git diff --check`
- `python3 -m unittest scripts.tests.test_documentation_contract`
- `python3 scripts/documentation_contract.py`
- `python3 scripts/vendor_runtime_contract.py validate`
- `python3 scripts/benchmark_history.py validate --all`
- `python3 scripts/benchmark_history.py rebuild-index --check`
- `python3 scripts/build_output_policy.py validate`
- `./scripts/check_project_inputs.sh` (359 tests)
- `npm --prefix website run build`
- GitHub Markdown rendering and direct DMG resolution