### PR TITLE
Repair cross-platform model delivery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,8 @@ scripts/macos_test.sh gate
 scripts/ios_device.sh preflight
 scripts/ui_test.sh ios smoke
 scripts/ui_test.sh ios benchmark
+# Opt-in isolated background-delivery lifecycle proof; never an ordinary UI lane.
+scripts/ui_test.sh ios model-download
 scripts/ios_device.sh gate
 ```
 
@@ -185,6 +187,7 @@ gates. Listening remains optional independent annotation →
 | `Tests/VocelloMacUITests/` | macOS smoke and benchmark UI tests |
 | `Tests/VocelloiOSUITests/` | Physical-iPhone smoke and benchmark UI tests |
 | `scripts/ui_test.sh` | Unified explicit XCUITest entry point |
+| `docs/reference/model-delivery.md` | Shared downloader, iOS restoration ledger, retry/cancel, diagnostics, and isolated live proof |
 | `benchmarks/`, `scripts/benchmark_history.py` | PASS-only, privacy-safe benchmark registry and generated index |
 | `Tests/VocelloCoreTests/`, `Tests/VocelloEngineIntegrationTests/` | Deterministic Core/output/telemetry and XPC transport tests |
 | `docs/project-map.html` | Canonical interactive feature, component, dependency, and workflow map |

--- a/QwenVoice.xcodeproj/project.pbxproj
+++ b/QwenVoice.xcodeproj/project.pbxproj
@@ -63,7 +63,9 @@
 		2652AA780375CA68D2A076C9 /* IOSShellPrimitives.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA28E2DF284402995B080598 /* IOSShellPrimitives.swift */; };
 		2774CCB9AA73B8B0AB929C4D /* GenerateCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944BB98E564576BA42D80E3E /* GenerateCommand.swift */; };
 		280A67A391CE1EE6F93C3BC4 /* UnsafeSpeechGenerationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC0AAA8033470C310E11EA6 /* UnsafeSpeechGenerationModel.swift */; };
+		295227743AD5033491455176 /* VocelloiOSModelDownloadUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A460ED1FFAC6253A10DB399 /* VocelloiOSModelDownloadUITests.swift */; };
 		2A2A5CEFC23A86F73E9B1CCC /* GenerationMigrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8833440B1C4055104BE1C4 /* GenerationMigrations.swift */; };
+		2B47852312BC5ADBD59E0AEE /* ModelDownloadDiagnosticsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62B18285F5BF030DFCD13276 /* ModelDownloadDiagnosticsStore.swift */; };
 		2C76DCA86A8223765A4151FE /* QVoiceiOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006BE9D0FEE391DC25395879 /* QVoiceiOSApp.swift */; };
 		2C9D40B6961C3AA1D1DA2C52 /* MacWarmupAdmissionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5190BFE7853E14F8FFC844 /* MacWarmupAdmissionPolicy.swift */; };
 		2D233C6F443119FA6212B35C /* MainThreadStallWatchdog.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66191A5DDE964FBA36052A3 /* MainThreadStallWatchdog.swift */; };
@@ -128,6 +130,7 @@
 		526AB39EEB0CE64693396887 /* QwenVoiceEngineService.xpc in CopyFiles */ = {isa = PBXBuildFile; fileRef = 34A69E43A7FA75DD38753845 /* QwenVoiceEngineService.xpc */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5377189B01790E90BDEEE4AE /* eric.wav in Resources */ = {isa = PBXBuildFile; fileRef = 3B9B756B0B79BA2E94926CD3 /* eric.wav */; };
 		54629EA454BE4A228E48B874 /* GenerationSemanticsLanguageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5D3ADAE3566B96C3337BAB /* GenerationSemanticsLanguageTests.swift */; };
+		54FC6AE5F636C4E0D86D77A2 /* ModelDownloadContracts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E49D20CE50DF8A66191ECE /* ModelDownloadContracts.swift */; };
 		5534D672FF2E267DAFE941E4 /* IOSEngineLifecycleToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8CA939BDEDD6DB1F479C5F /* IOSEngineLifecycleToast.swift */; };
 		5582DF3AC1881AE1C07BBBB3 /* TTSEngineStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82A05DAF95ECD80C6A42AD1F /* TTSEngineStore.swift */; };
 		5689BE482459B9DFDA157DBF /* BatchCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBD264895A6D236200B068D4 /* BatchCommand.swift */; };
@@ -277,6 +280,7 @@
 		D27D60A56143986204A2D592 /* Voice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 623B6EAE78F8B7100D4675F4 /* Voice.swift */; };
 		D3BBFC311AF428545AD5CB7C /* IOSRecordVoiceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2290D85D02EF277B2AC164A /* IOSRecordVoiceSheet.swift */; };
 		D4008E9B424CE5E4D9D76879 /* VocelloMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3548C32EC85AB76ABEAEA6A8 /* VocelloMain.swift */; };
+		D45A1753FBA6D932E5DB46C0 /* ModelDownloadLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3906B4F64C4DEF21F1AFEF77 /* ModelDownloadLifecycleTests.swift */; };
 		D75C67CBCAC91DF7F71B0273 /* IOSScrollRefinements.swift in Sources */ = {isa = PBXBuildFile; fileRef = E829FDA2BC5308802AB3A837 /* IOSScrollRefinements.swift */; };
 		D9CD489105C5ADCF38E6EE96 /* IOSModelDeliverySupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC061E247067EDDB99401F09 /* IOSModelDeliverySupport.swift */; };
 		DA60A835AE1FB55B29533BCA /* Support.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E86AC791986726B8753994F /* Support.swift */; };
@@ -307,6 +311,7 @@
 		EC1CE92663E01892C52898ED /* VoiceClipTranscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F068FE73DB34691E0E3372C /* VoiceClipTranscriber.swift */; };
 		EC8305F1E9D7786A6389F921 /* IOSStudioGenerationActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C26CF50ADDF233BEFB0351 /* IOSStudioGenerationActions.swift */; };
 		ECEE4AE6F2D1AF6BA9EFECAA /* GenerationLibraryEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D4F51C8BBABFB4246536FD /* GenerationLibraryEvents.swift */; };
+		EDA50C5B7EBB79527D8D1CA7 /* IOSModelDownloadLedger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B290DD34425D07A47B0BACDD /* IOSModelDownloadLedger.swift */; };
 		EE07BEF2786B5C66AD3F61DA /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 955EAA47F1E723B2D9DED7AD /* README.md */; };
 		EE74F86575A75A733CEB560D /* VocelloiOSUITestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDB19FC47AD8EFFA3B2539D /* VocelloiOSUITestCase.swift */; };
 		EE9C991DADF85B8748E2B82B /* AudioPreparation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA6871405D0795C9867A2F7 /* AudioPreparation.swift */; };
@@ -544,7 +549,9 @@
 		37D3D0691D493C308EB2B348 /* GenerationEnginePresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationEnginePresentation.swift; sourceTree = "<group>"; };
 		3837D18DB04238E5D9200B5E /* IOSSettingsViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSSettingsViews.swift; sourceTree = "<group>"; };
 		38606B1D5B92FD43EEDFA217 /* EngineServiceTransportAccumulatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EngineServiceTransportAccumulatorTests.swift; sourceTree = "<group>"; };
+		3906B4F64C4DEF21F1AFEF77 /* ModelDownloadLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDownloadLifecycleTests.swift; sourceTree = "<group>"; };
 		3912F66CF11ACFE5DD83B2BE /* NativeRuntimeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeRuntimeFactory.swift; sourceTree = "<group>"; };
+		3A460ED1FFAC6253A10DB399 /* VocelloiOSModelDownloadUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocelloiOSModelDownloadUITests.swift; sourceTree = "<group>"; };
 		3AC640F31070C11F3F6C432D /* GenerationVariationPreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationVariationPreference.swift; sourceTree = "<group>"; };
 		3ADE213695C11F46205AE6DC /* QwenVoice.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QwenVoice.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B9B756B0B79BA2E94926CD3 /* eric.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = eric.wav; sourceTree = "<group>"; };
@@ -560,6 +567,7 @@
 		44E29A8F18ADF5E5C68E11E1 /* ModelManagerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelManagerViewModel.swift; sourceTree = "<group>"; };
 		452CA311723F50EB66FFBC4D /* mlx-audio-swift */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "mlx-audio-swift"; path = "third_party_patches/mlx-audio-swift"; sourceTree = SOURCE_ROOT; };
 		455E64C0038726A97D8F7BC4 /* VoiceBriefEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceBriefEditor.swift; sourceTree = "<group>"; };
+		45E49D20CE50DF8A66191ECE /* ModelDownloadContracts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDownloadContracts.swift; sourceTree = "<group>"; };
 		473C7A803F9F31801C56EDE1 /* IOSAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSAccessibility.swift; sourceTree = "<group>"; };
 		474261D7C145B2FFB657E3F7 /* IOSAppDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSAppDefaults.swift; sourceTree = "<group>"; };
 		492494B8403570CFFAAD7769 /* IOSStudioCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSStudioCanvas.swift; sourceTree = "<group>"; };
@@ -590,6 +598,7 @@
 		617BE72142511CD5043C341E /* qwenvoice_contract.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = qwenvoice_contract.json; sourceTree = "<group>"; };
 		6192F80DEA6E70A576CC05C7 /* AtomicWAVPublicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicWAVPublicationTests.swift; sourceTree = "<group>"; };
 		623B6EAE78F8B7100D4675F4 /* Voice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Voice.swift; sourceTree = "<group>"; };
+		62B18285F5BF030DFCD13276 /* ModelDownloadDiagnosticsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDownloadDiagnosticsStore.swift; sourceTree = "<group>"; };
 		637866C95AC607A5E0509956 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		6436F73812606485A0589C35 /* AppPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPaths.swift; sourceTree = "<group>"; };
 		64B446ABFD75C0AE283E6D66 /* GenerationSemantics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationSemantics.swift; sourceTree = "<group>"; };
@@ -655,6 +664,7 @@
 		ABDB19FC47AD8EFFA3B2539D /* VocelloiOSUITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocelloiOSUITestCase.swift; sourceTree = "<group>"; };
 		AE6BCB1EBEAB95BB7072AC30 /* VoiceDesignBriefCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceDesignBriefCatalog.swift; sourceTree = "<group>"; };
 		B03BDEE35746990C5202A7A9 /* sohee.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = sohee.wav; sourceTree = "<group>"; };
+		B290DD34425D07A47B0BACDD /* IOSModelDownloadLedger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOSModelDownloadLedger.swift; sourceTree = "<group>"; };
 		B3D02EB9F1A9C5CFD933A98F /* VocelloiOSUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = VocelloiOSUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B52E6F8ECC8DB9E266F1EE87 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		B62852B52626359D53D76C11 /* QwenVoice.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = QwenVoice.entitlements; sourceTree = "<group>"; };
@@ -887,6 +897,7 @@
 			isa = PBXGroup;
 			children = (
 				BBCE5DF7AD407A17AF522154 /* VocelloiOSBenchmarkUITests.swift */,
+				3A460ED1FFAC6253A10DB399 /* VocelloiOSModelDownloadUITests.swift */,
 				CDDDFA0A5DBF06B5F473D5DA /* VocelloiOSSmokeUITests.swift */,
 				ABDB19FC47AD8EFFA3B2539D /* VocelloiOSUITestCase.swift */,
 			);
@@ -934,11 +945,14 @@
 				F84E19D8BAEB03195166A26A /* IOSMemoryMetricsBridge.m */,
 				49BEE66D24F4934078649171 /* IOSMemoryQualificationPlan.swift */,
 				FC8AF8C5F67A18A2A6790A33 /* IOSMemorySnapshot.swift */,
+				B290DD34425D07A47B0BACDD /* IOSModelDownloadLedger.swift */,
 				B91514FA8C99D6C0162B95D2 /* LatestEventCoalescer.swift */,
 				E7D8418594EA6787C67A3BFD /* MetricKitMemoryExitSummary.swift */,
 				C9DFF46140E21950EEDD4721 /* MLXModelLoadCoordinator.swift */,
 				5480928772E9EF2D5AE57945 /* MLXTTSEngine.swift */,
 				3F056FE32E688786725FCC8D /* ModelAssets.swift */,
+				45E49D20CE50DF8A66191ECE /* ModelDownloadContracts.swift */,
+				62B18285F5BF030DFCD13276 /* ModelDownloadDiagnosticsStore.swift */,
 				C5814A0DF5264DE6671474C8 /* ModelRegistry.swift */,
 				05AE04FC3819262A8952F8FB /* NativeCloneSupport.swift */,
 				94A9B9883FADDCC6CEB61F10 /* NativeDeviceClassGate.swift */,
@@ -1386,6 +1400,7 @@
 				8E5042DE0774445AE17AEDA2 /* LanguageTestSupport.swift */,
 				5932A386FF76F76B0E476E8D /* MainThreadStallWatchdogTests.swift */,
 				92897B88826720DA43A40B19 /* MemoryTelemetryV8Tests.swift */,
+				3906B4F64C4DEF21F1AFEF77 /* ModelDownloadLifecycleTests.swift */,
 				99ADD3256887325626693B3B /* PromptLanguageDetectorTests.swift */,
 				7AB88B8C400B171FB3344FC3 /* Qwen3SupportedLanguageTests.swift */,
 				340E2BD754D44D2C17FF440C /* WordErrorRateTests.swift */,
@@ -1931,11 +1946,14 @@
 				94B78EACF79C8D0C97B1A8A2 /* IOSMemoryMetricsBridge.m in Sources */,
 				F5BA627B8C3FDC2723674F27 /* IOSMemoryQualificationPlan.swift in Sources */,
 				DFF41A112585ADC31484F16C /* IOSMemorySnapshot.swift in Sources */,
+				EDA50C5B7EBB79527D8D1CA7 /* IOSModelDownloadLedger.swift in Sources */,
 				BB752024AFAACE7A138CA40E /* LatestEventCoalescer.swift in Sources */,
 				A1A06C031B9A40EA24BB7C8A /* MLXModelLoadCoordinator.swift in Sources */,
 				3D8813651CD03DBB73CF1029 /* MLXTTSEngine.swift in Sources */,
 				A6C3CAD0B42E40029BF8662A /* MetricKitMemoryExitSummary.swift in Sources */,
 				6F2BABA0C7850D795608204A /* ModelAssets.swift in Sources */,
+				54FC6AE5F636C4E0D86D77A2 /* ModelDownloadContracts.swift in Sources */,
+				2B47852312BC5ADBD59E0AEE /* ModelDownloadDiagnosticsStore.swift in Sources */,
 				850CDA13E23723B8A92F7D9C /* ModelRegistry.swift in Sources */,
 				06445A839283CCD0ADBFF1C7 /* NativeCloneSupport.swift in Sources */,
 				8D9A691EFE792C66890246A2 /* NativeDeviceClassGate.swift in Sources */,
@@ -2062,6 +2080,7 @@
 				64531299DDEF9DB9352ED082 /* MainThreadStallWatchdog.swift in Sources */,
 				B2F24D789A1F4DE0B7A5E124 /* MainThreadStallWatchdogTests.swift in Sources */,
 				9D3421699759E1D7B88C354A /* MemoryTelemetryV8Tests.swift in Sources */,
+				D45A1753FBA6D932E5DB46C0 /* ModelDownloadLifecycleTests.swift in Sources */,
 				C249DAFEA220226AC8AC9A1F /* PromptLanguageDetectorTests.swift in Sources */,
 				1A29ACA5ECBACAE2F5AC4958 /* Qwen3SupportedLanguageTests.swift in Sources */,
 				1B078BCA387E60CFA8C95C82 /* VoiceClipTranscriber.swift in Sources */,
@@ -2174,6 +2193,7 @@
 			files = (
 				D10C5160F084B1EFF1C98B30 /* VocelloUIAutomationSupport.swift in Sources */,
 				5CEA95BA39656930F468D27B /* VocelloiOSBenchmarkUITests.swift in Sources */,
+				295227743AD5033491455176 /* VocelloiOSModelDownloadUITests.swift in Sources */,
 				40DC335349106693E0EC365F /* VocelloiOSSmokeUITests.swift in Sources */,
 				EE74F86575A75A733CEB560D /* VocelloiOSUITestCase.swift in Sources */,
 			);

--- a/Sources/QwenVoiceCore/HuggingFaceDownloader.swift
+++ b/Sources/QwenVoiceCore/HuggingFaceDownloader.swift
@@ -1,14 +1,17 @@
 import CryptoKit
-import Foundation
-import QwenVoiceCore
+@preconcurrency import Foundation
 
 /// Downloads a HuggingFace model repository using native URLSession.
-public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, @unchecked Sendable {
+public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate {
 
     public enum DownloadPhase: String, Equatable, Sendable {
+        case queued
+        case waitingForConnectivity
         case downloading
+        case retrying
         case verifying
         case installing
+        case cancelling
     }
 
     public struct RepositoryProgress: Equatable, Sendable {
@@ -18,10 +21,25 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         public let totalFiles: Int
         public let bytesPerSecond: Int64?
         public let isStalled: Bool
+        public let estimatedSecondsRemaining: Double?
+        public let retryCount: Int
+        public let statusMessage: String?
         public let phase: DownloadPhase
     }
 
-    /// Tunable download-engine parameters. Defaults match the macOS/CLI profile: 4 parallel
+    public struct TransferMetrics: Codable, Equatable, Sendable {
+        public let relativePath: String?
+        public let protocolName: String?
+        public let redirectCount: Int
+        public let reusedConnection: Bool
+        public let cellular: Bool
+        public let constrained: Bool
+        public let expensive: Bool
+        public let transferredBytes: Int64
+        public let durationSeconds: Double
+    }
+
+    /// Tunable download-engine parameters. Defaults match the macOS/CLI profile: 6 parallel
     /// connections per host and `chunkLargeFiles = false`. iOS uses a memory-safer profile:
     /// fewer parallel files and `chunkLargeFiles = false` (background URLSession throttles many
     /// small range requests, and chunks multiply in-flight buffers). The foreground URLSession's
@@ -37,7 +55,7 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
 
     public enum DownloadError: LocalizedError {
         case cancelled
-        case httpError(statusCode: Int, path: String)
+        case httpError(statusCode: Int, path: String, retryAfterSeconds: Double? = nil)
         case fileDownloadFailed(path: String, underlying: Error)
         case integrityCheckFailed(path: String, reason: String)
         case rangeUnsupported(path: String)
@@ -50,7 +68,7 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
             switch self {
             case .cancelled:
                 return "Download cancelled"
-            case .httpError(let code, let path):
+            case .httpError(let code, let path, _):
                 return "HTTP \(code) downloading \(path)"
             case .fileDownloadFailed(let path, let underlying):
                 return "Failed to download \(path): \(underlying.localizedDescription)"
@@ -114,25 +132,60 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
     struct DownloadedTemporaryFile: Sendable {
         let url: URL
         let statusCode: Int?
+        let retryAfterSeconds: Double?
+        let contentRange: String?
     }
 
-    final class RepositoryProgressHandlerBox: @unchecked Sendable {
-        let handler: (RepositoryProgress) -> Void
+    final class RepositoryProgressHandlerBox: Sendable {
+        let handler: @Sendable (RepositoryProgress) -> Void
 
-        init(_ handler: @escaping (RepositoryProgress) -> Void) {
+        init(_ handler: @escaping @Sendable (RepositoryProgress) -> Void) {
             self.handler = handler
         }
     }
 
+    final class TransferMetricsHandlerBox: Sendable {
+        let handler: @Sendable (TransferMetrics) -> Void
+
+        init(_ handler: @escaping @Sendable (TransferMetrics) -> Void) {
+            self.handler = handler
+        }
+    }
+
+    final class VerifiedArtifactHandlerBox: Sendable {
+        let handler: @Sendable (VerifiedArtifactReceipt) async -> Void
+
+        init(_ handler: @escaping @Sendable (VerifiedArtifactReceipt) async -> Void) {
+            self.handler = handler
+        }
+    }
+
+    /// Foundation has not annotated FileManager as Sendable. Confine that compatibility gap to
+    /// one immutable adapter instead of making the downloader broadly unchecked.
+    final class FileManagerBox: @unchecked Sendable {
+        let value: FileManager
+
+        init(_ value: FileManager) {
+            self.value = value
+        }
+    }
+
     final class TaskCancellationBox: @unchecked Sendable {
-        private let cancellation: () -> Void
+        private let task: URLSessionDownloadTask
+        private let resumeDataURL: URL?
 
         init(task: URLSessionDownloadTask, resumeDataURL: URL?) {
-            self.cancellation = {
-                task.cancel { resumeData in
+            self.task = task
+            self.resumeDataURL = resumeDataURL
+        }
+
+        func cancelAndWait() async {
+            await withCheckedContinuation { continuation in
+                task.cancel { [resumeDataURL] resumeData in
                     guard let resumeDataURL,
                           let resumeData,
                           !resumeData.isEmpty else {
+                        continuation.resume()
                         return
                     }
                     try? FileManager.default.createDirectory(
@@ -140,12 +193,9 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
                         withIntermediateDirectories: true
                     )
                     try? resumeData.write(to: resumeDataURL, options: .atomic)
+                    continuation.resume()
                 }
             }
-        }
-
-        func cancel() {
-            cancellation()
         }
     }
 
@@ -172,8 +222,22 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         private var lastSpeedSampleTime: TimeInterval?
         private var lastSpeedSampleBytes: Int64 = 0
         private var lastMeasuredBytesPerSecond: Int64?
+        private var lastProgressPublicationTime: TimeInterval?
+        private var lastPublishedBytes: Int64 = -1
+        private var lastPublishedPhase: DownloadPhase?
         private var phase: DownloadPhase = .downloading
         private var heartbeatTask: Task<Void, Never>?
+        private var retryCount = 0
+        private var statusMessage: String?
+        // A download file callback precedes task metrics and the terminal task callback.
+        // Keep the durable file staged until didCompleteWithError so callers cannot publish
+        // a success summary before URLSession has delivered its final metrics.
+        private var stagedSuccessfulDownloads: [Int: (ModelDownloadTaskIdentity?, DownloadedTemporaryFile)] = [:]
+        private var unclaimedCompletionsByRelativePath: [String: DownloadedTemporaryFile] = [:]
+        private var expectedTaskIdentityByURL: [URL: ModelDownloadTaskIdentity] = [:]
+        private var adoptedTasksByRelativePath: [String: URLSessionDownloadTask] = [:]
+        private var backgroundCompletionGate = ModelDownloadBackgroundCompletionGate()
+        private var verifiedReceiptsByPath: [String: VerifiedArtifactReceipt] = [:]
 
         /// Bytes counted so far: completed files (at their exact size) plus the live sum of
         /// in-flight task bytes (single-stream or chunk). Recomputed so retries and chunks
@@ -186,7 +250,7 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
             self.repositoryProgressHandler = repositoryProgressHandler
         }
 
-        func resetForNewRepositoryDownload() {
+        func resetForNewRepositoryDownload(preserveUnclaimedCompletions: Bool) {
             isCancelled = false
             activeCancellations.removeAll()
             continuations.removeAll()
@@ -201,7 +265,26 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
             lastSpeedSampleTime = nil
             lastSpeedSampleBytes = 0
             lastMeasuredBytesPerSecond = nil
+            lastProgressPublicationTime = nil
+            lastPublishedBytes = -1
+            lastPublishedPhase = nil
             phase = .downloading
+            retryCount = 0
+            statusMessage = nil
+            if !preserveUnclaimedCompletions {
+                for (_, staged) in stagedSuccessfulDownloads.values {
+                    try? FileManager.default.removeItem(at: staged.url)
+                }
+                stagedSuccessfulDownloads.removeAll()
+                for completion in unclaimedCompletionsByRelativePath.values {
+                    try? FileManager.default.removeItem(at: completion.url)
+                }
+                unclaimedCompletionsByRelativePath.removeAll()
+            }
+            expectedTaskIdentityByURL.removeAll()
+            adoptedTasksByRelativePath.removeAll()
+            backgroundCompletionGate.resetForRequest()
+            verifiedReceiptsByPath.removeAll()
             heartbeatTask?.cancel()
             heartbeatTask = nil
         }
@@ -230,20 +313,65 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
             resumeDataURL: URL?,
             fileIndex: Int,
             existingBytes: Int64 = 0
-        ) {
+        ) -> Bool {
             let taskID = task.taskIdentifier
+            if isCancelled {
+                task.cancel()
+                continuation.resume(throwing: DownloadError.cancelled)
+                return false
+            }
+            if let identity = ModelDownloadTaskIdentity.decode(taskDescription: task.taskDescription),
+               let completed = unclaimedCompletionsByRelativePath.removeValue(forKey: identity.relativePath) {
+                task.cancel()
+                continuation.resume(returning: completed)
+                return false
+            }
             activeCancellations[taskID] = TaskCancellationBox(task: task, resumeDataURL: resumeDataURL)
             continuations[taskID] = continuation
             destinations[taskID] = destination
             taskFileIndex[taskID] = fileIndex
             taskBytes[taskID] = existingBytes
+            if existingBytes > 0 {
+                let now = ProcessInfo.processInfo.systemUptime
+                applySpeedMeasurement(
+                    now: now,
+                    totalDownloaded: repositoryDownloadedBytes,
+                    advancedDelta: existingBytes
+                )
+                emitRepositoryProgress(isStalled: false)
+            }
+            return true
         }
 
-        func requestCancellation() {
+        func requestCancellation() async {
+            guard !isCancelled else { return }
             isCancelled = true
-            for cancellation in activeCancellations.values {
-                cancellation.cancel()
+            phase = .cancelling
+            statusMessage = nil
+            emitRepositoryProgress(isStalled: false, force: true)
+            let cancellations = Array(activeCancellations.values)
+            await withTaskGroup(of: Void.self) { group in
+                for cancellation in cancellations {
+                    group.addTask {
+                        await cancellation.cancelAndWait()
+                    }
+                }
             }
+            let pendingContinuations = Array(continuations.values)
+            continuations.removeAll()
+            activeCancellations.removeAll()
+            destinations.removeAll()
+            for continuation in pendingContinuations {
+                continuation.resume(throwing: DownloadError.cancelled)
+            }
+            for (_, staged) in stagedSuccessfulDownloads.values {
+                try? FileManager.default.removeItem(at: staged.url)
+            }
+            stagedSuccessfulDownloads.removeAll()
+            for completion in unclaimedCompletionsByRelativePath.values {
+                try? FileManager.default.removeItem(at: completion.url)
+            }
+            unclaimedCompletionsByRelativePath.removeAll()
         }
 
         func cancellationRequested() -> Bool {
@@ -252,7 +380,65 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
 
         func setPhase(_ phase: DownloadPhase) {
             self.phase = phase
-            emitRepositoryProgress(isStalled: false)
+            if phase != .retrying { statusMessage = nil }
+            emitRepositoryProgress(isStalled: false, force: true)
+        }
+
+        func setRetry(number: Int, reason: String) {
+            retryCount = number
+            statusMessage = reason
+            phase = .retrying
+            emitRepositoryProgress(isStalled: false, force: true)
+        }
+
+        func setWaitingForConnectivity(_ waiting: Bool) {
+            if waiting {
+                phase = .waitingForConnectivity
+                statusMessage = "Waiting for connectivity"
+            } else if phase == .waitingForConnectivity {
+                phase = .downloading
+                statusMessage = nil
+            }
+            emitRepositoryProgress(isStalled: false, force: true)
+        }
+
+        func configureExpectedTasks(_ values: [(URL, ModelDownloadTaskIdentity)]) {
+            expectedTaskIdentityByURL = Dictionary(uniqueKeysWithValues: values)
+            adoptedTasksByRelativePath.removeAll()
+        }
+
+        func expectedIdentity(for url: URL) -> ModelDownloadTaskIdentity? {
+            expectedTaskIdentityByURL[url]
+        }
+
+        func adopt(task: URLSessionDownloadTask, identity: ModelDownloadTaskIdentity) -> Bool {
+            guard !isCancelled,
+                  adoptedTasksByRelativePath[identity.relativePath] == nil else {
+                return false
+            }
+            adoptedTasksByRelativePath[identity.relativePath] = task
+            return true
+        }
+
+        func takeAdoptedTask(for url: URL) -> URLSessionDownloadTask? {
+            guard let identity = expectedTaskIdentityByURL[url] else { return nil }
+            return adoptedTasksByRelativePath.removeValue(forKey: identity.relativePath)
+        }
+
+        func markBackgroundEventsFinished() -> Bool {
+            backgroundCompletionGate.markEventsFinished()
+        }
+
+        func markPostprocessingFinished() -> Bool {
+            backgroundCompletionGate.markPostprocessingFinished()
+        }
+
+        func recordVerifiedReceipt(_ receipt: VerifiedArtifactReceipt) {
+            verifiedReceiptsByPath[receipt.relativePath] = receipt
+        }
+
+        func verifiedReceipts() -> [String: VerifiedArtifactReceipt] {
+            verifiedReceiptsByPath
         }
 
         /// Per-task progress from the URLSession delegate. Monotonic per task, so a
@@ -297,7 +483,7 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
             repositoryCompletedFiles += 1
             let now = ProcessInfo.processInfo.systemUptime
             applySpeedMeasurement(now: now, totalDownloaded: repositoryDownloadedBytes, advancedDelta: expectedSize - liveForFile)
-            emitRepositoryProgress(isStalled: false)
+            emitRepositoryProgress(isStalled: false, force: true)
         }
 
         func finishRepositoryDownload() {
@@ -305,17 +491,52 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
             heartbeatTask = nil
         }
 
-        func resumeSuccess(taskID: Int, temporaryFile: DownloadedTemporaryFile) {
+        func stageSuccess(
+            taskID: Int,
+            identity: ModelDownloadTaskIdentity?,
+            temporaryFile: DownloadedTemporaryFile
+        ) {
+            if let (_, superseded) = stagedSuccessfulDownloads.updateValue(
+                (identity, temporaryFile),
+                forKey: taskID
+            ) {
+                try? FileManager.default.removeItem(at: superseded.url)
+            }
+        }
+
+        func completeStagedSuccess(taskID: Int) {
+            guard let (identity, temporaryFile) = stagedSuccessfulDownloads.removeValue(forKey: taskID) else {
+                return
+            }
             let continuation = continuations.removeValue(forKey: taskID)
             destinations.removeValue(forKey: taskID)
             activeCancellations.removeValue(forKey: taskID)
             // NOTE: taskFileIndex/taskBytes are intentionally left in place — the file's
             // live bytes stay counted until reportFileCompleted folds them in (success) or
             // resetFileProgress clears them (retry).
-            continuation?.resume(returning: temporaryFile)
+            if isCancelled {
+                try? FileManager.default.removeItem(at: temporaryFile.url)
+                continuation?.resume(throwing: DownloadError.cancelled)
+            } else if let continuation {
+                continuation.resume(returning: temporaryFile)
+            } else if let identity {
+                // Background callbacks may arrive before launch reconciliation has registered
+                // the adopted task. Keep the durable temporary file until adoption completes.
+                if let superseded = unclaimedCompletionsByRelativePath.updateValue(
+                    temporaryFile,
+                    forKey: identity.relativePath
+                ) {
+                    try? FileManager.default.removeItem(at: superseded.url)
+                }
+            } else {
+                try? FileManager.default.removeItem(at: temporaryFile.url)
+            }
         }
 
         func resumeFailure(taskID: Int, error: Error) {
+            if let (_, staged) = stagedSuccessfulDownloads.removeValue(forKey: taskID) {
+                try? FileManager.default.removeItem(at: staged.url)
+            }
             let continuation = continuations.removeValue(forKey: taskID)
             destinations.removeValue(forKey: taskID)
             activeCancellations.removeValue(forKey: taskID)
@@ -329,10 +550,21 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         private func applySpeedMeasurement(now: TimeInterval, totalDownloaded: Int64, advancedDelta: Int64) {
             guard advancedDelta > 0 else { return }
             if let previousSpeedSampleTime = lastSpeedSampleTime {
-                let elapsed = max(now - previousSpeedSampleTime, 0.001)
+                let elapsed = now - previousSpeedSampleTime
+                guard elapsed >= 0.5 else {
+                    lastProgressAdvanceTime = now
+                    return
+                }
                 let deltaBytes = totalDownloaded - lastSpeedSampleBytes
                 if deltaBytes > 0 {
-                    lastMeasuredBytesPerSecond = Int64(Double(deltaBytes) / elapsed)
+                    let instantaneous = Double(deltaBytes) / elapsed
+                    if let previous = lastMeasuredBytesPerSecond {
+                        lastMeasuredBytesPerSecond = Int64(
+                            (Double(previous) * 0.75) + (instantaneous * 0.25)
+                        )
+                    } else {
+                        lastMeasuredBytesPerSecond = Int64(instantaneous)
+                    }
                     lastSpeedSampleTime = now
                     lastSpeedSampleBytes = totalDownloaded
                 }
@@ -359,24 +591,48 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
             guard !activeCancellations.isEmpty else { return }
 
             let now = ProcessInfo.processInfo.systemUptime
-            guard let lastProgressAdvanceTime, now - lastProgressAdvanceTime >= 1.5 else {
+            guard phase == .downloading,
+                  let lastProgressAdvanceTime,
+                  now - lastProgressAdvanceTime >= 20 else {
                 return
             }
-            emitRepositoryProgress(isStalled: true)
+            emitRepositoryProgress(isStalled: true, force: true)
         }
 
-        private func emitRepositoryProgress(isStalled: Bool) {
+        private func emitRepositoryProgress(isStalled: Bool, force: Bool = false) {
+            let downloaded = min(repositoryDownloadedBytes, repositoryTotalBytes)
+            let now = ProcessInfo.processInfo.systemUptime
+            let phaseChanged = lastPublishedPhase != phase
+            let reachedCompletion = repositoryTotalBytes > 0
+                && downloaded == repositoryTotalBytes
+                && lastPublishedBytes != downloaded
+            if !force, !isStalled, !phaseChanged, !reachedCompletion,
+               let lastProgressPublicationTime,
+               now - lastProgressPublicationTime < 0.25 {
+                return
+            }
+            let remaining = max(repositoryTotalBytes - downloaded, 0)
+            let eta = lastMeasuredBytesPerSecond.flatMap { speed -> Double? in
+                guard speed > 0, phase == .downloading else { return nil }
+                return Double(remaining) / Double(speed)
+            }
             repositoryProgressHandler?.handler(
                 RepositoryProgress(
-                    downloadedBytes: min(repositoryDownloadedBytes, repositoryTotalBytes),
+                    downloadedBytes: downloaded,
                     totalBytes: repositoryTotalBytes,
                     completedFiles: min(repositoryCompletedFiles, repositoryTotalFiles),
                     totalFiles: repositoryTotalFiles,
                     bytesPerSecond: lastMeasuredBytesPerSecond,
                     isStalled: isStalled,
+                    estimatedSecondsRemaining: eta,
+                    retryCount: retryCount,
+                    statusMessage: statusMessage,
                     phase: phase
                 )
             )
+            lastProgressPublicationTime = now
+            lastPublishedBytes = downloaded
+            lastPublishedPhase = phase
         }
     }
 
@@ -434,16 +690,25 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         }
     }
 
-    private var session: URLSession!
+    // Foundation's delegate protocols are Sendable, while URLSession is initialized after
+    // self so it can retain this delegate. The session reference is assigned once during init;
+    // all mutable transfer state remains isolated by DownloadStateRegistry.
+    private nonisolated(unsafe) var session: URLSession!
     private let state: DownloadStateRegistry
     private let apiBaseURL: URL
     private let resolveBaseURL: URL
-    private let fileManager: FileManager
+    private let fileManagerBox: FileManagerBox
+    private var fileManager: FileManager { fileManagerBox.value }
     private let engineConfiguration: Configuration
+    private let isBackgroundSession: Bool
+    private let durableTemporaryDirectory: URL
+    private let verificationProcessGeneration = UUID().uuidString
     /// Invoked from `urlSessionDidFinishEvents(forBackgroundURLSession:)` (background sessions
     /// only) with the session's identifier so iOS can flush its app-delegate completion handler.
     /// macOS/CLI pass `nil` (foreground sessions never trigger this callback).
     private let backgroundSessionCompletionHandler: (@Sendable (String) -> Void)?
+    private let transferMetricsHandler: TransferMetricsHandlerBox?
+    private let verifiedArtifactHandler: VerifiedArtifactHandlerBox?
 
     static func validatedRelativeRepoPath(_ path: String) throws -> String {
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -594,24 +859,31 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
     }
 
     public init(
-        progressHandler: ((RepositoryProgress) -> Void)?,
+        progressHandler: (@Sendable (RepositoryProgress) -> Void)?,
         sessionConfiguration: URLSessionConfiguration = .default,
         engineConfiguration: Configuration = Configuration(),
         apiBaseURL: URL = URL(string: "https://huggingface.co/api/models")!,
         resolveBaseURL: URL = URL(string: "https://huggingface.co")!,
         fileManager: FileManager = .default,
+        durableTemporaryDirectory: URL? = nil,
+        transferMetricsHandler: (@Sendable (TransferMetrics) -> Void)? = nil,
+        verifiedArtifactHandler: (@Sendable (VerifiedArtifactReceipt) async -> Void)? = nil,
         backgroundSessionCompletionHandler: (@Sendable (String) -> Void)? = nil
     ) {
         let progressBox = progressHandler.map(RepositoryProgressHandlerBox.init)
         state = DownloadStateRegistry(repositoryProgressHandler: progressBox)
         self.apiBaseURL = apiBaseURL
         self.resolveBaseURL = resolveBaseURL
-        self.fileManager = fileManager
+        self.fileManagerBox = FileManagerBox(fileManager)
         self.engineConfiguration = engineConfiguration
         self.backgroundSessionCompletionHandler = backgroundSessionCompletionHandler
+        self.transferMetricsHandler = transferMetricsHandler.map(TransferMetricsHandlerBox.init)
+        self.verifiedArtifactHandler = verifiedArtifactHandler.map(VerifiedArtifactHandlerBox.init)
+        self.isBackgroundSession = sessionConfiguration.identifier != nil
+        self.durableTemporaryDirectory = durableTemporaryDirectory ?? fileManager.temporaryDirectory
         super.init()
 
-        let isBackground = sessionConfiguration.identifier != nil
+        let isBackground = isBackgroundSession
         let config: URLSessionConfiguration
         if isBackground {
             // Background configs are effectively singletons-by-identifier; copying/mutating one
@@ -634,15 +906,20 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
     /// Resolve the file list from the live HuggingFace API, then download + verify + install.
     /// macOS + CLI path.
     public func downloadRepo(repo: String, revision: String = "main", to targetDir: URL) async throws {
-        await state.resetForNewRepositoryDownload()
-        let files = try await listFiles(repo: repo, revision: revision)
-        try await runDownload(
-            files: files,
-            repo: repo,
-            revision: revision,
-            targetDir: targetDir,
-            persistStateManifest: true
-        )
+        await state.resetForNewRepositoryDownload(preserveUnclaimedCompletions: isBackgroundSession)
+        do {
+            let files = try await listFiles(repo: repo, revision: revision)
+            try await runDownload(
+                files: files,
+                repo: repo,
+                revision: revision,
+                targetDir: targetDir,
+                persistStateManifest: true
+            )
+        } catch {
+            if !isBackgroundSession { session.invalidateAndCancel() }
+            throw error
+        }
     }
 
     /// Download + verify + install a pre-resolved file list (no API call). iOS path — the caller
@@ -653,15 +930,19 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         _ files: [RepoFile],
         repo: String,
         revision: String,
-        to targetDir: URL
+        to targetDir: URL,
+        requestIdentity: ModelDownloadRequestIdentity? = nil,
+        stagingRoot explicitStagingRoot: URL? = nil
     ) async throws {
-        await state.resetForNewRepositoryDownload()
+        await state.resetForNewRepositoryDownload(preserveUnclaimedCompletions: isBackgroundSession)
         try await runDownload(
             files: files,
             repo: repo,
             revision: revision,
             targetDir: targetDir,
-            persistStateManifest: false
+            persistStateManifest: false,
+            requestIdentity: requestIdentity,
+            explicitStagingRoot: explicitStagingRoot
         )
     }
 
@@ -672,12 +953,14 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         repo: String,
         revision: String,
         targetDir: URL,
-        persistStateManifest: Bool
+        persistStateManifest: Bool,
+        requestIdentity: ModelDownloadRequestIdentity? = nil,
+        explicitStagingRoot: URL? = nil
     ) async throws {
         let totalBytes = files.reduce(Int64(0)) { $0 + $1.size }
         await state.beginRepositoryDownload(totalBytes: totalBytes, totalFiles: files.count)
 
-        let stagingRoot = Self.stagingRoot(forTargetDirectory: targetDir)
+        let stagingRoot = explicitStagingRoot ?? Self.stagingRoot(forTargetDirectory: targetDir)
         let filesRoot = stagingRoot.appendingPathComponent("files", isDirectory: true)
         let partialRoot = stagingRoot.appendingPathComponent("partials", isDirectory: true)
         let resumeRoot = stagingRoot.appendingPathComponent("resume-data", isDirectory: true)
@@ -688,6 +971,35 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         Self.markExcludedFromBackup(filesRoot)
         Self.markExcludedFromBackup(partialRoot)
         Self.markExcludedFromBackup(resumeRoot)
+        try fileManager.createDirectory(at: durableTemporaryDirectory, withIntermediateDirectories: true)
+        Self.markExcludedFromBackup(durableTemporaryDirectory)
+
+        if let requestIdentity {
+            let expectedTasks = try files.map { file -> (URL, ModelDownloadTaskIdentity) in
+                let relativePath = try Self.validatedRelativeRepoPath(file.path)
+                let url = try file.absoluteURL ?? Self.fileResolveURL(
+                    resolveBaseURL: resolveBaseURL,
+                    repo: repo,
+                    revision: revision,
+                    relativePath: relativePath
+                )
+                return (
+                    url,
+                    ModelDownloadTaskIdentity(
+                        logicalRequestID: requestIdentity.logicalRequestID,
+                        modelID: requestIdentity.modelID,
+                        artifactVersion: requestIdentity.artifactVersion,
+                        relativePath: relativePath,
+                        expectedSize: file.size,
+                        expectedSHA256: file.sha256
+                    )
+                )
+            }
+            await state.configureExpectedTasks(expectedTasks)
+            if isBackgroundSession {
+                await reconcileBackgroundTasks(expected: Dictionary(uniqueKeysWithValues: expectedTasks.map { ($0.1.relativePath, $0.1) }))
+            }
+        }
         // The download-state manifest is the macOS resume-after-crash record; iOS keeps its own
         // lightweight in-flight list, so the catalog path skips this.
         if persistStateManifest {
@@ -705,12 +1017,17 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
                 files,
                 repo: repo,
                 revision: revision,
+                artifactVersion: requestIdentity?.artifactVersion ?? revision,
                 filesRoot: filesRoot,
                 partialRoot: partialRoot,
                 resumeRoot: resumeRoot
             )
             await state.setPhase(.verifying)
-            try verifyDownloadedFiles(files, in: filesRoot)
+            try await verifyDownloadedFilesUsingReceipts(
+                files,
+                artifactVersion: requestIdentity?.artifactVersion ?? revision,
+                in: filesRoot
+            )
             try persistInstalledIntegrityManifest(
                 repo: repo,
                 revision: revision,
@@ -723,11 +1040,15 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
             Self.markExcludedFromBackup(targetDir)
             try? fileManager.removeItem(at: stagingRoot)
             await state.finishRepositoryDownload()
+            await completeBackgroundEventsAfterPostprocessing()
+            if !isBackgroundSession { session.finishTasksAndInvalidate() }
         } catch {
             // A failure (or cancellation) mid-download: tear down any remaining
             // in-flight URLSession tasks so the caller doesn't wait for them.
             await state.requestCancellation()
             await state.finishRepositoryDownload()
+            await completeBackgroundEventsAfterPostprocessing()
+            if !isBackgroundSession { session.invalidateAndCancel() }
             throw error
         }
     }
@@ -736,6 +1057,67 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
     /// don't race against a removed directory.
     public func cancel() async {
         await state.requestCancellation()
+    }
+
+    /// Remove orphan or stale tasks when no durable request is eligible for adoption.
+    public func cancelAllSessionTasks() async {
+        let tasks = await withCheckedContinuation { continuation in
+            session.getAllTasks { continuation.resume(returning: $0) }
+        }
+        await withTaskGroup(of: Void.self) { group in
+            for case let task as URLSessionDownloadTask in tasks {
+                group.addTask {
+                    await withCheckedContinuation { continuation in
+                        task.cancel { _ in continuation.resume() }
+                    }
+                }
+            }
+        }
+        await state.requestCancellation()
+    }
+
+    private func completeBackgroundEventsAfterPostprocessing() async {
+        guard isBackgroundSession,
+              let identifier = session.configuration.identifier,
+              await state.markPostprocessingFinished() else { return }
+        backgroundSessionCompletionHandler?(identifier)
+    }
+
+    private func reconcileBackgroundTasks(expected: [String: ModelDownloadTaskIdentity]) async {
+        let tasks = await withCheckedContinuation { continuation in
+            session.getAllTasks { continuation.resume(returning: $0) }
+        }
+        var existing: [ModelDownloadExistingTask] = []
+        var validIdentityByTaskID: [Int: ModelDownloadTaskIdentity] = [:]
+        for task in tasks {
+            var validIdentity: ModelDownloadTaskIdentity?
+            if let identity = ModelDownloadTaskIdentity.decode(taskDescription: task.taskDescription),
+               let expectedIdentity = expected[identity.relativePath],
+               identity == expectedIdentity,
+               let taskURL = task.originalRequest?.url,
+               await state.expectedIdentity(for: taskURL) == expectedIdentity {
+                validIdentity = identity
+                validIdentityByTaskID[task.taskIdentifier] = identity
+            }
+            existing.append(ModelDownloadExistingTask(
+                taskID: task.taskIdentifier,
+                identity: validIdentity
+            ))
+        }
+        let plan = ModelDownloadTaskReconciler.plan(
+            expected: Array(expected.values),
+            existing: existing
+        )
+        let cancelled = Set(plan.cancelledTaskIDs)
+        for task in tasks {
+            guard !cancelled.contains(task.taskIdentifier),
+                  let downloadTask = task as? URLSessionDownloadTask,
+                  let identity = validIdentityByTaskID[task.taskIdentifier],
+                  await state.adopt(task: downloadTask, identity: identity) else {
+                task.cancel()
+                continue
+            }
+        }
     }
 
     // MARK: - Private: List Files
@@ -783,6 +1165,7 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         _ files: [RepoFile],
         repo: String,
         revision: String,
+        artifactVersion: String,
         filesRoot: URL,
         partialRoot: URL,
         resumeRoot: URL
@@ -807,6 +1190,7 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
                         fileIndex: index,
                         repo: repo,
                         revision: revision,
+                        artifactVersion: artifactVersion,
                         filesRoot: filesRoot,
                         partialRoot: partialRoot,
                         resumeRoot: resumeRoot
@@ -826,6 +1210,7 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
                         fileIndex: index,
                         repo: repo,
                         revision: revision,
+                        artifactVersion: artifactVersion,
                         filesRoot: filesRoot,
                         partialRoot: partialRoot,
                         resumeRoot: resumeRoot
@@ -842,6 +1227,7 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         fileIndex: Int,
         repo: String,
         revision: String,
+        artifactVersion: String,
         filesRoot: URL,
         partialRoot: URL,
         resumeRoot: URL
@@ -858,6 +1244,13 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         try fileManager.createDirectory(at: partialURL.deletingLastPathComponent(), withIntermediateDirectories: true)
 
         if fileIsValid(at: destURL, expectedSize: file.size, sha256: file.sha256) {
+            try await recordVerifiedReceipt(
+                relativePath: relativePath,
+                artifactVersion: artifactVersion,
+                expectedSize: file.size,
+                expectedSHA256: file.sha256,
+                fileURL: destURL
+            )
             await state.reportFileCompleted(fileIndex: fileIndex, expectedSize: file.size)
             return
         }
@@ -883,6 +1276,14 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
             fileIndex: fileIndex
         )
 
+        try await recordVerifiedReceipt(
+            relativePath: relativePath,
+            artifactVersion: artifactVersion,
+            expectedSize: file.size,
+            expectedSHA256: file.sha256,
+            fileURL: destURL
+        )
+
         await state.reportFileCompleted(fileIndex: fileIndex, expectedSize: file.size)
     }
 
@@ -894,6 +1295,7 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         fileIndex: Int,
         repo: String,
         revision: String,
+        artifactVersion: String,
         filesRoot: URL,
         partialRoot: URL,
         resumeRoot: URL
@@ -904,6 +1306,7 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
                 fileIndex: fileIndex,
                 repo: repo,
                 revision: revision,
+                artifactVersion: artifactVersion,
                 filesRoot: filesRoot,
                 partialRoot: partialRoot,
                 resumeRoot: resumeRoot
@@ -931,7 +1334,8 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         // Retry transient failures (network drops, HTTP 5xx/429, integrity mismatches)
         // so a single hiccup no longer fails the whole repo download. The partial
         // already on disk lets each attempt resume via a Range request.
-        var attempt = 0
+        var retryNumber = 0
+        var integrityRetryUsed = false
         var avoidChunking = false
         while true {
             do {
@@ -950,13 +1354,7 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
                 )
                 return
             } catch {
-                // Cancellation and non-retryable HTTP 4xx client errors fail fast.
                 if let dlError = error as? DownloadError {
-                    if case .cancelled = dlError { throw error }
-                    if case .httpError(let code, _) = dlError,
-                       (400..<500).contains(code), code != 429 {
-                        throw error
-                    }
                     // The server ignored a byte-range request — fall back to single-stream
                     // for the remaining attempts instead of thrashing on chunks. The chunked
                     // attempt may have left a sparse/holey partial, so clear it too.
@@ -975,24 +1373,44 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
                     }
                 }
 
-                attempt += 1
-                guard attempt <= engineConfiguration.maxDownloadRetries else { throw error }
-
-                // A partial that failed integrity can't be resumed into a correct file;
-                // clear it (and any resume blob) so the next attempt downloads fresh.
-                if let dlError = error as? DownloadError, case .integrityCheckFailed = dlError {
+                retryNumber += 1
+                let disposition = ModelDownloadRetryPolicy.disposition(
+                    error: error,
+                    retryNumber: retryNumber,
+                    integrityRetryAlreadyUsed: integrityRetryUsed
+                )
+                let delay: Double
+                switch disposition {
+                case .cancelled, .fail:
+                    throw error
+                case .retry(let afterSeconds):
+                    delay = afterSeconds
+                case .retryClean(let afterSeconds):
+                    delay = afterSeconds
                     try? fileManager.removeItem(at: partialURL)
                     try? fileManager.removeItem(at: resumeDataURL)
+                    if let dlError = error as? DownloadError,
+                       case .integrityCheckFailed = dlError {
+                        integrityRetryUsed = true
+                    }
                 }
 
-                let backoff = Self.retryBackoffSeconds(for: attempt)
-                try? await Task.sleep(for: .seconds(backoff))
-                if Task.isCancelled {
+                guard retryNumber <= engineConfiguration.maxDownloadRetries else { throw error }
+                guard !Task.isCancelled,
+                      !(await state.cancellationRequested()) else {
                     throw DownloadError.cancelled
                 }
-                if await state.cancellationRequested() {
+                await state.setRetry(number: retryNumber, reason: retryReason(for: error))
+                do {
+                    try await Task.sleep(for: .seconds(delay))
+                } catch {
                     throw DownloadError.cancelled
                 }
+                guard !Task.isCancelled,
+                      !(await state.cancellationRequested()) else {
+                    throw DownloadError.cancelled
+                }
+                await state.setPhase(.downloading)
             }
         }
     }
@@ -1039,6 +1457,13 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
             throw DownloadError.cancelled
         }
 
+        if completedBytes > 0, downloaded.statusCode == 206,
+           !Self.contentRange(downloaded.contentRange, startsAt: completedBytes) {
+            try? fileManager.removeItem(at: downloaded.url)
+            try? fileManager.removeItem(at: partialURL)
+            throw DownloadError.rangeUnsupported(path: url.path)
+        }
+
         try applyDownloadedTemporaryFile(
             downloaded,
             partialURL: partialURL,
@@ -1053,11 +1478,19 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         try publishDownloadedFile(partialURL, to: destination)
     }
 
-    /// Exponential backoff (with jitter) between retry attempts: ~1s, ~2s, ~4s, capped.
-    private static func retryBackoffSeconds(for attempt: Int) -> Double {
-        let base = pow(2.0, Double(attempt - 1))
-        let jitter = Double.random(in: 0...0.5)
-        return min(base + jitter, 10)
+    private func retryReason(for error: Error) -> String {
+        if let downloadError = error as? DownloadError {
+            switch downloadError {
+            case .httpError(let statusCode, _, _): return "HTTP \(statusCode)"
+            case .integrityCheckFailed: return "Integrity verification"
+            case .rangeUnsupported: return "Range response"
+            case .chunkAssemblyFailed: return "Chunk assembly"
+            case .fileDownloadFailed: return "Network transfer"
+            case .cancelled: return "Cancelled"
+            case .invalidRemotePath, .invalidLocalDestination, .apiError: return "Configuration"
+            }
+        }
+        return "Network transfer"
     }
 
     /// Download a large file as parallel byte-range chunks, assembling them into the
@@ -1125,21 +1558,22 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         let downloaded = try await withCheckedThrowingContinuation { continuation in
             let task = session.downloadTask(with: request)
             Task {
-                await state.register(
+                let shouldResume = await state.register(
                     task: task,
                     destination: url,
                     continuation: continuation,
                     resumeDataURL: nil,
                     fileIndex: fileIndex
                 )
-                task.resume()
+                if shouldResume { task.resume() }
             }
         }
 
         // The delegate treats 200 and 206 as success; for a range request 200 means the
         // server ignored Range and returned the whole file — throw a dedicated error so the
         // file-level retry falls back to a single stream instead of thrashing on chunks.
-        guard downloaded.statusCode == 206 else {
+        guard downloaded.statusCode == 206,
+              Self.contentRange(downloaded.contentRange, matchesStart: start, end: end) else {
             try? fileManager.removeItem(at: downloaded.url)
             throw DownloadError.rangeUnsupported(path: url.path)
         }
@@ -1166,19 +1600,71 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         return ranges
     }
 
+    static func contentRange(_ value: String?, startsAt expectedStart: Int64) -> Bool {
+        guard let value,
+              let match = value.range(
+                of: #"^bytes\s+([0-9]+)-([0-9]+)/(?:[0-9]+|\*)$"#,
+                options: [.regularExpression, .caseInsensitive]
+              ) else { return false }
+        let matched = String(value[match])
+        guard let rangePart = matched.split(separator: " ").last?.split(separator: "/").first,
+              let start = rangePart.split(separator: "-").first.flatMap({ Int64($0) }) else {
+            return false
+        }
+        return start == expectedStart
+    }
+
+    static func contentRange(_ value: String?, matchesStart expectedStart: Int64, end expectedEnd: Int64) -> Bool {
+        guard contentRange(value, startsAt: expectedStart),
+              let value,
+              let rangePart = value.split(separator: " ").last?.split(separator: "/").first else {
+            return false
+        }
+        let bounds = rangePart.split(separator: "-")
+        guard bounds.count == 2, let end = Int64(bounds[1]) else { return false }
+        return end == expectedEnd
+    }
+
     private func downloadTemporaryFile(
         from url: URL,
         existingBytes: Int64,
         resumeDataURL: URL,
         fileIndex: Int
     ) async throws -> DownloadedTemporaryFile {
+        if Task.isCancelled {
+            throw DownloadError.cancelled
+        }
+        if await state.cancellationRequested() {
+            throw DownloadError.cancelled
+        }
+
+        if let adoptedTask = await state.takeAdoptedTask(for: url) {
+            return try await withCheckedThrowingContinuation { continuation in
+                Task {
+                    let receivedBytes = max(existingBytes, adoptedTask.countOfBytesReceived)
+                    let shouldResume = await state.register(
+                        task: adoptedTask,
+                        destination: url,
+                        continuation: continuation,
+                        resumeDataURL: resumeDataURL,
+                        fileIndex: fileIndex,
+                        existingBytes: receivedBytes
+                    )
+                    if shouldResume, adoptedTask.state == .suspended {
+                        adoptedTask.resume()
+                    }
+                }
+            }
+        }
+
         if fileManager.fileExists(atPath: resumeDataURL.path),
            let resumeData = try? Data(contentsOf: resumeDataURL) {
             do {
                 return try await withCheckedThrowingContinuation { continuation in
                     let task = session.downloadTask(withResumeData: resumeData)
                     Task {
-                        await state.register(
+                        task.taskDescription = await state.expectedIdentity(for: url)?.encodedTaskDescription
+                        let shouldResume = await state.register(
                             task: task,
                             destination: url,
                             continuation: continuation,
@@ -1186,19 +1672,32 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
                             fileIndex: fileIndex,
                             existingBytes: existingBytes
                         )
-                        task.resume()
+                        if shouldResume { task.resume() }
                     }
                 }
             } catch {
                 try? fileManager.removeItem(at: resumeDataURL)
+                if Task.isCancelled {
+                    throw DownloadError.cancelled
+                }
+                if await state.cancellationRequested() {
+                    throw DownloadError.cancelled
+                }
             }
         }
 
+        if Task.isCancelled {
+            throw DownloadError.cancelled
+        }
+        if await state.cancellationRequested() {
+            throw DownloadError.cancelled
+        }
         let request = Self.downloadRequest(for: url, existingBytes: existingBytes)
         return try await withCheckedThrowingContinuation { continuation in
             let task = session.downloadTask(with: request)
             Task {
-                await state.register(
+                task.taskDescription = await state.expectedIdentity(for: url)?.encodedTaskDescription
+                let shouldResume = await state.register(
                     task: task,
                     destination: url,
                     continuation: continuation,
@@ -1206,7 +1705,7 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
                     fileIndex: fileIndex,
                     existingBytes: existingBytes
                 )
-                task.resume()
+                if shouldResume { task.resume() }
             }
         }
     }
@@ -1257,15 +1756,63 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
         }
     }
 
-    private func verifyDownloadedFiles(_ files: [RepoFile], in root: URL) throws {
+    private func recordVerifiedReceipt(
+        relativePath: String,
+        artifactVersion: String,
+        expectedSize: Int64,
+        expectedSHA256: String?,
+        fileURL: URL
+    ) async throws {
+        let attributes = try fileManager.attributesOfItem(atPath: fileURL.path)
+        let fileSize = (attributes[.size] as? NSNumber)?.int64Value ?? 0
+        let modificationDate = attributes[.modificationDate] as? Date ?? .distantPast
+        let fileIdentifier = (attributes[.systemFileNumber] as? NSNumber)?.uint64Value
+        let receipt = VerifiedArtifactReceipt(
+            relativePath: relativePath,
+            artifactVersion: artifactVersion,
+            expectedSize: expectedSize,
+            expectedSHA256: Self.normalizedSHA256(expectedSHA256),
+            fileSize: fileSize,
+            modificationTimeNanoseconds: Int64(modificationDate.timeIntervalSince1970 * 1_000_000_000),
+            fileIdentifier: fileIdentifier,
+            verificationProcessGeneration: verificationProcessGeneration
+        )
+        await state.recordVerifiedReceipt(receipt)
+        await verifiedArtifactHandler?.handler(receipt)
+    }
+
+    private func verifyDownloadedFilesUsingReceipts(
+        _ files: [RepoFile],
+        artifactVersion: String,
+        in root: URL
+    ) async throws {
+        let receipts = await state.verifiedReceipts()
         for file in files {
             let relativePath = try Self.validatedRelativeRepoPath(file.path)
             let destination = try Self.validatedDestinationURL(for: relativePath, in: root)
-            try Self.validateDownloadedFile(
-                at: destination,
-                expectedSize: file.size,
-                sha256: file.sha256
+            let attributes = try fileManager.attributesOfItem(atPath: destination.path)
+            let currentSize = (attributes[.size] as? NSNumber)?.int64Value ?? 0
+            let currentModificationDate = attributes[.modificationDate] as? Date ?? .distantPast
+            let currentModificationNanoseconds = Int64(
+                currentModificationDate.timeIntervalSince1970 * 1_000_000_000
             )
+            let currentFileIdentifier = (attributes[.systemFileNumber] as? NSNumber)?.uint64Value
+            guard let receipt = receipts[relativePath],
+                  receipt.matches(
+                    relativePath: relativePath,
+                    artifactVersion: artifactVersion,
+                    expectedSize: file.size,
+                    expectedSHA256: Self.normalizedSHA256(file.sha256),
+                    fileSize: currentSize,
+                    modificationTimeNanoseconds: currentModificationNanoseconds,
+                    fileIdentifier: currentFileIdentifier,
+                    processGeneration: verificationProcessGeneration
+                  ) else {
+                throw DownloadError.integrityCheckFailed(
+                    path: relativePath,
+                    reason: "missing or changed same-process verification receipt"
+                )
+            }
         }
     }
 
@@ -1405,7 +1952,18 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
     /// Foreground sessions (macOS/CLI) never trigger this, so they're unaffected.
     public func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
         guard let identifier = session.configuration.identifier else { return }
-        backgroundSessionCompletionHandler?(identifier)
+        Task {
+            if await state.markBackgroundEventsFinished() {
+                backgroundSessionCompletionHandler?(identifier)
+            }
+        }
+    }
+
+    public func urlSession(
+        _ session: URLSession,
+        taskIsWaitingForConnectivity task: URLSessionTask
+    ) {
+        Task { await state.setWaitingForConnectivity(true) }
     }
 
     public func urlSession(
@@ -1417,6 +1975,7 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
     ) {
         let taskID = downloadTask.taskIdentifier
         Task {
+            await state.setWaitingForConnectivity(false)
             await state.reportProgress(taskID: taskID, totalBytesWritten: totalBytesWritten)
         }
     }
@@ -1428,27 +1987,41 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
     ) {
         let taskID = downloadTask.taskIdentifier
 
-        let statusCode = (downloadTask.response as? HTTPURLResponse)?.statusCode
+        let response = downloadTask.response as? HTTPURLResponse
+        let statusCode = response?.statusCode
+        let retryAfterSeconds = Self.retryAfterSeconds(from: response)
+        let contentRange = response?.value(forHTTPHeaderField: "Content-Range")
         if let statusCode, ![200, 206].contains(statusCode) {
             Task {
                 let path = await state.destinationPath(taskID: taskID)
                 await state.resumeFailure(
                     taskID: taskID,
-                    error: DownloadError.httpError(statusCode: statusCode, path: path)
+                    error: DownloadError.httpError(
+                        statusCode: statusCode,
+                        path: path,
+                        retryAfterSeconds: retryAfterSeconds
+                    )
                 )
             }
             return
         }
 
-        let safeTmp = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
+        let safeTmp = durableTemporaryDirectory
+            .appendingPathComponent("task-\(taskID)-\(UUID().uuidString)")
 
         do {
-            try FileManager.default.moveItem(at: location, to: safeTmp)
+            try fileManager.createDirectory(at: durableTemporaryDirectory, withIntermediateDirectories: true)
+            try fileManager.moveItem(at: location, to: safeTmp)
             Task {
-                await state.resumeSuccess(
+                await state.stageSuccess(
                     taskID: taskID,
-                    temporaryFile: DownloadedTemporaryFile(url: safeTmp, statusCode: statusCode)
+                    identity: ModelDownloadTaskIdentity.decode(taskDescription: downloadTask.taskDescription),
+                    temporaryFile: DownloadedTemporaryFile(
+                        url: safeTmp,
+                        statusCode: statusCode,
+                        retryAfterSeconds: retryAfterSeconds,
+                        contentRange: contentRange
+                    )
                 )
             }
         } catch {
@@ -1461,12 +2034,39 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
     public func urlSession(
         _ session: URLSession,
         task: URLSessionTask,
+        didFinishCollecting metrics: URLSessionTaskMetrics
+    ) {
+        guard let transferMetricsHandler else { return }
+        let transactions = metrics.transactionMetrics
+        let last = transactions.last
+        let identity = ModelDownloadTaskIdentity.decode(taskDescription: task.taskDescription)
+        transferMetricsHandler.handler(
+            TransferMetrics(
+                relativePath: identity?.relativePath,
+                protocolName: last?.networkProtocolName,
+                redirectCount: metrics.redirectCount,
+                reusedConnection: transactions.contains(where: { $0.isReusedConnection }),
+                cellular: transactions.contains(where: { $0.isCellular }),
+                constrained: transactions.contains(where: { $0.isConstrained }),
+                expensive: transactions.contains(where: { $0.isExpensive }),
+                transferredBytes: task.countOfBytesReceived,
+                durationSeconds: metrics.taskInterval.duration
+            )
+        )
+    }
+
+    public func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
         didCompleteWithError error: Error?
     ) {
         let taskID = task.taskIdentifier
-        guard let error else { return }
-
         Task {
+            await state.setWaitingForConnectivity(false)
+            guard let error else {
+                await state.completeStagedSuccess(taskID: taskID)
+                return
+            }
             let path = await state.destinationPath(taskID: taskID)
             if (error as NSError).code == NSURLErrorCancelled {
                 await state.resumeFailure(taskID: taskID, error: DownloadError.cancelled)
@@ -1477,5 +2077,18 @@ public final class HuggingFaceDownloader: NSObject, URLSessionDownloadDelegate, 
                 )
             }
         }
+    }
+
+    private static func retryAfterSeconds(from response: HTTPURLResponse?) -> Double? {
+        guard let value = response?.value(forHTTPHeaderField: "Retry-After") else { return nil }
+        if let seconds = Double(value.trimmingCharacters(in: .whitespacesAndNewlines)) {
+            return min(max(seconds, 0), 300)
+        }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE',' dd MMM yyyy HH':'mm':'ss z"
+        guard let date = formatter.date(from: value) else { return nil }
+        return min(max(date.timeIntervalSinceNow, 0), 300)
     }
 }

--- a/Sources/QwenVoiceCore/IOSModelDownloadLedger.swift
+++ b/Sources/QwenVoiceCore/IOSModelDownloadLedger.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+public struct IOSModelDownloadLedger: Codable, Equatable, Sendable {
+    public static let currentSchemaVersion = 2
+
+    public enum Status: String, Codable, Sendable {
+        case queued
+        case waitingForConnectivity
+        case downloading
+        case retrying
+        case verifying
+        case installing
+        case cancelRequested
+        case installed
+        case failed
+        case deleted
+    }
+
+    public struct VerifiedFile: Codable, Equatable, Sendable {
+        public let relativePath: String
+        public let expectedSize: Int64
+        public let sha256: String?
+
+        public init(relativePath: String, expectedSize: Int64, sha256: String?) {
+            self.relativePath = relativePath
+            self.expectedSize = expectedSize
+            self.sha256 = sha256
+        }
+    }
+
+    public struct Request: Codable, Equatable, Sendable {
+        public let logicalRequestID: String
+        public let modelID: String
+        public let artifactVersion: String
+        public let repo: String
+        public let revision: String
+        public let targetFolder: String
+        public let expectedFiles: [String]
+        public var verifiedFiles: [VerifiedFile]
+        public var retryCount: Int
+        public var receivedBytes: Int64
+        public var totalBytes: Int64
+        public var status: Status
+
+        public init(
+            logicalRequestID: String,
+            modelID: String,
+            artifactVersion: String,
+            repo: String,
+            revision: String,
+            targetFolder: String,
+            expectedFiles: [String],
+            verifiedFiles: [VerifiedFile],
+            retryCount: Int,
+            receivedBytes: Int64,
+            totalBytes: Int64,
+            status: Status
+        ) {
+            self.logicalRequestID = logicalRequestID
+            self.modelID = modelID
+            self.artifactVersion = artifactVersion
+            self.repo = repo
+            self.revision = revision
+            self.targetFolder = targetFolder
+            self.expectedFiles = expectedFiles
+            self.verifiedFiles = verifiedFiles
+            self.retryCount = retryCount
+            self.receivedBytes = receivedBytes
+            self.totalBytes = totalBytes
+            self.status = status
+        }
+    }
+
+    public let schemaVersion: Int
+    public var requests: [Request]
+
+    public init(requests: [Request] = []) {
+        self.schemaVersion = Self.currentSchemaVersion
+        self.requests = requests
+    }
+
+    public func validated() throws -> Self {
+        guard schemaVersion == Self.currentSchemaVersion else {
+            throw IOSModelDownloadLedgerError.unsupportedSchema(schemaVersion)
+        }
+        var logicalIDs = Set<String>()
+        var modelIDs = Set<String>()
+        for request in requests {
+            guard !request.logicalRequestID.isEmpty,
+                  !request.modelID.isEmpty,
+                  !request.artifactVersion.isEmpty,
+                  !request.targetFolder.isEmpty,
+                  !request.targetFolder.contains("/"),
+                  request.expectedFiles.allSatisfy({ isSafeRelativePath($0) }),
+                  request.verifiedFiles.allSatisfy({ isSafeRelativePath($0.relativePath) }),
+                  request.receivedBytes >= 0,
+                  request.totalBytes >= 0,
+                  request.retryCount >= 0,
+                  logicalIDs.insert(request.logicalRequestID).inserted,
+                  modelIDs.insert(request.modelID).inserted else {
+                throw IOSModelDownloadLedgerError.invalidDocument
+            }
+        }
+        return self
+    }
+
+    private func isSafeRelativePath(_ value: String) -> Bool {
+        !value.isEmpty && !value.hasPrefix("/") && !value.split(separator: "/").contains("..")
+    }
+}
+
+public enum IOSModelDownloadLedgerError: LocalizedError, Equatable, Sendable {
+    case unsupportedSchema(Int)
+    case invalidDocument
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedSchema(let version):
+            return "Unsupported model-download ledger schema \(version)."
+        case .invalidDocument:
+            return "The model-download ledger is invalid."
+        }
+    }
+}
+
+public struct IOSModelDownloadLedgerStore {
+    public let fileURL: URL
+    public let fileManager: FileManager
+
+    public init(fileURL: URL, fileManager: FileManager = .default) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    public func load() throws -> IOSModelDownloadLedger {
+        guard fileManager.fileExists(atPath: fileURL.path) else {
+            return IOSModelDownloadLedger()
+        }
+        let data = try Data(contentsOf: fileURL)
+        return try JSONDecoder().decode(IOSModelDownloadLedger.self, from: data).validated()
+    }
+
+    public func save(_ ledger: IOSModelDownloadLedger) throws {
+        let validated = try ledger.validated()
+        try fileManager.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        try encoder.encode(validated).write(to: fileURL, options: [.atomic])
+    }
+}

--- a/Sources/QwenVoiceCore/ModelDownloadContracts.swift
+++ b/Sources/QwenVoiceCore/ModelDownloadContracts.swift
@@ -1,0 +1,305 @@
+import Foundation
+
+/// Stable identity encoded in `URLSessionTask.taskDescription`. It deliberately contains no URL
+/// or filesystem path so it is safe to persist and use when adopting background tasks.
+public struct ModelDownloadTaskIdentity: Codable, Equatable, Hashable, Sendable {
+    public static let currentSchemaVersion = 1
+
+    public let schemaVersion: Int
+    public let logicalRequestID: String
+    public let modelID: String
+    public let artifactVersion: String
+    public let relativePath: String
+    public let expectedSize: Int64
+    public let expectedSHA256: String?
+
+    public init(
+        logicalRequestID: String,
+        modelID: String,
+        artifactVersion: String,
+        relativePath: String,
+        expectedSize: Int64,
+        expectedSHA256: String?
+    ) {
+        self.schemaVersion = Self.currentSchemaVersion
+        self.logicalRequestID = logicalRequestID
+        self.modelID = modelID
+        self.artifactVersion = artifactVersion
+        self.relativePath = relativePath
+        self.expectedSize = expectedSize
+        self.expectedSHA256 = expectedSHA256
+    }
+
+    public var encodedTaskDescription: String? {
+        guard let data = try? JSONEncoder().encode(self) else { return nil }
+        return data.base64EncodedString()
+    }
+
+    public static func decode(taskDescription: String?) -> Self? {
+        guard let taskDescription,
+              let data = Data(base64Encoded: taskDescription),
+              let identity = try? JSONDecoder().decode(Self.self, from: data),
+              identity.schemaVersion == currentSchemaVersion else {
+            return nil
+        }
+        return identity
+    }
+}
+
+public struct ModelDownloadRequestIdentity: Equatable, Hashable, Sendable {
+    public let logicalRequestID: String
+    public let modelID: String
+    public let artifactVersion: String
+
+    public init(logicalRequestID: String, modelID: String, artifactVersion: String) {
+        self.logicalRequestID = logicalRequestID
+        self.modelID = modelID
+        self.artifactVersion = artifactVersion
+    }
+}
+
+public struct ModelDownloadExistingTask: Equatable, Sendable {
+    public let taskID: Int
+    public let identity: ModelDownloadTaskIdentity?
+
+    public init(taskID: Int, identity: ModelDownloadTaskIdentity?) {
+        self.taskID = taskID
+        self.identity = identity
+    }
+}
+
+public struct ModelDownloadReconciliationPlan: Equatable, Sendable {
+    public let adoptedTaskByRelativePath: [String: Int]
+    public let cancelledTaskIDs: [Int]
+    public let missingRelativePaths: [String]
+}
+
+/// Small production-used state machine that makes UIKit background-event completion testable
+/// without creating a URLSession or launching an app. The completion is released exactly once,
+/// and only after URLSession has delivered all delegate events and durable postprocessing ended.
+public struct ModelDownloadBackgroundCompletionGate: Equatable, Sendable {
+    public private(set) var eventsFinished = false
+    public private(set) var postprocessingFinished = false
+    public private(set) var completionDelivered = false
+
+    public init() {}
+
+    public mutating func markEventsFinished() -> Bool {
+        eventsFinished = true
+        return takeCompletionIfReady()
+    }
+
+    public mutating func markPostprocessingFinished() -> Bool {
+        postprocessingFinished = true
+        return takeCompletionIfReady()
+    }
+
+    /// Start another logical request while preserving an already-delivered session event only
+    /// when UIKit has not yet received its completion. A fully delivered cycle starts cleanly.
+    public mutating func resetForRequest() {
+        postprocessingFinished = false
+        if completionDelivered {
+            eventsFinished = false
+            completionDelivered = false
+        }
+    }
+
+    private mutating func takeCompletionIfReady() -> Bool {
+        guard eventsFinished, postprocessingFinished, !completionDelivered else { return false }
+        completionDelivered = true
+        return true
+    }
+}
+
+/// Deterministic task-inventory reconciliation used by the live URLSession bridge and fake-task
+/// tests. Exactly one valid task may own a file; stale, unknown, or duplicate tasks are cancelled.
+public enum ModelDownloadTaskReconciler {
+    public static func plan(
+        expected: [ModelDownloadTaskIdentity],
+        existing: [ModelDownloadExistingTask]
+    ) -> ModelDownloadReconciliationPlan {
+        let expectedByPath = Dictionary(uniqueKeysWithValues: expected.map { ($0.relativePath, $0) })
+        var adopted: [String: Int] = [:]
+        var cancelled: [Int] = []
+
+        for task in existing.sorted(by: { $0.taskID < $1.taskID }) {
+            guard let identity = task.identity,
+                  expectedByPath[identity.relativePath] == identity,
+                  adopted[identity.relativePath] == nil else {
+                cancelled.append(task.taskID)
+                continue
+            }
+            adopted[identity.relativePath] = task.taskID
+        }
+
+        return ModelDownloadReconciliationPlan(
+            adoptedTaskByRelativePath: adopted,
+            cancelledTaskIDs: cancelled.sorted(),
+            missingRelativePaths: expectedByPath.keys.filter { adopted[$0] == nil }.sorted()
+        )
+    }
+}
+
+public enum ModelDownloadProgressReconciler {
+    /// A relaunched or retried task may report fewer bytes than the durable ledger while it is
+    /// being adopted. User-visible progress never moves backward and never exceeds the total.
+    public static func visibleBytes(current: Int64, persisted: Int64, total: Int64?) -> Int64 {
+        let value = max(0, max(current, persisted))
+        guard let total, total > 0 else { return value }
+        return min(value, total)
+    }
+}
+
+/// Proof that one immutable staged file was read and verified in this process generation.
+/// The receipt lets final installation avoid a second multi-gigabyte hash pass while still
+/// invalidating on relaunch or any metadata change.
+public struct VerifiedArtifactReceipt: Codable, Equatable, Sendable {
+    public static let currentSchemaVersion = 1
+
+    public let schemaVersion: Int
+    public let relativePath: String
+    public let artifactVersion: String
+    public let expectedSize: Int64
+    public let expectedSHA256: String?
+    public let fileSize: Int64
+    public let modificationTimeNanoseconds: Int64
+    public let fileIdentifier: UInt64?
+    public let verificationProcessGeneration: String
+
+    public init(
+        relativePath: String,
+        artifactVersion: String,
+        expectedSize: Int64,
+        expectedSHA256: String?,
+        fileSize: Int64,
+        modificationTimeNanoseconds: Int64,
+        fileIdentifier: UInt64?,
+        verificationProcessGeneration: String
+    ) {
+        self.schemaVersion = Self.currentSchemaVersion
+        self.relativePath = relativePath
+        self.artifactVersion = artifactVersion
+        self.expectedSize = expectedSize
+        self.expectedSHA256 = expectedSHA256
+        self.fileSize = fileSize
+        self.modificationTimeNanoseconds = modificationTimeNanoseconds
+        self.fileIdentifier = fileIdentifier
+        self.verificationProcessGeneration = verificationProcessGeneration
+    }
+
+    public func matches(
+        relativePath: String,
+        artifactVersion: String,
+        expectedSize: Int64,
+        expectedSHA256: String?,
+        fileSize: Int64,
+        modificationTimeNanoseconds: Int64,
+        fileIdentifier: UInt64?,
+        processGeneration: String
+    ) -> Bool {
+        self.relativePath == relativePath
+            && self.artifactVersion == artifactVersion
+            && self.expectedSize == expectedSize
+            && self.expectedSHA256 == expectedSHA256
+            && self.fileSize == fileSize
+            && self.modificationTimeNanoseconds == modificationTimeNanoseconds
+            && self.fileIdentifier == fileIdentifier
+            && verificationProcessGeneration == processGeneration
+    }
+}
+
+public enum ModelDownloadRetryDisposition: Equatable, Sendable {
+    case retry(afterSeconds: Double)
+    case retryClean(afterSeconds: Double)
+    case fail
+    case cancelled
+}
+
+/// Pure retry classifier shared by the downloader and deterministic tests.
+public enum ModelDownloadRetryPolicy {
+    public static func disposition(
+        error: Error,
+        retryNumber: Int,
+        integrityRetryAlreadyUsed: Bool,
+        retryAfterSeconds: Double? = nil
+    ) -> ModelDownloadRetryDisposition {
+        if error is CancellationError {
+            return .cancelled
+        }
+
+        if let downloadError = error as? HuggingFaceDownloader.DownloadError {
+            switch downloadError {
+            case .cancelled:
+                return .cancelled
+            case .integrityCheckFailed:
+                guard !integrityRetryAlreadyUsed else { return .fail }
+                return .retryClean(afterSeconds: boundedDelay(retryAfterSeconds ?? backoff(retryNumber)))
+            case .httpError(let statusCode, _, let responseRetryAfter):
+                if statusCode == 408 || statusCode == 429 || (500...599).contains(statusCode) {
+                    return retryNumber <= 3
+                        ? .retry(afterSeconds: boundedDelay(retryAfterSeconds ?? responseRetryAfter ?? backoff(retryNumber)))
+                        : .fail
+                }
+                return .fail
+            case .rangeUnsupported, .chunkAssemblyFailed:
+                return retryNumber <= 3
+                    ? .retryClean(afterSeconds: boundedDelay(backoff(retryNumber)))
+                    : .fail
+            case .fileDownloadFailed(_, let underlying):
+                return dispositionForFoundationError(underlying, retryNumber: retryNumber)
+            case .invalidRemotePath, .invalidLocalDestination, .apiError:
+                return .fail
+            }
+        }
+
+        return dispositionForFoundationError(error, retryNumber: retryNumber)
+    }
+
+    private static func dispositionForFoundationError(
+        _ error: Error,
+        retryNumber: Int
+    ) -> ModelDownloadRetryDisposition {
+        let nsError = error as NSError
+        guard nsError.domain == NSURLErrorDomain else { return .fail }
+        if nsError.code == NSURLErrorCancelled { return .cancelled }
+
+        let permanentCodes: Set<Int> = [
+            NSURLErrorServerCertificateUntrusted,
+            NSURLErrorServerCertificateHasBadDate,
+            NSURLErrorServerCertificateHasUnknownRoot,
+            NSURLErrorServerCertificateNotYetValid,
+            NSURLErrorSecureConnectionFailed,
+            NSURLErrorClientCertificateRejected,
+            NSURLErrorClientCertificateRequired,
+            NSURLErrorCannotWriteToFile,
+            NSURLErrorDataLengthExceedsMaximum,
+            NSURLErrorFileDoesNotExist,
+            NSURLErrorNoPermissionsToReadFile,
+        ]
+        guard !permanentCodes.contains(nsError.code), retryNumber <= 3 else { return .fail }
+
+        let transientCodes: Set<Int> = [
+            NSURLErrorTimedOut,
+            NSURLErrorNetworkConnectionLost,
+            NSURLErrorNotConnectedToInternet,
+            NSURLErrorCannotConnectToHost,
+            NSURLErrorCannotFindHost,
+            NSURLErrorDNSLookupFailed,
+            NSURLErrorResourceUnavailable,
+            NSURLErrorInternationalRoamingOff,
+            NSURLErrorCallIsActive,
+            NSURLErrorDataNotAllowed,
+        ]
+        return transientCodes.contains(nsError.code)
+            ? .retry(afterSeconds: boundedDelay(backoff(retryNumber)))
+            : .fail
+    }
+
+    private static func backoff(_ retryNumber: Int) -> Double {
+        min(pow(2, Double(max(0, retryNumber - 1))), 10)
+    }
+
+    private static func boundedDelay(_ seconds: Double) -> Double {
+        min(max(seconds, 0), 300)
+    }
+}

--- a/Sources/QwenVoiceCore/ModelDownloadDiagnosticsStore.swift
+++ b/Sources/QwenVoiceCore/ModelDownloadDiagnosticsStore.swift
@@ -1,0 +1,318 @@
+import Foundation
+
+/// Compact local-only diagnostics for model delivery. The allowlisted schema cannot contain
+/// request URLs, filesystem paths, device identity, model prompts, or user content.
+public final class ModelDownloadDiagnosticsStore: @unchecked Sendable {
+    private struct Record: Codable, Sendable {
+        let schemaVersion: Int
+        let capturedAtUTC: String
+        let kind: String
+        let relativePath: String?
+        let protocolName: String?
+        let redirectCount: Int?
+        let reusedConnection: Bool?
+        let cellular: Bool?
+        let constrained: Bool?
+        let expensive: Bool?
+        let transferredBytes: Int64?
+        let durationSeconds: Double?
+        let classification: String?
+        let message: String?
+        let phase: String?
+        let downloadedBytes: Int64?
+        let totalBytes: Int64?
+        let bytesPerSecond: Int64?
+        let etaSeconds: Double?
+        let retryCount: Int?
+        let networkSeconds: Double?
+        let verificationSeconds: Double?
+        let installationSeconds: Double?
+        let expectedBytes: Int64?
+        let wireBytes: Int64?
+        let controlBytes: Int64?
+        let duplicateBytes: Int64?
+        let protocols: [String]?
+        let thermalState: String?
+        let finalIntegrity: Bool?
+
+        init(
+            capturedAtUTC: String,
+            kind: String,
+            relativePath: String? = nil,
+            protocolName: String? = nil,
+            redirectCount: Int? = nil,
+            reusedConnection: Bool? = nil,
+            cellular: Bool? = nil,
+            constrained: Bool? = nil,
+            expensive: Bool? = nil,
+            transferredBytes: Int64? = nil,
+            durationSeconds: Double? = nil,
+            classification: String? = nil,
+            message: String? = nil,
+            phase: String? = nil,
+            downloadedBytes: Int64? = nil,
+            totalBytes: Int64? = nil,
+            bytesPerSecond: Int64? = nil,
+            etaSeconds: Double? = nil,
+            retryCount: Int? = nil,
+            networkSeconds: Double? = nil,
+            verificationSeconds: Double? = nil,
+            installationSeconds: Double? = nil,
+            expectedBytes: Int64? = nil,
+            wireBytes: Int64? = nil,
+            controlBytes: Int64? = nil,
+            duplicateBytes: Int64? = nil,
+            protocols: [String]? = nil,
+            thermalState: String? = nil,
+            finalIntegrity: Bool? = nil
+        ) {
+            self.schemaVersion = 1
+            self.capturedAtUTC = capturedAtUTC
+            self.kind = kind
+            self.relativePath = relativePath
+            self.protocolName = protocolName
+            self.redirectCount = redirectCount
+            self.reusedConnection = reusedConnection
+            self.cellular = cellular
+            self.constrained = constrained
+            self.expensive = expensive
+            self.transferredBytes = transferredBytes
+            self.durationSeconds = durationSeconds
+            self.classification = classification
+            self.message = message
+            self.phase = phase
+            self.downloadedBytes = downloadedBytes
+            self.totalBytes = totalBytes
+            self.bytesPerSecond = bytesPerSecond
+            self.etaSeconds = etaSeconds
+            self.retryCount = retryCount
+            self.networkSeconds = networkSeconds
+            self.verificationSeconds = verificationSeconds
+            self.installationSeconds = installationSeconds
+            self.expectedBytes = expectedBytes
+            self.wireBytes = wireBytes
+            self.controlBytes = controlBytes
+            self.duplicateBytes = duplicateBytes
+            self.protocols = protocols
+            self.thermalState = thermalState
+            self.finalIntegrity = finalIntegrity
+        }
+    }
+
+    public let directory: URL
+    private let fileManager: FileManager
+    private let lock = NSLock()
+    private var runStartedAt: Date?
+    private var verificationStartedAt: Date?
+    private var installationStartedAt: Date?
+    private var lastPhase: String?
+    private var maximumRetryCount = 0
+    private var accumulatedWireBytes: Int64 = 0
+    private var accumulatedControlBytes: Int64 = 0
+    private var observedProtocols: Set<String> = []
+    private var terminalRecorded = false
+
+    public init(directory: URL, fileManager: FileManager = .default) {
+        self.directory = directory
+        self.fileManager = fileManager
+    }
+
+    public func record(metrics: HuggingFaceDownloader.TransferMetrics) {
+        let relativePath = sanitizeRelativePath(metrics.relativePath)
+        lock.lock()
+        if relativePath == nil {
+            // Catalog and other control-plane requests are useful network evidence, but are not
+            // model payload and therefore must not inflate duplicate artifact bytes.
+            accumulatedControlBytes += max(0, metrics.transferredBytes)
+        } else {
+            accumulatedWireBytes += max(0, metrics.transferredBytes)
+        }
+        if let protocolName = sanitizeToken(metrics.protocolName), !protocolName.isEmpty {
+            observedProtocols.insert(protocolName)
+        }
+        lock.unlock()
+        persist(Record(
+            capturedAtUTC: ISO8601DateFormatter().string(from: Date()),
+            kind: "task-metrics",
+            relativePath: relativePath,
+            protocolName: sanitizeToken(metrics.protocolName),
+            redirectCount: metrics.redirectCount,
+            reusedConnection: metrics.reusedConnection,
+            cellular: metrics.cellular,
+            constrained: metrics.constrained,
+            expensive: metrics.expensive,
+            transferredBytes: metrics.transferredBytes,
+            durationSeconds: metrics.durationSeconds
+        ))
+    }
+
+    /// Persist only phase transitions, while retaining exact byte updates in the UI callback.
+    /// The resulting compact records make network, verification, and installation timing
+    /// independently auditable without retaining raw requests or model payloads.
+    public func record(progress: HuggingFaceDownloader.RepositoryProgress) {
+        let now = Date()
+        let phase = progress.phase.rawValue
+        lock.lock()
+        if terminalRecorded {
+            resetRunStateLocked()
+        }
+        if runStartedAt == nil { runStartedAt = now }
+        maximumRetryCount = max(maximumRetryCount, progress.retryCount)
+        guard lastPhase != phase else {
+            lock.unlock()
+            return
+        }
+        lastPhase = phase
+        if progress.phase == .verifying { verificationStartedAt = now }
+        if progress.phase == .installing { installationStartedAt = now }
+        lock.unlock()
+
+        persist(Record(
+            capturedAtUTC: ISO8601DateFormatter().string(from: now),
+            kind: "phase",
+            phase: phase,
+            downloadedBytes: progress.downloadedBytes,
+            totalBytes: progress.totalBytes,
+            bytesPerSecond: progress.bytesPerSecond,
+            etaSeconds: progress.estimatedSecondsRemaining,
+            retryCount: progress.retryCount
+        ))
+    }
+
+    public func recordSuccess(expectedBytes: Int64) {
+        let now = Date()
+        lock.lock()
+        let networkSeconds = verificationStartedAt.flatMap { start in
+            runStartedAt.map { max(0, start.timeIntervalSince($0)) }
+        }
+        let verificationSeconds = installationStartedAt.flatMap { end in
+            verificationStartedAt.map { max(0, end.timeIntervalSince($0)) }
+        }
+        let installationSeconds = installationStartedAt.map { max(0, now.timeIntervalSince($0)) }
+        let wireBytes = accumulatedWireBytes
+        let controlBytes = accumulatedControlBytes
+        let retryCount = maximumRetryCount
+        let protocols = observedProtocols.sorted()
+        terminalRecorded = true
+        lock.unlock()
+
+        persist(Record(
+            capturedAtUTC: ISO8601DateFormatter().string(from: now),
+            kind: "success",
+            retryCount: retryCount,
+            networkSeconds: networkSeconds,
+            verificationSeconds: verificationSeconds,
+            installationSeconds: installationSeconds,
+            expectedBytes: expectedBytes,
+            wireBytes: wireBytes,
+            controlBytes: controlBytes,
+            duplicateBytes: max(0, wireBytes - max(0, expectedBytes)),
+            protocols: protocols,
+            thermalState: thermalStateToken(),
+            finalIntegrity: true
+        ))
+    }
+
+    public func recordFailure(classification: String, message: String) {
+        persist(Record(
+            capturedAtUTC: ISO8601DateFormatter().string(from: Date()),
+            kind: "failure",
+            classification: sanitizeToken(classification),
+            message: sanitizeMessage(message)
+        ))
+    }
+
+    private func persist(_ record: Record) {
+        lock.lock()
+        defer { lock.unlock() }
+        do {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            let data = try encoder.encode(record)
+            try data.write(
+                to: directory.appendingPathComponent("attempt-\(UUID().uuidString).json"),
+                options: [.atomic]
+            )
+            try prune()
+        } catch {
+            // Diagnostics must never interfere with model delivery.
+        }
+    }
+
+    private func prune() throws {
+        let keys: Set<URLResourceKey> = [.contentModificationDateKey, .fileSizeKey]
+        let files = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: Array(keys),
+            options: [.skipsHiddenFiles]
+        ).filter { $0.pathExtension == "json" }.sorted {
+            let lhs = (try? $0.resourceValues(forKeys: keys).contentModificationDate) ?? .distantPast
+            let rhs = (try? $1.resourceValues(forKeys: keys).contentModificationDate) ?? .distantPast
+            return lhs > rhs
+        }
+
+        var retainedBytes: Int64 = 0
+        for (index, file) in files.enumerated() {
+            let size = Int64((try? file.resourceValues(forKeys: keys).fileSize) ?? 0)
+            if index >= 20 || retainedBytes + size > 5 * 1_024 * 1_024 {
+                try? fileManager.removeItem(at: file)
+            } else {
+                retainedBytes += size
+            }
+        }
+    }
+
+    private func sanitizeRelativePath(_ value: String?) -> String? {
+        guard let value,
+              !value.isEmpty,
+              !value.hasPrefix("/"),
+              !value.contains(":"),
+              !value.split(separator: "/").contains("..") else { return nil }
+        return String(value.prefix(300))
+    }
+
+    private func sanitizeToken(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let allowed = value.unicodeScalars.filter {
+            CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-")).contains($0)
+        }
+        return String(String.UnicodeScalarView(allowed).prefix(100))
+    }
+
+    private func sanitizeMessage(_ value: String) -> String {
+        let withoutURLs = value.replacingOccurrences(
+            of: #"[A-Za-z][A-Za-z0-9+.-]*://\S+"#,
+            with: "<redacted-url>",
+            options: .regularExpression
+        )
+        let withoutPaths = withoutURLs.replacingOccurrences(
+            of: #"/(?:Users|private|var|tmp)/\S+"#,
+            with: "<redacted-path>",
+            options: .regularExpression
+        )
+        return String(withoutPaths.prefix(500))
+    }
+
+    private func resetRunStateLocked() {
+        runStartedAt = nil
+        verificationStartedAt = nil
+        installationStartedAt = nil
+        lastPhase = nil
+        maximumRetryCount = 0
+        accumulatedWireBytes = 0
+        accumulatedControlBytes = 0
+        observedProtocols.removeAll()
+        terminalRecorded = false
+    }
+
+    private func thermalStateToken() -> String {
+        switch ProcessInfo.processInfo.thermalState {
+        case .nominal: return "nominal"
+        case .fair: return "fair"
+        case .serious: return "serious"
+        case .critical: return "critical"
+        @unknown default: return "unknown"
+        }
+    }
+}

--- a/Sources/ViewModels/ModelManagerViewModel.swift
+++ b/Sources/ViewModels/ModelManagerViewModel.swift
@@ -9,9 +9,13 @@ final class ModelManagerViewModel {
 
     struct DownloadProgress: Equatable, Sendable {
         enum Phase: String, Equatable, Sendable {
+            case queued
+            case waitingForConnectivity
             case downloading
+            case retrying
             case verifying
             case installing
+            case cancelling
         }
 
         let downloadedBytes: Int64
@@ -20,6 +24,9 @@ final class ModelManagerViewModel {
         let totalFiles: Int?
         let bytesPerSecond: Int64?
         let isStalled: Bool
+        let estimatedSecondsRemaining: Double?
+        let retryCount: Int
+        let statusMessage: String?
         let phase: Phase
 
         static let initial = DownloadProgress(
@@ -29,6 +36,9 @@ final class ModelManagerViewModel {
             totalFiles: nil,
             bytesPerSecond: nil,
             isStalled: false,
+            estimatedSecondsRemaining: nil,
+            retryCount: 0,
+            statusMessage: nil,
             phase: .downloading
         )
     }
@@ -488,17 +498,31 @@ final class ModelManagerViewModel {
 
     private func downloadDetail(for progress: DownloadProgress) -> String? {
         if progress.isStalled {
-            return "Waiting for the connection to resume."
+            return "No progress for 20 seconds."
         }
+        var details: [String] = []
         if let totalBytes = progress.totalBytes, totalBytes > 0 {
             let downloaded = Self.formattedFileSize(progress.downloadedBytes)
             let total = Self.formattedFileSize(totalBytes)
-            return "\(downloaded) of \(total)"
+            details.append("\(downloaded) of \(total)")
+        } else if let totalFiles = progress.totalFiles, totalFiles > 0 {
+            details.append("\(progress.completedFiles) of \(totalFiles) files")
         }
-        if let totalFiles = progress.totalFiles, totalFiles > 0 {
-            return "\(progress.completedFiles) of \(totalFiles) files"
+        if let bytesPerSecond = progress.bytesPerSecond, bytesPerSecond > 0,
+           progress.phase == .downloading {
+            details.append("\(Self.formattedFileSize(bytesPerSecond))/s")
         }
-        return nil
+        if let eta = progress.estimatedSecondsRemaining, eta.isFinite,
+           progress.phase == .downloading {
+            details.append("about \(max(1, Int(eta.rounded())))s remaining")
+        }
+        if progress.phase == .retrying, progress.retryCount > 0 {
+            details.append("retry \(progress.retryCount); verified files will be reused")
+        }
+        if let statusMessage = progress.statusMessage, !statusMessage.isEmpty {
+            details.append(statusMessage)
+        }
+        return details.isEmpty ? nil : details.joined(separator: " · ")
     }
 
     private func repairDetail(missingRequiredPaths: [String]) -> String {
@@ -573,37 +597,47 @@ final class ModelManagerViewModel {
         let targetDir = model.installDirectory(in: modelsDirectory)
         let modelsDirectory = self.modelsDirectory
 
-        // Clear any stale downloader/task for this model before starting fresh.
-        // The stale cancel is fire-and-forget here because no staging deletion follows it;
-        // the new download will recreate staging if needed.
+        // A replacement must not register tasks until the previous downloader's cancellation
+        // callbacks have finished. Preserve staging for retry, but serialize session ownership.
         let staleDownloader = downloaders.removeValue(forKey: modelID)
-        downloadTasks[modelID]?.cancel()
-        downloadTasks.removeValue(forKey: modelID)
-        if let staleDownloader {
-            Task { await staleDownloader.cancel() }
-        }
+        let staleTask = downloadTasks.removeValue(forKey: modelID)
+        staleTask?.cancel()
 
         try? fileManager.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
         removeInstallMetadata(for: model)
 
-        let downloader = HuggingFaceDownloader(progressHandler: { [weak self] progress in
-            Task { @MainActor [weak self] in
-                self?.publishDownloadProgressIfCurrent(
-                    epoch: epoch,
-                    modelID: modelID,
-                    progress: progress
-                )
-            }
-        })
+        let diagnostics = ModelDownloadDiagnosticsStore(
+            directory: modelsDirectory
+                .deletingLastPathComponent()
+                .appendingPathComponent("diagnostics/model-downloads", isDirectory: true)
+        )
+        let downloader = HuggingFaceDownloader(
+            progressHandler: { [weak self] progress in
+                diagnostics.record(progress: progress)
+                Task { @MainActor [weak self] in
+                    self?.publishDownloadProgressIfCurrent(
+                        epoch: epoch,
+                        modelID: modelID,
+                        progress: progress
+                    )
+                }
+            },
+            transferMetricsHandler: { diagnostics.record(metrics: $0) }
+        )
         downloaders[modelID] = downloader
 
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
+            if let staleDownloader {
+                await staleDownloader.cancel()
+                await staleTask?.value
+            }
             await self.runModelDownload(
                 model: model,
                 epoch: epoch,
                 downloader: downloader,
-                targetDir: targetDir
+                targetDir: targetDir,
+                diagnostics: diagnostics
             )
         }
         downloadTasks[modelID] = task
@@ -615,7 +649,8 @@ final class ModelManagerViewModel {
         model: TTSModel,
         epoch: Int,
         downloader: HuggingFaceDownloader,
-        targetDir: URL
+        targetDir: URL,
+        diagnostics: ModelDownloadDiagnosticsStore
     ) async {
         do {
             try await downloader.downloadRepo(
@@ -629,6 +664,9 @@ final class ModelManagerViewModel {
                 lastFailureMessages[model.id] = "Download finished, but required model files are still missing."
             } else {
                 persistInstallMetadata(for: model, snapshot: postDownloadSnapshot)
+                diagnostics.recordSuccess(
+                    expectedBytes: model.estimatedDownloadBytes ?? Int64(postDownloadSnapshot.sizeBytes)
+                )
             }
         } catch is CancellationError {
             guard isCurrentEpoch(epoch, for: model.id) else { return }
@@ -638,10 +676,20 @@ final class ModelManagerViewModel {
             case .cancelled:
                 lastFailureMessages.removeValue(forKey: model.id)
             default:
+                ModelDownloadDiagnosticsStore(
+                    directory: modelsDirectory
+                        .deletingLastPathComponent()
+                        .appendingPathComponent("diagnostics/model-downloads", isDirectory: true)
+                ).recordFailure(classification: "download", message: dlError.localizedDescription)
                 lastFailureMessages[model.id] = dlError.localizedDescription
             }
         } catch {
             guard isCurrentEpoch(epoch, for: model.id) else { return }
+            ModelDownloadDiagnosticsStore(
+                directory: modelsDirectory
+                    .deletingLastPathComponent()
+                    .appendingPathComponent("diagnostics/model-downloads", isDirectory: true)
+            ).recordFailure(classification: "download", message: error.localizedDescription)
             lastFailureMessages[model.id] = error.localizedDescription
         }
         await handleMutationCompletion(for: model.id)
@@ -1054,6 +1102,9 @@ final class ModelManagerViewModel {
                 totalFiles: progress.totalFiles > 0 ? progress.totalFiles : nil,
                 bytesPerSecond: progress.bytesPerSecond,
                 isStalled: progress.isStalled,
+                estimatedSecondsRemaining: progress.estimatedSecondsRemaining,
+                retryCount: progress.retryCount,
+                statusMessage: progress.statusMessage,
                 phase: DownloadProgress.Phase(progress.phase)
             )
         )
@@ -1063,23 +1114,39 @@ final class ModelManagerViewModel {
 private extension ModelManagerViewModel.DownloadProgress.Phase {
     var displayLabel: String {
         switch self {
+        case .queued:
+            return "Queued"
+        case .waitingForConnectivity:
+            return "Waiting for network"
         case .downloading:
             return "Downloading"
+        case .retrying:
+            return "Retrying"
         case .verifying:
             return "Verifying"
         case .installing:
             return "Installing"
+        case .cancelling:
+            return "Cancelling"
         }
     }
 
     init(_ phase: HuggingFaceDownloader.DownloadPhase) {
         switch phase {
+        case .queued:
+            self = .queued
+        case .waitingForConnectivity:
+            self = .waitingForConnectivity
         case .downloading:
             self = .downloading
+        case .retrying:
+            self = .retrying
         case .verifying:
             self = .verifying
         case .installing:
             self = .installing
+        case .cancelling:
+            self = .cancelling
         }
     }
 }

--- a/Sources/VocelloCLI/ModelsCommand.swift
+++ b/Sources/VocelloCLI/ModelsCommand.swift
@@ -103,15 +103,33 @@ enum ModelsCommand {
         let revision = descriptor.huggingFaceRevision ?? "main"
         note("Installing \(modelID) from \(repo) (revision \(revision.prefix(7))\u{2026})")
 
-        let downloader = HuggingFaceDownloader(progressHandler: { progress in
-            let pct = progress.totalBytes > 0
-                ? Int(Double(progress.downloadedBytes) / Double(progress.totalBytes) * 100)
-                : 0
-            let speed = progress.bytesPerSecond.map { "\(humanBytes($0))/s" } ?? "—"
-            noteVerbose("  \(progress.phase.rawValue) · \(pct)% · \(humanBytes(progress.downloadedBytes))/\(humanBytes(progress.totalBytes)) · \(speed)")
-        })
+        let diagnostics = ModelDownloadDiagnosticsStore(
+            directory: ctx.modelsDirectory
+                .deletingLastPathComponent()
+                .appendingPathComponent("diagnostics/model-downloads", isDirectory: true)
+        )
+        let downloader = HuggingFaceDownloader(
+            progressHandler: { progress in
+                diagnostics.record(progress: progress)
+                let pct = progress.totalBytes > 0
+                    ? Int(Double(progress.downloadedBytes) / Double(progress.totalBytes) * 100)
+                    : 0
+                let speed = progress.bytesPerSecond.map { "\(humanBytes($0))/s" } ?? "—"
+                let eta = progress.estimatedSecondsRemaining.map { " · ETA \(max(1, Int($0.rounded())))s" } ?? ""
+                noteVerbose("  \(progress.phase.rawValue) · \(pct)% · \(humanBytes(progress.downloadedBytes))/\(humanBytes(progress.totalBytes)) · \(speed)\(eta)")
+            },
+            transferMetricsHandler: { diagnostics.record(metrics: $0) }
+        )
 
-        try await downloader.downloadRepo(repo: repo, revision: revision, to: targetDir)
+        do {
+            try await downloader.downloadRepo(repo: repo, revision: revision, to: targetDir)
+            diagnostics.recordSuccess(
+                expectedBytes: descriptor.estimatedDownloadBytes ?? directorySize(targetDir)
+            )
+        } catch {
+            diagnostics.recordFailure(classification: "download", message: error.localizedDescription)
+            throw error
+        }
 
         print("✓ Installed \(modelID) (\(humanBytes(directorySize(targetDir))))")
     }

--- a/Sources/iOS/IOSModelDownloadCoordinator.swift
+++ b/Sources/iOS/IOSModelDownloadCoordinator.swift
@@ -1,23 +1,19 @@
 import Foundation
 import QwenVoiceCore
 
-/// Progress snapshot consumed by `IOSModelInstallerViewModel`. (Moved here from the deleted
-/// `IOSModelDeliveryActor`; the coordinator emits the same contract so the view model's `apply`
-/// is unchanged. Only `downloading/verifying/installing/installed/deleting/deleted/failed` are
-/// produced by the new engine — the pause/interrupt cases are dead.)
 struct IOSModelDeliverySnapshot: Equatable, Sendable {
     enum Phase: String, Codable, Sendable {
+        case queued
+        case waitingForConnectivity
         case downloading
-        case interrupted
-        case resuming
-        case restarting
-        case paused
+        case retrying
         case verifying
         case installing
+        case cancelling
         case installed
+        case failed
         case deleting
         case deleted
-        case failed
     }
 
     let modelID: String
@@ -25,16 +21,40 @@ struct IOSModelDeliverySnapshot: Equatable, Sendable {
     let downloadedBytes: Int64
     let totalBytes: Int64?
     let estimatedBytes: Int64?
+    let bytesPerSecond: Int64?
+    let estimatedSecondsRemaining: Double?
+    let retryCount: Int
     let message: String?
-    /// Monotonic token so the view model can ignore stale progress after cancel/fail.
     let operationGeneration: UInt64
+
+    init(
+        modelID: String,
+        phase: Phase,
+        downloadedBytes: Int64,
+        totalBytes: Int64?,
+        estimatedBytes: Int64?,
+        bytesPerSecond: Int64? = nil,
+        estimatedSecondsRemaining: Double? = nil,
+        retryCount: Int = 0,
+        message: String?,
+        operationGeneration: UInt64
+    ) {
+        self.modelID = modelID
+        self.phase = phase
+        self.downloadedBytes = downloadedBytes
+        self.totalBytes = totalBytes
+        self.estimatedBytes = estimatedBytes
+        self.bytesPerSecond = bytesPerSecond
+        self.estimatedSecondsRemaining = estimatedSecondsRemaining
+        self.retryCount = retryCount
+        self.message = message
+        self.operationGeneration = operationGeneration
+    }
 }
 
-/// Lightweight record of an in-flight download, persisted so the coordinator can reattach the
-/// background URLSession (by identifier) and restore UI state after an app kill/relaunch.
-/// URLSession auto-resumes pending tasks by identifier; the on-disk partials let each task
-/// Range-resume, so the app only needs this list to know what was in flight.
-struct IOSInFlightDownloadRecord: Codable, Sendable {
+/// Schema-v1 compatibility record. It is decoded only by the one-time migration and is never
+/// written again. The absolute target path is reduced to its final folder name before v2 storage.
+private struct IOSLegacyInFlightDownloadRecord: Codable, Sendable {
     let modelID: String
     let artifactVersion: String
     let backgroundSessionIdentifier: String
@@ -44,55 +64,43 @@ struct IOSInFlightDownloadRecord: Codable, Sendable {
     let totalBytes: Int64
 }
 
-struct IOSInFlightDownloadsDocument: Codable, Sendable {
-    static let currentSchemaVersion = 1
+private struct IOSLegacyInFlightDownloadsDocument: Codable, Sendable {
     let schemaVersion: Int
-    let downloads: [IOSInFlightDownloadRecord]
+    let downloads: [IOSLegacyInFlightDownloadRecord]
 }
 
-/// Drives the shared `HuggingFaceDownloader` engine for iOS model downloads over a **background**
-/// URLSession so large model downloads survive app backgrounding and device locking. Profile:
-/// **one native `downloadTask` per file** (byte-range chunking OFF — manual chunking caused uneven
-/// throughput) + the model's files downloading concurrently (`maxConcurrentFiles = 6`) for speed,
-/// and **one model at a time** (`maxConcurrentModels = 1`; a second request queues). Cancelling
-/// discards the partial (no resume). On app relaunch, in-flight records let the coordinator
-/// reattach to the same background-session identifier and resume from on-disk partials. Preserves
-/// the `IOSModelDeliverySnapshot` contract the view model consumes. macOS/CLI keep byte-range ON
-/// (fast there); iOS trades that for stability/background survivability.
-///
-/// The `backgroundSessionIdentifier` / `IOSModelDeliveryBackgroundEventRelay` /
-/// `backgroundSessionCompletionHandler` plumbing is active: `HuggingFaceDownloader` forwards
-/// `urlSessionDidFinishEvents(forBackgroundURLSession:)` so the app delegate's system completion
-/// handler is always called.
+/// Owns one bundle-aware background URLSession for the whole iOS app lifetime. One model runs at
+/// a time, queued requests are durable, and task adoption occurs inside `HuggingFaceDownloader`
+/// before any missing task is created.
 @MainActor
 final class IOSModelDownloadCoordinator {
     struct InFlightDownload {
         let modelID: String
-        let downloader: HuggingFaceDownloader   // retained for the download's lifetime
+        let logicalRequestID: String
         let task: Task<Void, Never>
         let targetDir: URL
-        /// Background session identifier used to reattach after app relaunch.
-        let backgroundSessionIdentifier: String
+        let stagingRoot: URL
         let totalBytes: Int64
         let operationGeneration: UInt64
     }
 
     typealias SnapshotSink = @MainActor (IOSModelDeliverySnapshot) -> Void
 
-    /// Maximum number of models downloading concurrently. **1 on iOS** (concurrent model downloads
-    /// don't behave well on device — kept single). The bounded queue stays, so a second Download
-    /// request queues and starts when the first terminates; bump this to re-enable concurrency.
     private static let maxConcurrentModels = 1
-
     private let modelAssetStore: LocalModelAssetStore
     private let configuration: IOSModelDeliveryConfiguration
     private let fileManager: FileManager
     private let snapshotSink: SnapshotSink
     private let catalogSession: URLSession
+    private let ledgerStore: IOSModelDownloadLedgerStore
+    private let diagnosticsStore: ModelDownloadDiagnosticsStore
     private var inflight: [String: InFlightDownload] = [:]
     private var pending: [ModelDescriptor] = []
     private var cachedCatalog: IOSModelCatalogDocument?
     private var operationGeneration: UInt64 = 0
+    private var lastLedgerProgressWrite: [String: TimeInterval] = [:]
+
+    private lazy var downloader: HuggingFaceDownloader = makeSharedDownloader()
 
     init(
         modelAssetStore: LocalModelAssetStore,
@@ -105,154 +113,161 @@ final class IOSModelDownloadCoordinator {
         self.fileManager = fileManager
         self.snapshotSink = snapshotSink
         self.catalogSession = URLSession(configuration: .ephemeral)
+        self.ledgerStore = IOSModelDownloadLedgerStore(
+            fileURL: AppPaths.modelDeliveryStateFile,
+            fileManager: fileManager
+        )
+        self.diagnosticsStore = ModelDownloadDiagnosticsStore(
+            directory: AppPaths.modelDownloadDiagnosticsDir,
+            fileManager: fileManager
+        )
     }
 
-    // MARK: - Public (mirrors what IOSModelInstallerViewModel calls)
-
-    /// Request a model download. Returns immediately; the bounded queue runs up to
-    /// `maxConcurrentModels` at once. A model already queued or downloading is a no-op.
-    /// Cancel = discard (no resume).
     func install(model: ModelDescriptor) async throws {
         guard model.iosDownloadEligible else {
             throw IOSModelDeliveryError.notEligibleForIOS(modelID: model.id)
         }
-        if inflight[model.id] != nil { return }
-        if pending.contains(where: { $0.id == model.id }) { return }
+        if inflight[model.id] != nil || pending.contains(where: { $0.id == model.id }) { return }
 
-        try fileManager.createDirectory(at: AppPaths.modelsDir, withIntermediateDirectories: true)
-        try fileManager.createDirectory(at: AppPaths.modelDownloadStagingDir, withIntermediateDirectories: true)
-        try? IOSModelDeliverySupport.excludeFromBackup(AppPaths.modelsDir)
-        try? IOSModelDeliverySupport.excludeFromBackup(AppPaths.modelDownloadStagingDir)
+        try prepareDirectories()
+        let entry = try IOSModelDeliverySupport.matchingCatalogEntry(
+            for: model,
+            in: try await fetchCatalog(),
+            configuration: configuration
+        )
+        let totalBytes = entry.totalBytes > 0
+            ? entry.totalBytes
+            : entry.files.reduce(Int64(0)) { $0 + $1.sizeBytes }
+        try IOSModelDeliverySupport.ensureSufficientDiskSpace(
+            requiredBytes: totalBytes,
+            at: AppPaths.appSupportDir,
+            fileManager: fileManager
+        )
 
+        var ledger = try ledgerStore.load()
+        if let index = ledger.requests.firstIndex(where: { $0.modelID == model.id }) {
+            ledger.requests[index].status = .queued
+            ledger.requests[index].totalBytes = totalBytes
+        } else {
+            ledger.requests.append(makeLedgerRequest(model: model, entry: entry, totalBytes: totalBytes))
+        }
+        try ledgerStore.save(ledger)
         pending.append(model)
+        publishSnapshot(for: model, phase: .queued, downloadedBytes: ledgerRequest(model.id, in: ledger)?.receivedBytes ?? 0)
         await startPendingDownloads()
     }
 
-    /// Cancel a download (in-flight or queued) and discard its staged partial (true cancel).
     func cancel(modelID: String) async {
-        // Queued but not yet started: just drop it from the queue.
         if let pendingIndex = pending.firstIndex(where: { $0.id == modelID }) {
             pending.remove(at: pendingIndex)
-            let descriptor = modelAssetStore.descriptor(id: modelID)?.model
-            publish(.init(
-                modelID: modelID, phase: .deleted, downloadedBytes: 0, totalBytes: nil,
-                estimatedBytes: descriptor?.estimatedDownloadBytes, message: nil,
-                operationGeneration: endOperation()
-            ))
+            markLedgerTerminal(modelID: modelID, status: .deleted)
+            discardStaging(modelID: modelID)
+            publishTerminal(modelID: modelID, phase: .deleted)
             return
         }
         guard let active = inflight[modelID] else { return }
-        let terminalGeneration = endOperation()
-        await active.downloader.cancel()
+
+        updateLedger(modelID: modelID) { $0.status = .cancelRequested }
+        publishSnapshot(
+            modelID: modelID,
+            phase: .cancelling,
+            downloadedBytes: ledgerReceivedBytes(modelID: modelID),
+            totalBytes: active.totalBytes,
+            message: nil,
+            generation: active.operationGeneration
+        )
+
+        await downloader.cancel()
         active.task.cancel()
-        HuggingFaceDownloader.discardStaging(forTargetDirectory: active.targetDir)
+        await active.task.value
         inflight.removeValue(forKey: modelID)
-        removeInFlightRecord(modelID: modelID)
-        let descriptor = modelAssetStore.descriptor(id: modelID)?.model
-        publish(.init(
-            modelID: modelID, phase: .deleted, downloadedBytes: 0, totalBytes: nil,
-            estimatedBytes: descriptor?.estimatedDownloadBytes, message: nil,
-            operationGeneration: terminalGeneration
-        ))
-        await startPendingDownloads()   // drain the freed slot
+        try? fileManager.removeItem(at: active.stagingRoot)
+        markLedgerTerminal(modelID: modelID, status: .deleted)
+        publishTerminal(modelID: modelID, phase: .deleted)
+        await startPendingDownloads()
     }
 
-    /// Delete an installed model (and cancel first if it's mid-download).
     func delete(model: ModelDescriptor) async throws {
         if inflight[model.id] != nil || pending.contains(where: { $0.id == model.id }) {
             await cancel(modelID: model.id)
         }
-
         let generation = beginOperation()
-        publish(.init(
-            modelID: model.id, phase: .deleting, downloadedBytes: 0, totalBytes: nil,
-            estimatedBytes: model.estimatedDownloadBytes, message: nil,
-            operationGeneration: generation
-        ))
-
+        publishSnapshot(
+            modelID: model.id,
+            phase: .deleting,
+            downloadedBytes: 0,
+            totalBytes: nil,
+            message: nil,
+            generation: generation
+        )
         let targetDir = model.installDirectory(in: AppPaths.modelsDir)
         if fileManager.fileExists(atPath: targetDir.path) {
             try fileManager.removeItem(at: targetDir)
         }
-        HuggingFaceDownloader.discardStaging(forTargetDirectory: targetDir)
-
-        let terminalGeneration = endOperation()
-        publish(.init(
-            modelID: model.id, phase: .deleted, downloadedBytes: 0, totalBytes: nil,
-            estimatedBytes: model.estimatedDownloadBytes, message: nil,
-            operationGeneration: terminalGeneration
-        ))
+        discardStaging(modelID: model.id)
+        markLedgerTerminal(modelID: model.id, status: .deleted)
+        publishTerminal(modelID: model.id, phase: .deleted)
     }
 
-    /// On app launch: resume any downloads that were in flight when the app was killed/backgrounded.
-    /// The background URLSession reattaches by identifier; on-disk partials let each file
-    /// Range-resume. Records beyond the concurrency cap are re-queued.
     func restoreInFlightDownloadsIfNeeded() async {
-        let records = loadInFlightRecords()
-        var activeSessionIDs = Set<String>()
-        for record in records {
-            guard let descriptor = modelAssetStore.descriptor(id: record.modelID)?.model else {
-                removeInFlightRecord(modelID: record.modelID)
-                continue
-            }
-            let targetDir = URL(fileURLWithPath: record.targetFolderPath, isDirectory: true)
-            let alreadyInstalled = (try? descriptor.isAvailable(in: AppPaths.modelsDir, fileManager: fileManager)) == true
-            // Stale if the catalog's artifact version bumped or the model finished installing.
-            if descriptor.artifactVersion != record.artifactVersion || alreadyInstalled {
-                HuggingFaceDownloader.discardStaging(forTargetDirectory: targetDir)
-                removeInFlightRecord(modelID: record.modelID)
-                continue
-            }
+        do {
+            try prepareDirectories()
+            try await migrateV1IfNeeded()
+            var ledger = try ledgerStore.load()
+            var restored: [ModelDescriptor] = []
 
-            // At cap: re-queue so it starts when a slot frees (its record stays for recovery).
-            guard inflight.count < Self.maxConcurrentModels else {
-                if !pending.contains(where: { $0.id == record.modelID }) {
-                    pending.append(descriptor)
+            for index in ledger.requests.indices {
+                let request = ledger.requests[index]
+                guard let descriptor = modelAssetStore.descriptor(id: request.modelID)?.model,
+                      descriptor.artifactVersion == request.artifactVersion else {
+                    ledger.requests[index].status = .failed
+                    continue
                 }
-                continue
+                let installed = descriptor.isAvailable(
+                    in: AppPaths.modelsDir,
+                    fileManager: fileManager
+                )
+                if installed {
+                    ledger.requests[index].status = .installed
+                    continue
+                }
+                if request.status == .cancelRequested || request.status == .deleted {
+                    discardStaging(modelID: request.modelID)
+                    ledger.requests[index].status = .deleted
+                    continue
+                }
+                if request.status != .installed {
+                    ledger.requests[index].status = .queued
+                    restored.append(descriptor)
+                }
             }
-
-            guard let files = try? await resolveFiles(for: descriptor) else {
-                removeInFlightRecord(modelID: record.modelID)
-                continue
+            try ledgerStore.save(ledger)
+            pending = restored
+            if restored.isEmpty {
+                await downloader.cancelAllSessionTasks()
+                IOSModelDeliveryBackgroundEventRelay.completeOrphans(keeping: [])
+            } else {
+                IOSModelDeliveryBackgroundEventRelay.completeOrphans(
+                    keeping: [configuration.backgroundSessionIdentifier]
+                )
+                await startPendingDownloads()
             }
-
-            activeSessionIDs.insert(record.backgroundSessionIdentifier)
-            let generation = beginOperation()
-            let downloader = makeDownloader(
-                modelID: record.modelID, totalBytes: record.totalBytes,
-                estimatedBytes: descriptor.estimatedDownloadBytes, generation: generation,
-                sessionID: record.backgroundSessionIdentifier
-            )
-            publish(.init(
-                modelID: record.modelID, phase: .downloading, downloadedBytes: 0,
-                totalBytes: record.totalBytes, estimatedBytes: descriptor.estimatedDownloadBytes,
-                message: nil, operationGeneration: generation
-            ))
-            inflight[record.modelID] = startRun(
-                modelID: record.modelID, files: files, repo: record.repo, revision: record.revision,
-                targetDir: targetDir, downloader: downloader, generation: generation,
-                totalBytes: record.totalBytes, estimatedBytes: descriptor.estimatedDownloadBytes,
-                sessionID: record.backgroundSessionIdentifier
-            )
+        } catch {
+            diagnosticsStore.recordFailure(classification: "ledger-restore", message: error.localizedDescription)
+            await downloader.cancelAllSessionTasks()
+            IOSModelDeliveryBackgroundEventRelay.completeOrphans(keeping: [])
         }
-        // Flush orphan completion handlers for sessions we did NOT reattach.
-        IOSModelDeliveryBackgroundEventRelay.completeOrphans(keeping: activeSessionIDs)
     }
 
-    /// Flush any pending background completion handler for a session we're not running, while
-    /// keeping handlers for sessions that have in-flight records (about to be restored) or an
-    /// active downloader.
     func resumeBackgroundEventsIfNeeded() async {
-        let records = loadInFlightRecords()
-        let active = Set(inflight.values.map(\.backgroundSessionIdentifier))
-            .union(records.map(\.backgroundSessionIdentifier))
-        IOSModelDeliveryBackgroundEventRelay.completeOrphans(keeping: active)
+        let hasActiveWork = (try? ledgerStore.load().requests.contains(where: {
+            ![.installed, .failed, .deleted].contains($0.status)
+        })) == true
+        IOSModelDeliveryBackgroundEventRelay.completeOrphans(
+            keeping: hasActiveWork ? [configuration.backgroundSessionIdentifier] : []
+        )
     }
 
-    // MARK: - Private: queue
-
-    /// Launch queued downloads until the concurrency cap is reached.
     private func startPendingDownloads() async {
         while inflight.count < Self.maxConcurrentModels, let model = pending.first {
             pending.removeFirst()
@@ -260,193 +275,137 @@ final class IOSModelDownloadCoordinator {
         }
     }
 
-    /// Resolve one queued model against the (cached) catalog and start its download.
     private func beginDownload(_ model: ModelDescriptor) async {
-        let entry: IOSModelCatalogEntry
         do {
             let catalog = try await fetchCatalog()
-            entry = try IOSModelDeliverySupport.matchingCatalogEntry(
-                for: model, in: catalog, configuration: configuration
+            let entry = try IOSModelDeliverySupport.matchingCatalogEntry(
+                for: model,
+                in: catalog,
+                configuration: configuration
+            )
+            let files = resolveFiles(entry: entry)
+            let totalBytes = entry.totalBytes > 0
+                ? entry.totalBytes
+                : entry.files.reduce(Int64(0)) { $0 + $1.sizeBytes }
+            let targetDir = model.installDirectory(in: AppPaths.modelsDir)
+            let stagingRoot = stagingRoot(modelID: model.id)
+            let generation = beginOperation()
+
+            var ledger = try ledgerStore.load()
+            guard let request = ledgerRequest(model.id, in: ledger) else {
+                throw IOSModelDownloadLedgerError.invalidDocument
+            }
+            updateRequest(model.id, in: &ledger) { $0.status = .downloading }
+            try ledgerStore.save(ledger)
+
+            let task = Task { @MainActor [weak self] in
+                guard let self else { return }
+                await self.runDownload(
+                    model: model,
+                    request: request,
+                    files: files,
+                    targetDir: targetDir,
+                    stagingRoot: stagingRoot,
+                    generation: generation,
+                    totalBytes: totalBytes
+                )
+            }
+            inflight[model.id] = InFlightDownload(
+                modelID: model.id,
+                logicalRequestID: request.logicalRequestID,
+                task: task,
+                targetDir: targetDir,
+                stagingRoot: stagingRoot,
+                totalBytes: totalBytes,
+                operationGeneration: generation
             )
         } catch {
+            markLedgerTerminal(modelID: model.id, status: .failed)
             publishFailed(modelID: model.id, message: error.localizedDescription)
-            return
         }
-        let totalBytes = entry.totalBytes > 0
-            ? entry.totalBytes
-            : entry.files.reduce(Int64(0)) { $0 + $1.sizeBytes }
-        do {
-            try IOSModelDeliverySupport.ensureSufficientDiskSpace(
-                requiredBytes: totalBytes, at: AppPaths.appSupportDir, fileManager: fileManager
-            )
-        } catch {
-            publishFailed(modelID: model.id, message: error.localizedDescription)
-            return
-        }
-
-        let files = resolveFiles(entry: entry)
-        let repo = model.huggingFaceRepo
-        let revision = model.huggingFaceRevision ?? "main"
-        let targetDir = model.installDirectory(in: AppPaths.modelsDir)
-        let sessionID = "com.qwenvoice.ios.model-download.\(model.id)"
-        let generation = beginOperation()
-        let downloader = makeDownloader(
-            modelID: model.id, totalBytes: totalBytes,
-            estimatedBytes: model.estimatedDownloadBytes, generation: generation,
-            sessionID: sessionID
-        )
-
-        upsertInFlightRecord(.init(
-            modelID: model.id, artifactVersion: model.artifactVersion,
-            backgroundSessionIdentifier: sessionID, repo: repo, revision: revision,
-            targetFolderPath: targetDir.path, totalBytes: totalBytes
-        ))
-        inflight[model.id] = startRun(
-            modelID: model.id, files: files, repo: repo, revision: revision, targetDir: targetDir,
-            downloader: downloader, generation: generation,
-            totalBytes: totalBytes, estimatedBytes: model.estimatedDownloadBytes, sessionID: sessionID
-        )
-    }
-
-    /// Spawn the download Task and return the `InFlightDownload` handle. The Task reconciles the
-    /// terminal state, gated on `generation` so a cancel/fail that supersedes it is a no-op.
-    private func startRun(
-        modelID: String,
-        files: [HuggingFaceDownloader.RepoFile],
-        repo: String,
-        revision: String,
-        targetDir: URL,
-        downloader: HuggingFaceDownloader,
-        generation: UInt64,
-        totalBytes: Int64,
-        estimatedBytes: Int64?,
-        sessionID: String
-    ) -> InFlightDownload {
-        let task = Task { @MainActor [weak self] in
-            guard let self else { return }
-            await self.runDownload(
-                modelID: modelID, files: files, repo: repo, revision: revision, targetDir: targetDir,
-                downloader: downloader, generation: generation,
-                totalBytes: totalBytes, estimatedBytes: estimatedBytes
-            )
-        }
-        return InFlightDownload(
-            modelID: modelID, downloader: downloader, task: task, targetDir: targetDir,
-            backgroundSessionIdentifier: sessionID, totalBytes: totalBytes, operationGeneration: generation
-        )
     }
 
     private func runDownload(
-        modelID: String,
+        model: ModelDescriptor,
+        request: IOSModelDownloadLedger.Request,
         files: [HuggingFaceDownloader.RepoFile],
-        repo: String,
-        revision: String,
         targetDir: URL,
-        downloader: HuggingFaceDownloader,
+        stagingRoot: URL,
         generation: UInt64,
-        totalBytes: Int64,
-        estimatedBytes: Int64?
+        totalBytes: Int64
     ) async {
         do {
-            try await downloader.downloadFiles(files, repo: repo, revision: revision, to: targetDir)
-            guard inflight[modelID]?.operationGeneration == generation else { return }
-            inflight.removeValue(forKey: modelID)
-            removeInFlightRecord(modelID: modelID)
-            publish(.init(
-                modelID: modelID, phase: .installed, downloadedBytes: totalBytes,
-                totalBytes: totalBytes, estimatedBytes: estimatedBytes, message: nil,
-                operationGeneration: generation
-            ))
+            try await downloader.downloadFiles(
+                files,
+                repo: request.repo,
+                revision: request.revision,
+                to: targetDir,
+                requestIdentity: ModelDownloadRequestIdentity(
+                    logicalRequestID: request.logicalRequestID,
+                    modelID: request.modelID,
+                    artifactVersion: request.artifactVersion
+                ),
+                stagingRoot: stagingRoot
+            )
+            guard inflight[model.id]?.operationGeneration == generation else { return }
+            inflight.removeValue(forKey: model.id)
+            markLedgerTerminal(modelID: model.id, status: .installed, receivedBytes: totalBytes)
+            diagnosticsStore.recordSuccess(expectedBytes: totalBytes)
+            publishSnapshot(
+                modelID: model.id,
+                phase: .installed,
+                downloadedBytes: totalBytes,
+                totalBytes: totalBytes,
+                message: nil,
+                generation: generation
+            )
         } catch is CancellationError {
-            // Cancel is handled by `cancel(modelID:)` (inflight already cleared); no-op here.
             return
-        } catch let dlError as HuggingFaceDownloader.DownloadError {
-            if case .cancelled = dlError { return }
-            guard inflight[modelID]?.operationGeneration == generation else { return }
-            inflight.removeValue(forKey: modelID)
-            removeInFlightRecord(modelID: modelID)
-            publish(.init(
-                modelID: modelID, phase: .failed, downloadedBytes: 0, totalBytes: totalBytes,
-                estimatedBytes: estimatedBytes, message: dlError.localizedDescription,
-                operationGeneration: generation
-            ))
+        } catch let error as HuggingFaceDownloader.DownloadError {
+            if case .cancelled = error { return }
+            guard inflight[model.id]?.operationGeneration == generation else { return }
+            inflight.removeValue(forKey: model.id)
+            markLedgerTerminal(modelID: model.id, status: .failed)
+            diagnosticsStore.recordFailure(classification: "transfer", message: error.localizedDescription)
+            publishFailed(modelID: model.id, message: error.localizedDescription)
         } catch {
-            guard inflight[modelID]?.operationGeneration == generation else { return }
-            inflight.removeValue(forKey: modelID)
-            removeInFlightRecord(modelID: modelID)
-            publish(.init(
-                modelID: modelID, phase: .failed, downloadedBytes: 0, totalBytes: totalBytes,
-                estimatedBytes: estimatedBytes, message: error.localizedDescription,
-                operationGeneration: generation
-            ))
+            guard inflight[model.id]?.operationGeneration == generation else { return }
+            inflight.removeValue(forKey: model.id)
+            markLedgerTerminal(modelID: model.id, status: .failed)
+            diagnosticsStore.recordFailure(classification: "filesystem", message: error.localizedDescription)
+            publishFailed(modelID: model.id, message: error.localizedDescription)
         }
-        // A slot just freed (success or failure) — drain the next queued download. (The cancel
-        // paths `return` above, so this only runs for terminal success/failure; cancel drains
-        // itself in `cancel(modelID:)`.)
         await startPendingDownloads()
     }
 
-    private func publishFailed(modelID: String, message: String) {
-        let descriptor = modelAssetStore.descriptor(id: modelID)?.model
-        publish(.init(
-            modelID: modelID, phase: .failed, downloadedBytes: 0, totalBytes: nil,
-            estimatedBytes: descriptor?.estimatedDownloadBytes, message: message,
-            operationGeneration: endOperation()
-        ))
-    }
-
-    // MARK: - Private: catalog + downloader
-
-    /// Resolve a catalog entry's files into engine `RepoFile`s with host-allowlist-validated URLs.
-    private func resolveFiles(entry: IOSModelCatalogEntry) -> [HuggingFaceDownloader.RepoFile] {
-        entry.files.map { f in
-            let url = (try? IOSModelDeliverySupport.downloadURL(for: f, entry: entry, configuration: configuration))
-            return HuggingFaceDownloader.RepoFile(
-                path: f.relativePath, size: f.sizeBytes, sha256: f.sha256, absoluteURL: url
-            )
-        }
-    }
-
-    /// Resolve files for `descriptor` via the (cached) catalog (used by relaunch-restore).
-    private func resolveFiles(for descriptor: ModelDescriptor) async throws -> [HuggingFaceDownloader.RepoFile] {
-        let catalog = try await fetchCatalog()
-        let entry = try IOSModelDeliverySupport.matchingCatalogEntry(
-            for: descriptor, in: catalog, configuration: configuration
-        )
-        return resolveFiles(entry: entry)
-    }
-
-    /// Build the engine with the iOS background-session profile: one `URLSession` per model
-    /// (singleton by identifier), byte-range chunking off, 6 concurrent files. The background
-    /// configuration lets downloads continue while the app is backgrounded or the device is locked.
-    private func makeDownloader(
-        modelID: String,
-        totalBytes: Int64,
-        estimatedBytes: Int64?,
-        generation: UInt64,
-        sessionID: String
-    ) -> HuggingFaceDownloader {
+    private func makeSharedDownloader() -> HuggingFaceDownloader {
         var engineConfig = HuggingFaceDownloader.Configuration()
-        engineConfig.maxConcurrentFiles = 6          // the model's files download concurrently (6)
-        engineConfig.chunkLargeFiles = false         // one native downloadTask per file — stable, even throughput (no chunk tapering)
+        engineConfig.maxConcurrentFiles = 6
+        engineConfig.chunkLargeFiles = false
 
-        let sessionConfig = URLSessionConfiguration.background(withIdentifier: sessionID)
-        sessionConfig.isDiscretionary = false        // user-initiated; do not defer
+        let sessionConfig = URLSessionConfiguration.background(
+            withIdentifier: configuration.backgroundSessionIdentifier
+        )
+        sessionConfig.isDiscretionary = false
         sessionConfig.waitsForConnectivity = true
         sessionConfig.sessionSendsLaunchEvents = true
         sessionConfig.httpMaximumConnectionsPerHost = 6
 
         return HuggingFaceDownloader(
             progressHandler: { [weak self] progress in
-                Task { @MainActor [weak self] in
-                    self?.handleProgress(
-                        modelID: modelID, generation: generation, totalBytes: totalBytes,
-                        estimatedBytes: estimatedBytes, progress: progress
-                    )
-                }
+                Task { @MainActor [weak self] in self?.handleProgress(progress) }
             },
             sessionConfiguration: sessionConfig,
             engineConfiguration: engineConfig,
+            durableTemporaryDirectory: AppPaths.modelDownloadDelegateFilesDir,
+            // The diagnostics store is internally serialized. Record synchronously so the
+            // terminal success summary cannot overtake URLSession's final task metrics.
+            transferMetricsHandler: { [diagnosticsStore] metrics in
+                diagnosticsStore.record(metrics: metrics)
+            },
+            verifiedArtifactHandler: { [weak self] receipt in
+                await MainActor.run { [weak self] in self?.recordVerifiedFile(receipt) }
+            },
             backgroundSessionCompletionHandler: { identifier in
                 Task { @MainActor in
                     IOSModelDeliveryBackgroundEventRelay.complete(forSessionIdentifier: identifier)
@@ -455,56 +414,205 @@ final class IOSModelDownloadCoordinator {
         )
     }
 
-    private func handleProgress(
-        modelID: String,
-        generation: UInt64,
-        totalBytes: Int64,
-        estimatedBytes: Int64?,
-        progress: HuggingFaceDownloader.RepositoryProgress
-    ) {
-        guard inflight[modelID]?.operationGeneration == generation else { return }   // stale
+    private func handleProgress(_ progress: HuggingFaceDownloader.RepositoryProgress) {
+        diagnosticsStore.record(progress: progress)
+        guard let active = inflight.values.first,
+              let descriptor = modelAssetStore.descriptor(id: active.modelID)?.model else { return }
         let phase: IOSModelDeliverySnapshot.Phase
+        let ledgerStatus: IOSModelDownloadLedger.Status
         switch progress.phase {
-        case .downloading: phase = .downloading
-        case .verifying: phase = .verifying
-        case .installing: phase = .installing
+        case .queued:
+            phase = .queued; ledgerStatus = .queued
+        case .waitingForConnectivity:
+            phase = .waitingForConnectivity; ledgerStatus = .waitingForConnectivity
+        case .downloading:
+            phase = .downloading; ledgerStatus = .downloading
+        case .retrying:
+            phase = .retrying; ledgerStatus = .retrying
+        case .verifying:
+            phase = .verifying; ledgerStatus = .verifying
+        case .installing:
+            phase = .installing; ledgerStatus = .installing
+        case .cancelling:
+            phase = .cancelling; ledgerStatus = .cancelRequested
         }
-        publish(.init(
-            modelID: modelID, phase: phase, downloadedBytes: progress.downloadedBytes,
-            totalBytes: progress.totalBytes > 0 ? progress.totalBytes : totalBytes,
-            estimatedBytes: estimatedBytes, message: nil, operationGeneration: generation
-        ))
+        let visibleBytes = ModelDownloadProgressReconciler.visibleBytes(
+            current: progress.downloadedBytes,
+            persisted: ledgerReceivedBytes(modelID: active.modelID),
+            total: active.totalBytes
+        )
+        persistProgressIfNeeded(
+            modelID: active.modelID,
+            status: ledgerStatus,
+            bytes: visibleBytes,
+            retryCount: progress.retryCount
+        )
+        publishSnapshot(
+            modelID: active.modelID,
+            phase: phase,
+            downloadedBytes: visibleBytes,
+            totalBytes: progress.totalBytes > 0 ? progress.totalBytes : active.totalBytes,
+            bytesPerSecond: progress.phase == .downloading ? progress.bytesPerSecond : nil,
+            estimatedSecondsRemaining: progress.estimatedSecondsRemaining,
+            retryCount: progress.retryCount,
+            message: progress.isStalled ? "No progress for 20 seconds" : progress.statusMessage,
+            generation: active.operationGeneration,
+            estimatedBytes: descriptor.estimatedDownloadBytes
+        )
     }
 
-    private func publish(_ snapshot: IOSModelDeliverySnapshot) {
-        snapshotSink(snapshot)
+    private func resolveFiles(entry: IOSModelCatalogEntry) -> [HuggingFaceDownloader.RepoFile] {
+        entry.files.map { file in
+            HuggingFaceDownloader.RepoFile(
+                path: file.relativePath,
+                size: file.sizeBytes,
+                sha256: file.sha256,
+                absoluteURL: try? IOSModelDeliverySupport.downloadURL(
+                    for: file,
+                    entry: entry,
+                    configuration: configuration
+                )
+            )
+        }
     }
 
     private func fetchCatalog() async throws -> IOSModelCatalogDocument {
         if let cachedCatalog { return cachedCatalog }
-        let document = try await fetchCatalogUncached()
-        cachedCatalog = document
-        return document
-    }
-
-    private func fetchCatalogUncached() async throws -> IOSModelCatalogDocument {
+        let document: IOSModelCatalogDocument
         if configuration.catalogURL.isBundledModelCatalog {
-            guard let catalogURL = Bundle.main.url(
+            guard let url = Bundle.main.url(
                 forResource: IOSModelDeliveryConfiguration.bundledCatalogResourceName,
                 withExtension: IOSModelDeliveryConfiguration.bundledCatalogResourceExtension
             ) else {
                 throw IOSModelDeliveryError.invalidCatalog("Bundled iPhone model catalog is missing.")
             }
-            let data = try Data(contentsOf: catalogURL)
-            return try JSONDecoder().decode(IOSModelCatalogDocument.self, from: data)
+            document = try JSONDecoder().decode(IOSModelCatalogDocument.self, from: Data(contentsOf: url))
+        } else {
+            let (data, response) = try await catalogSession.data(from: configuration.catalogURL)
+            guard let response = response as? HTTPURLResponse,
+                  (200..<300).contains(response.statusCode) else {
+                throw IOSModelDeliveryError.invalidCatalog("Catalog endpoint returned an unexpected response.")
+            }
+            document = try JSONDecoder().decode(IOSModelCatalogDocument.self, from: data)
         }
+        cachedCatalog = document
+        return document
+    }
 
-        let (data, response) = try await catalogSession.data(from: configuration.catalogURL)
-        guard let httpResponse = response as? HTTPURLResponse,
-              (200..<300).contains(httpResponse.statusCode) else {
-            throw IOSModelDeliveryError.invalidCatalog("Catalog endpoint returned an unexpected response.")
+    private func makeLedgerRequest(
+        model: ModelDescriptor,
+        entry: IOSModelCatalogEntry,
+        totalBytes: Int64
+    ) -> IOSModelDownloadLedger.Request {
+        IOSModelDownloadLedger.Request(
+            logicalRequestID: UUID().uuidString,
+            modelID: model.id,
+            artifactVersion: model.artifactVersion,
+            repo: model.huggingFaceRepo,
+            revision: model.huggingFaceRevision ?? "main",
+            targetFolder: model.installDirectory(in: AppPaths.modelsDir).lastPathComponent,
+            expectedFiles: entry.files.map(\.relativePath).sorted(),
+            verifiedFiles: [],
+            retryCount: 0,
+            receivedBytes: 0,
+            totalBytes: totalBytes,
+            status: .queued
+        )
+    }
+
+    private func prepareDirectories() throws {
+        for directory in [
+            AppPaths.modelsDir,
+            AppPaths.modelDownloadRootDir,
+            AppPaths.modelDownloadStagingDir,
+            AppPaths.modelDownloadDelegateFilesDir,
+            AppPaths.modelDownloadDiagnosticsDir,
+        ] {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            try? IOSModelDeliverySupport.excludeFromBackup(directory)
         }
-        return try JSONDecoder().decode(IOSModelCatalogDocument.self, from: data)
+    }
+
+    private func stagingRoot(modelID: String) -> URL {
+        AppPaths.modelDownloadStagingDir.appendingPathComponent(modelID, isDirectory: true)
+    }
+
+    private func discardStaging(modelID: String) {
+        try? fileManager.removeItem(at: stagingRoot(modelID: modelID))
+    }
+
+    private func persistProgressIfNeeded(
+        modelID: String,
+        status: IOSModelDownloadLedger.Status,
+        bytes: Int64,
+        retryCount: Int
+    ) {
+        let now = ProcessInfo.processInfo.systemUptime
+        let last = lastLedgerProgressWrite[modelID] ?? 0
+        guard now - last >= 0.5 || status != .downloading else { return }
+        lastLedgerProgressWrite[modelID] = now
+        updateLedger(modelID: modelID) {
+            $0.status = status
+            $0.receivedBytes = max($0.receivedBytes, bytes)
+            $0.retryCount = max($0.retryCount, retryCount)
+        }
+    }
+
+    private func recordVerifiedFile(_ receipt: VerifiedArtifactReceipt) {
+        guard let modelID = inflight.values.first?.modelID else { return }
+        updateLedger(modelID: modelID) { request in
+            request.verifiedFiles.removeAll { $0.relativePath == receipt.relativePath }
+            request.verifiedFiles.append(.init(
+                relativePath: receipt.relativePath,
+                expectedSize: receipt.expectedSize,
+                sha256: receipt.expectedSHA256
+            ))
+            request.verifiedFiles.sort { $0.relativePath < $1.relativePath }
+        }
+    }
+
+    private func updateLedger(
+        modelID: String,
+        mutate: (inout IOSModelDownloadLedger.Request) -> Void
+    ) {
+        do {
+            var ledger = try ledgerStore.load()
+            updateRequest(modelID, in: &ledger, mutate: mutate)
+            try ledgerStore.save(ledger)
+        } catch {
+            diagnosticsStore.recordFailure(classification: "ledger-write", message: error.localizedDescription)
+        }
+    }
+
+    private func updateRequest(
+        _ modelID: String,
+        in ledger: inout IOSModelDownloadLedger,
+        mutate: (inout IOSModelDownloadLedger.Request) -> Void
+    ) {
+        guard let index = ledger.requests.firstIndex(where: { $0.modelID == modelID }) else { return }
+        mutate(&ledger.requests[index])
+    }
+
+    private func ledgerRequest(
+        _ modelID: String,
+        in ledger: IOSModelDownloadLedger
+    ) -> IOSModelDownloadLedger.Request? {
+        ledger.requests.first(where: { $0.modelID == modelID })
+    }
+
+    private func ledgerReceivedBytes(modelID: String) -> Int64 {
+        (try? ledgerStore.load().requests.first(where: { $0.modelID == modelID })?.receivedBytes) ?? 0
+    }
+
+    private func markLedgerTerminal(
+        modelID: String,
+        status: IOSModelDownloadLedger.Status,
+        receivedBytes: Int64? = nil
+    ) {
+        updateLedger(modelID: modelID) {
+            $0.status = status
+            if let receivedBytes { $0.receivedBytes = receivedBytes }
+        }
     }
 
     private func beginOperation() -> UInt64 {
@@ -512,38 +620,181 @@ final class IOSModelDownloadCoordinator {
         return operationGeneration
     }
 
-    @discardableResult
-    private func endOperation() -> UInt64 {
-        operationGeneration += 1
-        return operationGeneration
-    }
-
-    // MARK: - In-flight persistence
-
-    private func loadInFlightRecords() -> [IOSInFlightDownloadRecord] {
-        guard let data = try? Data(contentsOf: AppPaths.iosInFlightDownloadsFile),
-              let document = try? JSONDecoder().decode(IOSInFlightDownloadsDocument.self, from: data) else {
-            return []
-        }
-        return document.downloads
-    }
-
-    private func saveInFlightRecords(_ records: [IOSInFlightDownloadRecord]) {
-        let document = IOSInFlightDownloadsDocument(
-            schemaVersion: IOSInFlightDownloadsDocument.currentSchemaVersion,
-            downloads: records
+    private func publishSnapshot(
+        for model: ModelDescriptor,
+        phase: IOSModelDeliverySnapshot.Phase,
+        downloadedBytes: Int64
+    ) {
+        publishSnapshot(
+            modelID: model.id,
+            phase: phase,
+            downloadedBytes: downloadedBytes,
+            totalBytes: model.estimatedDownloadBytes,
+            message: nil,
+            generation: beginOperation(),
+            estimatedBytes: model.estimatedDownloadBytes
         )
-        guard let data = try? JSONEncoder().encode(document) else { return }
-        try? data.write(to: AppPaths.iosInFlightDownloadsFile, options: .atomic)
     }
 
-    private func upsertInFlightRecord(_ record: IOSInFlightDownloadRecord) {
-        var records = loadInFlightRecords().filter { $0.modelID != record.modelID }
-        records.append(record)
-        saveInFlightRecords(records)
+    private func publishSnapshot(
+        modelID: String,
+        phase: IOSModelDeliverySnapshot.Phase,
+        downloadedBytes: Int64,
+        totalBytes: Int64?,
+        bytesPerSecond: Int64? = nil,
+        estimatedSecondsRemaining: Double? = nil,
+        retryCount: Int = 0,
+        message: String?,
+        generation: UInt64,
+        estimatedBytes: Int64? = nil
+    ) {
+        snapshotSink(.init(
+            modelID: modelID,
+            phase: phase,
+            downloadedBytes: downloadedBytes,
+            totalBytes: totalBytes,
+            estimatedBytes: estimatedBytes ?? modelAssetStore.descriptor(id: modelID)?.model.estimatedDownloadBytes,
+            bytesPerSecond: bytesPerSecond,
+            estimatedSecondsRemaining: estimatedSecondsRemaining,
+            retryCount: retryCount,
+            message: message,
+            operationGeneration: generation
+        ))
     }
 
-    private func removeInFlightRecord(modelID: String) {
-        saveInFlightRecords(loadInFlightRecords().filter { $0.modelID != modelID })
+    private func publishTerminal(modelID: String, phase: IOSModelDeliverySnapshot.Phase) {
+        publishSnapshot(
+            modelID: modelID,
+            phase: phase,
+            downloadedBytes: 0,
+            totalBytes: nil,
+            message: nil,
+            generation: beginOperation()
+        )
+    }
+
+    private func publishFailed(modelID: String, message: String) {
+        publishSnapshot(
+            modelID: modelID,
+            phase: .failed,
+            downloadedBytes: ledgerReceivedBytes(modelID: modelID),
+            totalBytes: modelAssetStore.descriptor(id: modelID)?.model.estimatedDownloadBytes,
+            message: message,
+            generation: beginOperation()
+        )
+    }
+
+    private func migrateV1IfNeeded() async throws {
+        let legacyURL = AppPaths.iosInFlightDownloadsFile
+        guard fileManager.fileExists(atPath: legacyURL.path) else { return }
+        let data = try Data(contentsOf: legacyURL)
+        let legacy = try JSONDecoder().decode(IOSLegacyInFlightDownloadsDocument.self, from: data)
+        guard legacy.schemaVersion == 1 else {
+            throw IOSModelDownloadLedgerError.unsupportedSchema(legacy.schemaVersion)
+        }
+
+        var ledger = try ledgerStore.load()
+        for record in legacy.downloads {
+            let legacyConfig = URLSessionConfiguration.background(
+                withIdentifier: record.backgroundSessionIdentifier
+            )
+            let legacySession = URLSession(configuration: legacyConfig)
+            let tasks = await withCheckedContinuation { continuation in
+                legacySession.getAllTasks { continuation.resume(returning: $0) }
+            }
+            await withTaskGroup(of: Void.self) { group in
+                for case let task as URLSessionDownloadTask in tasks {
+                    group.addTask {
+                        await withCheckedContinuation { continuation in
+                            task.cancel { _ in continuation.resume() }
+                        }
+                    }
+                }
+            }
+            guard await waitUntilSessionIsEmpty(legacySession) else {
+                legacySession.invalidateAndCancel()
+                throw IOSModelDownloadLedgerError.invalidDocument
+            }
+            legacySession.finishTasksAndInvalidate()
+
+            guard let descriptor = modelAssetStore.descriptor(id: record.modelID)?.model,
+                  descriptor.artifactVersion == record.artifactVersion,
+                  let entry = try? IOSModelDeliverySupport.matchingCatalogEntry(
+                    for: descriptor,
+                    in: try await fetchCatalog(),
+                    configuration: configuration
+                  ) else { continue }
+            try migrateLegacyStagingIfPresent(record: record)
+            if !ledger.requests.contains(where: { $0.modelID == record.modelID }) {
+                ledger.requests.append(makeLedgerRequest(
+                    model: descriptor,
+                    entry: entry,
+                    totalBytes: record.totalBytes
+                ))
+            }
+        }
+        try ledgerStore.save(ledger)
+        try fileManager.removeItem(at: legacyURL)
+    }
+
+    private func waitUntilSessionIsEmpty(_ session: URLSession) async -> Bool {
+        for _ in 0..<100 {
+            let tasks = await withCheckedContinuation { continuation in
+                session.getAllTasks { continuation.resume(returning: $0) }
+            }
+            if tasks.isEmpty { return true }
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+        return false
+    }
+
+    /// Move recoverable v1 partials into the single v2 staging hierarchy. Conflicting files are
+    /// retained under `legacy-conflicts` for a clean revalidation instead of being discarded or
+    /// trusted without hashing.
+    private func migrateLegacyStagingIfPresent(record: IOSLegacyInFlightDownloadRecord) throws {
+        let targetName = URL(fileURLWithPath: record.targetFolderPath).lastPathComponent
+        guard !targetName.isEmpty else { return }
+        let legacyRoot = AppPaths.modelsDir
+            .appendingPathComponent(".qwenvoice-downloads", isDirectory: true)
+            .appendingPathComponent(targetName, isDirectory: true)
+        guard fileManager.fileExists(atPath: legacyRoot.path) else { return }
+
+        let destinationRoot = AppPaths.modelDownloadStagingDir
+            .appendingPathComponent(record.modelID, isDirectory: true)
+        try fileManager.createDirectory(at: destinationRoot, withIntermediateDirectories: true)
+        guard let enumerator = fileManager.enumerator(
+            at: legacyRoot,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else { return }
+
+        let legacyComponents = legacyRoot.standardizedFileURL.pathComponents
+        for case let source as URL in enumerator {
+            let values = try source.resourceValues(forKeys: [.isRegularFileKey])
+            guard values.isRegularFile == true else { continue }
+            let relativeComponents = source.standardizedFileURL.pathComponents
+                .dropFirst(legacyComponents.count)
+            guard !relativeComponents.isEmpty,
+                  !relativeComponents.contains("..") else { continue }
+            let relativePath = relativeComponents.joined(separator: "/")
+            var destination = destinationRoot.appendingPathComponent(relativePath)
+            if fileManager.fileExists(atPath: destination.path) {
+                let sourceSize = (try? source.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? -1
+                let destinationSize = (try? destination.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? -2
+                if sourceSize == destinationSize {
+                    try fileManager.removeItem(at: source)
+                    continue
+                }
+                destination = destinationRoot
+                    .appendingPathComponent("legacy-conflicts", isDirectory: true)
+                    .appendingPathComponent("\(UUID().uuidString)-\(source.lastPathComponent)")
+            }
+            try fileManager.createDirectory(
+                at: destination.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try fileManager.moveItem(at: source, to: destination)
+        }
+        try? fileManager.removeItem(at: legacyRoot)
     }
 }

--- a/Sources/iOS/IOSModelInstallerViewModel.swift
+++ b/Sources/iOS/IOSModelInstallerViewModel.swift
@@ -6,13 +6,19 @@ final class IOSModelInstallerViewModel: ObservableObject {
     enum OperationState: Equatable {
         case idle
         case available(estimatedBytes: Int64?)
-        case downloading(progress: Double?, downloadedBytes: Int64, totalBytes: Int64?)
-        case interrupted(message: String?, downloadedBytes: Int64, totalBytes: Int64?)
-        case resuming(progress: Double?, downloadedBytes: Int64, totalBytes: Int64?)
-        case restarting(progress: Double?, downloadedBytes: Int64, totalBytes: Int64?)
-        case paused(progress: Double?, downloadedBytes: Int64, totalBytes: Int64?)
+        case queued
+        case waitingForConnectivity(downloadedBytes: Int64, totalBytes: Int64?)
+        case downloading(
+            progress: Double?, downloadedBytes: Int64, totalBytes: Int64?,
+            bytesPerSecond: Int64?, estimatedSecondsRemaining: Double?, message: String?
+        )
+        case retrying(
+            progress: Double?, downloadedBytes: Int64, totalBytes: Int64?,
+            retryCount: Int, reason: String?
+        )
         case verifying
         case installing
+        case cancelling
         case installed
         case deleting
         case unavailable(String)
@@ -128,14 +134,7 @@ final class IOSModelInstallerViewModel: ObservableObject {
     }
 
     func cancel(_ model: TTSModel) {
-        let bumpedGeneration = (lastAcceptedGeneration[model.id] ?? 0) + 1
-        lastAcceptedGeneration[model.id] = bumpedGeneration
-        // Immediately show available state before background refresh
-        if let descriptor = modelAssetStore?.descriptor(id: model.id)?.model {
-            states[model.id] = .available(estimatedBytes: descriptor.estimatedDownloadBytes)
-        } else {
-            states.removeValue(forKey: model.id)
-        }
+        states[model.id] = .cancelling
         guard let coordinator else { return }
         Task {
             await coordinator.cancel(modelID: model.id)
@@ -192,6 +191,13 @@ final class IOSModelInstallerViewModel: ObservableObject {
         lastAcceptedGeneration[snapshot.modelID] = snapshot.operationGeneration
 
         switch snapshot.phase {
+        case .queued:
+            states[snapshot.modelID] = .queued
+        case .waitingForConnectivity:
+            states[snapshot.modelID] = .waitingForConnectivity(
+                downloadedBytes: snapshot.downloadedBytes,
+                totalBytes: snapshot.totalBytes
+            )
         case .downloading:
             let progress: Double?
             if let totalBytes = snapshot.totalBytes, totalBytes > 0 {
@@ -202,54 +208,31 @@ final class IOSModelInstallerViewModel: ObservableObject {
             states[snapshot.modelID] = .downloading(
                 progress: progress,
                 downloadedBytes: snapshot.downloadedBytes,
-                totalBytes: snapshot.totalBytes
+                totalBytes: snapshot.totalBytes,
+                bytesPerSecond: snapshot.bytesPerSecond,
+                estimatedSecondsRemaining: snapshot.estimatedSecondsRemaining,
+                message: snapshot.message
             )
-        case .interrupted:
-            states[snapshot.modelID] = .interrupted(
-                message: snapshot.message,
-                downloadedBytes: snapshot.downloadedBytes,
-                totalBytes: snapshot.totalBytes
-            )
-        case .resuming:
+        case .retrying:
             let progress: Double?
             if let totalBytes = snapshot.totalBytes, totalBytes > 0 {
                 progress = Double(snapshot.downloadedBytes) / Double(totalBytes)
             } else {
                 progress = nil
             }
-            states[snapshot.modelID] = .resuming(
+            states[snapshot.modelID] = .retrying(
                 progress: progress,
                 downloadedBytes: snapshot.downloadedBytes,
-                totalBytes: snapshot.totalBytes
-            )
-        case .restarting:
-            let progress: Double?
-            if let totalBytes = snapshot.totalBytes, totalBytes > 0 {
-                progress = Double(snapshot.downloadedBytes) / Double(totalBytes)
-            } else {
-                progress = nil
-            }
-            states[snapshot.modelID] = .restarting(
-                progress: progress,
-                downloadedBytes: snapshot.downloadedBytes,
-                totalBytes: snapshot.totalBytes
-            )
-        case .paused:
-            let progress: Double?
-            if let totalBytes = snapshot.totalBytes, totalBytes > 0 {
-                progress = Double(snapshot.downloadedBytes) / Double(totalBytes)
-            } else {
-                progress = nil
-            }
-            states[snapshot.modelID] = .paused(
-                progress: progress,
-                downloadedBytes: snapshot.downloadedBytes,
-                totalBytes: snapshot.totalBytes
+                totalBytes: snapshot.totalBytes,
+                retryCount: snapshot.retryCount,
+                reason: snapshot.message
             )
         case .verifying:
             states[snapshot.modelID] = .verifying
         case .installing:
             states[snapshot.modelID] = .installing
+        case .cancelling:
+            states[snapshot.modelID] = .cancelling
         case .installed:
             states[snapshot.modelID] = .installed
             let modelID = snapshot.modelID

--- a/Sources/iOS/IOSSettingsViews.swift
+++ b/Sources/iOS/IOSSettingsViews.swift
@@ -583,13 +583,9 @@ struct IOSModelRow: View {
             installedControls
         case .available:
             installButton(title: "Install", accessibilityIdentifier: "iosModelDownload_\(model.id)")
-        case .downloading, .resuming, .restarting:
+        case .queued, .waitingForConnectivity, .downloading, .retrying:
             installButton(title: "Cancel", action: requestCancelOptions, accessibilityIdentifier: "iosModelCancel_\(model.id)")
-        case .interrupted:
-            installButton(title: "Cancel", action: requestDirectCancel, accessibilityIdentifier: "iosModelCancel_\(model.id)")
-        case .paused:
-            installButton(title: "Resume", action: requestInstall, accessibilityIdentifier: "iosModelResume_\(model.id)")
-        case .verifying, .installing, .deleting:
+        case .verifying, .installing, .cancelling, .deleting:
             ProgressView()
         case .unavailable:
             if case .incomplete = status {
@@ -638,40 +634,43 @@ struct IOSModelRow: View {
     @ViewBuilder
     private var statusDetailView: some View {
         switch operationState {
-        case .downloading(let progress, let downloadedBytes, let totalBytes):
+        case .downloading(
+            let progress, let downloadedBytes, let totalBytes,
+            let bytesPerSecond, let estimatedSecondsRemaining, let message
+        ):
             VStack(alignment: .leading, spacing: 6) {
                 ProgressView(value: progress ?? 0)
                     .tint(IOSBrandTheme.modeColor(for: model.mode))
                     .accessibilityIdentifier("iosModelProgress_\(model.id)")
-                Text(progressText(downloadedBytes: downloadedBytes, totalBytes: totalBytes))
+                Text(progressText(
+                    downloadedBytes: downloadedBytes,
+                    totalBytes: totalBytes,
+                    bytesPerSecond: bytesPerSecond,
+                    estimatedSecondsRemaining: estimatedSecondsRemaining,
+                    suffix: message
+                ))
                     .font(.system(size: 12))
                     .foregroundStyle(IOSAppTheme.textSecondary)
             }
-        case .interrupted(let message, let downloadedBytes, let totalBytes):
+        case .waitingForConnectivity(let downloadedBytes, let totalBytes):
             VStack(alignment: .leading, spacing: 6) {
-                Text(message ?? "Download interrupted.")
+                Text("Waiting for connectivity")
                     .font(.system(size: 12))
                     .foregroundStyle(IOSAppTheme.textSecondary)
                 Text(progressText(downloadedBytes: downloadedBytes, totalBytes: totalBytes))
                     .font(.system(size: 12))
                     .foregroundStyle(IOSAppTheme.textSecondary)
             }
-        case .resuming(let progress, let downloadedBytes, let totalBytes),
-                .restarting(let progress, let downloadedBytes, let totalBytes):
-            VStack(alignment: .leading, spacing: 6) {
-                ProgressView(value: progress ?? 0)
-                    .tint(IOSBrandTheme.modeColor(for: model.mode))
-                    .accessibilityIdentifier("iosModelProgress_\(model.id)")
-                Text(progressText(downloadedBytes: downloadedBytes, totalBytes: totalBytes))
-                    .font(.system(size: 12))
-                    .foregroundStyle(IOSAppTheme.textSecondary)
-            }
-        case .paused(let progress, let downloadedBytes, let totalBytes):
+        case .retrying(let progress, let downloadedBytes, let totalBytes, let retryCount, let reason):
             VStack(alignment: .leading, spacing: 6) {
                 ProgressView(value: progress ?? 0)
                     .tint(IOSBrandTheme.modeColor(for: model.mode))
                     .accessibilityIdentifier("iosModelProgress_\(model.id)")
-                Text(progressText(downloadedBytes: downloadedBytes, totalBytes: totalBytes))
+                Text(progressText(
+                    downloadedBytes: downloadedBytes,
+                    totalBytes: totalBytes,
+                    suffix: "Retry \(retryCount)\(reason.map { ": \($0)" } ?? "") · verified files will be reused"
+                ))
                     .font(.system(size: 12))
                     .foregroundStyle(IOSAppTheme.textSecondary)
             }
@@ -680,7 +679,7 @@ struct IOSModelRow: View {
                 .font(.system(size: 12))
                 .foregroundStyle(.red)
                 .fixedSize(horizontal: false, vertical: true)
-        case .available, .verifying, .installing, .installed, .deleting, .unavailable, .idle:
+        case .available, .queued, .verifying, .installing, .cancelling, .installed, .deleting, .unavailable, .idle:
             EmptyView()
         }
     }
@@ -716,7 +715,7 @@ struct IOSModelRow: View {
 
     private var showsStatusDetail: Bool {
         switch operationState {
-        case .downloading, .interrupted, .resuming, .restarting, .paused:
+        case .waitingForConnectivity, .downloading, .retrying:
             return true
         case .failed:
             return true
@@ -744,20 +743,20 @@ struct IOSModelRow: View {
             return "Active"
         case .available:
             return nil
+        case .queued:
+            return "Queued…"
+        case .waitingForConnectivity:
+            return "Waiting for network…"
         case .downloading:
             return "Downloading…"
-        case .interrupted:
-            return "Interrupted"
-        case .resuming:
-            return "Resuming…"
-        case .restarting:
-            return "Restarting…"
-        case .paused:
-            return "Paused"
+        case .retrying:
+            return "Retrying…"
         case .verifying:
             return "Verifying…"
         case .installing:
             return "Installing…"
+        case .cancelling:
+            return "Cancelling…"
         case .deleting:
             return "Removing…"
         case .unavailable:
@@ -767,10 +766,27 @@ struct IOSModelRow: View {
         }
     }
 
-    private func progressText(downloadedBytes: Int64, totalBytes: Int64?) -> String {
+    private func progressText(
+        downloadedBytes: Int64,
+        totalBytes: Int64?,
+        bytesPerSecond: Int64? = nil,
+        estimatedSecondsRemaining: Double? = nil,
+        suffix: String? = nil
+    ) -> String {
         let current = IOSSettingsFormatters.fileSize(downloadedBytes)
-        guard let totalBytes else { return "\(current) downloaded" }
-        let total = IOSSettingsFormatters.fileSize(totalBytes)
-        return "\(current) / \(total)"
+        var parts: [String]
+        if let totalBytes {
+            parts = ["\(current) / \(IOSSettingsFormatters.fileSize(totalBytes))"]
+        } else {
+            parts = ["\(current) downloaded"]
+        }
+        if let bytesPerSecond, bytesPerSecond > 0 {
+            parts.append("\(IOSSettingsFormatters.fileSize(bytesPerSecond))/s")
+        }
+        if let estimatedSecondsRemaining, estimatedSecondsRemaining.isFinite {
+            parts.append("about \(max(1, Int(estimatedSecondsRemaining.rounded())))s remaining")
+        }
+        if let suffix, !suffix.isEmpty { parts.append(suffix) }
+        return parts.joined(separator: " · ")
     }
 }

--- a/Sources/iOSSupport/Services/AppPaths.swift
+++ b/Sources/iOSSupport/Services/AppPaths.swift
@@ -75,13 +75,19 @@ enum AppPaths {
         modelDownloadRootDir.appendingPathComponent("staging", isDirectory: true)
     }
 
+    static var modelDownloadDelegateFilesDir: URL {
+        modelDownloadStagingDir.appendingPathComponent("delegate-files", isDirectory: true)
+    }
+
+    static var modelDownloadDiagnosticsDir: URL {
+        appSupportDir.appendingPathComponent("diagnostics/model-downloads", isDirectory: true)
+    }
+
     static var modelDeliveryStateFile: URL {
         modelDownloadRootDir.appendingPathComponent("ios_model_delivery_state.json", isDirectory: false)
     }
 
-    /// Lightweight in-flight download records for relaunch recovery (Phase 2). Lists downloads
-    /// that were interrupted by an app kill so the coordinator can reattach their background
-    /// URLSession (by identifier) and restore UI state on next launch.
+    /// Retired schema-v1 location, read only by the one-time migration.
     static var iosInFlightDownloadsFile: URL {
         modelDownloadRootDir.appendingPathComponent("ios_inflight_downloads.json", isDirectory: false)
     }

--- a/Sources/iOSSupport/Services/IOSModelDeliverySupport.swift
+++ b/Sources/iOSSupport/Services/IOSModelDeliverySupport.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 import QwenVoiceCore
 
@@ -232,79 +231,6 @@ enum IOSModelDeliverySupport {
         }
         try validateArtifactURL(url: url, configuration: configuration, label: "artifact")
         return url
-    }
-
-    static func verifyDownloadedModel(
-        descriptor: ModelDescriptor,
-        entry: IOSModelCatalogEntry,
-        stagedRoot: URL,
-        fileManager: FileManager = .default
-    ) throws {
-        let expectedPaths = Set(entry.files.map(\.relativePath))
-        let requiredPaths = Set(descriptor.requiredRelativePaths)
-        let missingRequired = requiredPaths.filter { relativePath in
-            !fileManager.fileExists(atPath: stagedRoot.appendingPathComponent(relativePath).path)
-        }
-        guard missingRequired.isEmpty else {
-            throw IOSModelDeliveryError.missingRequiredFiles(missingRequired.sorted())
-        }
-
-        for file in entry.files {
-            let fileURL = stagedRoot.appendingPathComponent(file.relativePath)
-            guard fileManager.fileExists(atPath: fileURL.path) else {
-                throw IOSModelDeliveryError.missingRequiredFiles([file.relativePath])
-            }
-            let digest = try sha256Hex(for: fileURL)
-            guard digest == file.sha256.lowercased() else {
-                throw IOSModelDeliveryError.fileHashMismatch(relativePath: file.relativePath)
-            }
-        }
-
-        if let enumerator = fileManager.enumerator(
-            at: stagedRoot,
-            includingPropertiesForKeys: [.isRegularFileKey],
-            options: [.skipsHiddenFiles]
-        ) {
-            for case let fileURL as URL in enumerator {
-                let isRegularFile = (try? fileURL.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true
-                guard isRegularFile else {
-                    continue
-                }
-                let relativePath = try relativePath(for: fileURL, within: stagedRoot)
-                if !expectedPaths.contains(relativePath) {
-                    throw IOSModelDeliveryError.unexpectedFile(relativePath)
-                }
-            }
-        }
-    }
-
-    private static func relativePath(for fileURL: URL, within rootURL: URL) throws -> String {
-        let normalizedRoot = rootURL.resolvingSymlinksInPath().standardizedFileURL
-        let normalizedFile = fileURL.resolvingSymlinksInPath().standardizedFileURL
-        let rootComponents = normalizedRoot.pathComponents
-        let fileComponents = normalizedFile.pathComponents
-
-        guard fileComponents.starts(with: rootComponents), fileComponents.count > rootComponents.count else {
-            throw IOSModelDeliveryError.unexpectedFile(normalizedFile.path)
-        }
-
-        return fileComponents.dropFirst(rootComponents.count).joined(separator: "/")
-    }
-
-    static func sha256Hex(for fileURL: URL) throws -> String {
-        let handle = try FileHandle(forReadingFrom: fileURL)
-        defer { try? handle.close() }
-
-        var hasher = SHA256()
-        while true {
-            let chunk = try handle.read(upToCount: 1_048_576) ?? Data()
-            if chunk.isEmpty {
-                break
-            }
-            hasher.update(data: chunk)
-        }
-        let digest = hasher.finalize()
-        return digest.map { String(format: "%02x", $0) }.joined()
     }
 
     static func ensureSufficientDiskSpace(

--- a/Tests/VocelloCoreTests/ModelDownloadLifecycleTests.swift
+++ b/Tests/VocelloCoreTests/ModelDownloadLifecycleTests.swift
@@ -1,0 +1,393 @@
+import Foundation
+@testable import QwenVoiceCore
+import XCTest
+
+final class ModelDownloadLifecycleTests: XCTestCase {
+    private func identity(
+        request: String = "request-a",
+        model: String = "model-a",
+        artifact: String = "v1",
+        path: String = "weights/model.safetensors"
+    ) -> ModelDownloadTaskIdentity {
+        ModelDownloadTaskIdentity(
+            logicalRequestID: request,
+            modelID: model,
+            artifactVersion: artifact,
+            relativePath: path,
+            expectedSize: 42,
+            expectedSHA256: String(repeating: "a", count: 64)
+        )
+    }
+
+    func testTaskIdentityRoundTripsWithoutURLOrFilesystemPath() throws {
+        let original = identity()
+        let encoded = try XCTUnwrap(original.encodedTaskDescription)
+        let decoded = try XCTUnwrap(ModelDownloadTaskIdentity.decode(taskDescription: encoded))
+
+        XCTAssertEqual(decoded, original)
+        XCTAssertFalse(encoded.contains("https"))
+        XCTAssertFalse(encoded.contains("/Users/"))
+    }
+
+    func testExistingTaskIsAdoptedWithNoDuplicateCreation() {
+        let expected = identity()
+        let plan = ModelDownloadTaskReconciler.plan(
+            expected: [expected],
+            existing: [ModelDownloadExistingTask(taskID: 7, identity: expected)]
+        )
+
+        XCTAssertEqual(plan.adoptedTaskByRelativePath, [expected.relativePath: 7])
+        XCTAssertTrue(plan.cancelledTaskIDs.isEmpty)
+        XCTAssertTrue(plan.missingRelativePaths.isEmpty)
+    }
+
+    func testUnknownStaleAndDuplicateTasksAreCancelled() {
+        let expected = identity()
+        let stale = identity(artifact: "v0")
+        let plan = ModelDownloadTaskReconciler.plan(
+            expected: [expected],
+            existing: [
+                ModelDownloadExistingTask(taskID: 4, identity: nil),
+                ModelDownloadExistingTask(taskID: 3, identity: stale),
+                ModelDownloadExistingTask(taskID: 2, identity: expected),
+                ModelDownloadExistingTask(taskID: 8, identity: expected),
+            ]
+        )
+
+        XCTAssertEqual(plan.adoptedTaskByRelativePath, [expected.relativePath: 2])
+        XCTAssertEqual(plan.cancelledTaskIDs, [3, 4, 8])
+        XCTAssertTrue(plan.missingRelativePaths.isEmpty)
+    }
+
+    func testMissingTaskIsCreatedOnlyForMissingIdentity() {
+        let first = identity(path: "a.safetensors")
+        let second = identity(path: "b.safetensors")
+        let plan = ModelDownloadTaskReconciler.plan(
+            expected: [first, second],
+            existing: [ModelDownloadExistingTask(taskID: 1, identity: first)]
+        )
+        XCTAssertEqual(plan.missingRelativePaths, ["b.safetensors"])
+    }
+
+    func testProgressNeverRegressesAcrossRelaunchOrRetry() {
+        XCTAssertEqual(
+            ModelDownloadProgressReconciler.visibleBytes(current: 20, persisted: 40, total: 100),
+            40
+        )
+        XCTAssertEqual(
+            ModelDownloadProgressReconciler.visibleBytes(current: 70, persisted: 40, total: 100),
+            70
+        )
+        XCTAssertEqual(
+            ModelDownloadProgressReconciler.visibleBytes(current: 120, persisted: 40, total: 100),
+            100
+        )
+    }
+
+    func testRetryPolicySeparatesTransientPermanentTLSDiskAndIntegrity() {
+        let transient = NSError(domain: NSURLErrorDomain, code: NSURLErrorNetworkConnectionLost)
+        let tls = NSError(domain: NSURLErrorDomain, code: NSURLErrorServerCertificateUntrusted)
+        let disk = NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotWriteToFile)
+
+        guard case .retry = ModelDownloadRetryPolicy.disposition(
+            error: transient,
+            retryNumber: 1,
+            integrityRetryAlreadyUsed: false
+        ) else { return XCTFail("connection loss must retry") }
+        XCTAssertEqual(
+            ModelDownloadRetryPolicy.disposition(error: tls, retryNumber: 1, integrityRetryAlreadyUsed: false),
+            .fail
+        )
+        XCTAssertEqual(
+            ModelDownloadRetryPolicy.disposition(error: disk, retryNumber: 1, integrityRetryAlreadyUsed: false),
+            .fail
+        )
+
+        let integrity = HuggingFaceDownloader.DownloadError.integrityCheckFailed(
+            path: "weights",
+            reason: "fixture"
+        )
+        guard case .retryClean = ModelDownloadRetryPolicy.disposition(
+            error: integrity,
+            retryNumber: 1,
+            integrityRetryAlreadyUsed: false
+        ) else { return XCTFail("first integrity mismatch must retry clean") }
+        XCTAssertEqual(
+            ModelDownloadRetryPolicy.disposition(
+                error: integrity,
+                retryNumber: 2,
+                integrityRetryAlreadyUsed: true
+            ),
+            .fail
+        )
+    }
+
+    func testHTTPRetryAfterIsCappedAndPermanent4xxFails() {
+        let throttled = HuggingFaceDownloader.DownloadError.httpError(
+            statusCode: 429,
+            path: "weights",
+            retryAfterSeconds: 900
+        )
+        XCTAssertEqual(
+            ModelDownloadRetryPolicy.disposition(
+                error: throttled,
+                retryNumber: 1,
+                integrityRetryAlreadyUsed: false
+            ),
+            .retry(afterSeconds: 300)
+        )
+        XCTAssertEqual(
+            ModelDownloadRetryPolicy.disposition(
+                error: HuggingFaceDownloader.DownloadError.httpError(statusCode: 404, path: "weights"),
+                retryNumber: 1,
+                integrityRetryAlreadyUsed: false
+            ),
+            .fail
+        )
+        for status in [408, 500, 503] {
+            let error = HuggingFaceDownloader.DownloadError.httpError(
+                statusCode: status,
+                path: "weights"
+            )
+            guard case .retry = ModelDownloadRetryPolicy.disposition(
+                error: error,
+                retryNumber: 3,
+                integrityRetryAlreadyUsed: false
+            ) else { return XCTFail("HTTP \(status) must retry through attempt three") }
+            XCTAssertEqual(
+                ModelDownloadRetryPolicy.disposition(
+                    error: error,
+                    retryNumber: 4,
+                    integrityRetryAlreadyUsed: false
+                ),
+                .fail
+            )
+        }
+        XCTAssertEqual(
+            ModelDownloadRetryPolicy.disposition(
+                error: CancellationError(),
+                retryNumber: 1,
+                integrityRetryAlreadyUsed: false
+            ),
+            .cancelled
+        )
+    }
+
+    func testBackgroundCompletionWaitsForDurablePostprocessingAndDeliversOnce() {
+        var eventsFirst = ModelDownloadBackgroundCompletionGate()
+        XCTAssertFalse(eventsFirst.markEventsFinished())
+        XCTAssertTrue(eventsFirst.markPostprocessingFinished())
+        XCTAssertFalse(eventsFirst.markPostprocessingFinished())
+        XCTAssertFalse(eventsFirst.markEventsFinished())
+
+        eventsFirst.resetForRequest()
+        XCTAssertFalse(eventsFirst.completionDelivered)
+        XCTAssertFalse(eventsFirst.markPostprocessingFinished())
+        XCTAssertTrue(eventsFirst.markEventsFinished())
+    }
+
+    func testVerifiedReceiptInvalidatesOnProcessOrMetadataChange() {
+        let receipt = VerifiedArtifactReceipt(
+            relativePath: "weights/model.safetensors",
+            artifactVersion: "v1",
+            expectedSize: 42,
+            expectedSHA256: String(repeating: "a", count: 64),
+            fileSize: 42,
+            modificationTimeNanoseconds: 100,
+            fileIdentifier: 7,
+            verificationProcessGeneration: "process-a"
+        )
+        XCTAssertTrue(receipt.matches(
+            relativePath: "weights/model.safetensors",
+            artifactVersion: "v1",
+            expectedSize: 42,
+            expectedSHA256: String(repeating: "a", count: 64),
+            fileSize: 42,
+            modificationTimeNanoseconds: 100,
+            fileIdentifier: 7,
+            processGeneration: "process-a"
+        ))
+        XCTAssertFalse(receipt.matches(
+            relativePath: "weights/model.safetensors",
+            artifactVersion: "v1",
+            expectedSize: 42,
+            expectedSHA256: String(repeating: "a", count: 64),
+            fileSize: 42,
+            modificationTimeNanoseconds: 101,
+            fileIdentifier: 7,
+            processGeneration: "process-a"
+        ))
+        XCTAssertFalse(receipt.matches(
+            relativePath: "weights/model.safetensors",
+            artifactVersion: "v1",
+            expectedSize: 42,
+            expectedSHA256: String(repeating: "a", count: 64),
+            fileSize: 42,
+            modificationTimeNanoseconds: 100,
+            fileIdentifier: 7,
+            processGeneration: "process-b"
+        ))
+    }
+
+    func testRangeValidationAcceptsExactAndRejectsIgnoredOrMalformedResponses() {
+        XCTAssertTrue(HuggingFaceDownloader.contentRange("bytes 100-199/1000", startsAt: 100))
+        XCTAssertTrue(HuggingFaceDownloader.contentRange("bytes 100-199/1000", matchesStart: 100, end: 199))
+        XCTAssertFalse(HuggingFaceDownloader.contentRange(nil, startsAt: 100))
+        XCTAssertFalse(HuggingFaceDownloader.contentRange("bytes 0-999/1000", startsAt: 100))
+        XCTAssertFalse(HuggingFaceDownloader.contentRange("bytes 100-*/1000", startsAt: 100))
+        XCTAssertFalse(HuggingFaceDownloader.contentRange("bytes 100-200/1000", matchesStart: 100, end: 199))
+    }
+
+    func testLedgerRoundTripAndAtomicReplacement() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = IOSModelDownloadLedgerStore(fileURL: root.appendingPathComponent("ledger.json"))
+        let request = IOSModelDownloadLedger.Request(
+            logicalRequestID: "logical",
+            modelID: "model",
+            artifactVersion: "v1",
+            repo: "repo",
+            revision: "revision",
+            targetFolder: "model-folder",
+            expectedFiles: ["weights/model.safetensors"],
+            verifiedFiles: [],
+            retryCount: 0,
+            receivedBytes: 12,
+            totalBytes: 42,
+            status: .downloading
+        )
+        try store.save(IOSModelDownloadLedger(requests: [request]))
+        XCTAssertEqual(try store.load().requests, [request])
+
+        var updated = request
+        updated.receivedBytes = 20
+        try store.save(IOSModelDownloadLedger(requests: [updated]))
+        XCTAssertEqual(try store.load().requests.first?.receivedBytes, 20)
+    }
+
+    func testCorruptAndUnsupportedLedgerFailClosed() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let url = root.appendingPathComponent("ledger.json")
+        let store = IOSModelDownloadLedgerStore(fileURL: url)
+
+        try Data("not-json".utf8).write(to: url)
+        XCTAssertThrowsError(try store.load())
+
+        try Data(#"{"schemaVersion":99,"requests":[]}"#.utf8).write(to: url)
+        XCTAssertThrowsError(try store.load()) { error in
+            XCTAssertEqual(error as? IOSModelDownloadLedgerError, .unsupportedSchema(99))
+        }
+    }
+
+    func testLedgerRejectsAbsoluteTraversalAndDuplicateModelRequests() {
+        func request(id: String, path: String) -> IOSModelDownloadLedger.Request {
+            IOSModelDownloadLedger.Request(
+                logicalRequestID: id,
+                modelID: "model",
+                artifactVersion: "v1",
+                repo: "repo",
+                revision: "revision",
+                targetFolder: "model-folder",
+                expectedFiles: [path],
+                verifiedFiles: [],
+                retryCount: 0,
+                receivedBytes: 0,
+                totalBytes: 42,
+                status: .queued
+            )
+        }
+
+        XCTAssertThrowsError(try IOSModelDownloadLedger(requests: [request(id: "a", path: "/tmp/file")]).validated())
+        XCTAssertThrowsError(try IOSModelDownloadLedger(requests: [request(id: "a", path: "../file")]).validated())
+        XCTAssertThrowsError(try IOSModelDownloadLedger(requests: [
+            request(id: "a", path: "one"),
+            request(id: "b", path: "two"),
+        ]).validated())
+    }
+
+    func testDiagnosticsAreBoundedAndRedactURLsAndAbsolutePaths() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = ModelDownloadDiagnosticsStore(directory: root)
+        for index in 0..<25 {
+            store.recordFailure(
+                classification: "network-\(index)",
+                message: "failed at https://example.invalid/private from /Users/example/private/file"
+            )
+        }
+        let files = try FileManager.default.contentsOfDirectory(at: root, includingPropertiesForKeys: nil)
+        XCTAssertLessThanOrEqual(files.count, 20)
+        let payload = try files.map { try String(contentsOf: $0, encoding: .utf8) }.joined()
+        XCTAssertFalse(payload.contains("example.invalid"))
+        XCTAssertFalse(payload.contains("/Users/example"))
+    }
+
+    func testDiagnosticsSummarizePhaseTimingWireBytesAndFinalIntegrity() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = ModelDownloadDiagnosticsStore(directory: root)
+
+        func progress(_ phase: HuggingFaceDownloader.DownloadPhase) -> HuggingFaceDownloader.RepositoryProgress {
+            HuggingFaceDownloader.RepositoryProgress(
+                downloadedBytes: phase == .downloading ? 20 : 100,
+                totalBytes: 100,
+                completedFiles: phase == .downloading ? 0 : 1,
+                totalFiles: 1,
+                bytesPerSecond: phase == .downloading ? 10 : nil,
+                isStalled: false,
+                estimatedSecondsRemaining: phase == .downloading ? 8 : nil,
+                retryCount: 1,
+                statusMessage: nil,
+                phase: phase
+            )
+        }
+
+        store.record(progress: progress(.downloading))
+        store.record(metrics: HuggingFaceDownloader.TransferMetrics(
+            relativePath: "weights/model.safetensors",
+            protocolName: "h3",
+            redirectCount: 1,
+            reusedConnection: true,
+            cellular: false,
+            constrained: false,
+            expensive: false,
+            transferredBytes: 120,
+            durationSeconds: 2
+        ))
+        store.record(metrics: HuggingFaceDownloader.TransferMetrics(
+            relativePath: nil,
+            protocolName: "h3",
+            redirectCount: 0,
+            reusedConnection: true,
+            cellular: false,
+            constrained: false,
+            expensive: false,
+            transferredBytes: 20,
+            durationSeconds: 0.1
+        ))
+        store.record(progress: progress(.verifying))
+        store.record(progress: progress(.installing))
+        store.recordSuccess(expectedBytes: 100)
+
+        let files = try FileManager.default.contentsOfDirectory(at: root, includingPropertiesForKeys: nil)
+        let objects = try files.compactMap { file -> [String: Any]? in
+            let data = try Data(contentsOf: file)
+            return try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        }
+        let success = try XCTUnwrap(objects.first { $0["kind"] as? String == "success" })
+        XCTAssertEqual(success["wireBytes"] as? Int, 120)
+        XCTAssertEqual(success["controlBytes"] as? Int, 20)
+        XCTAssertEqual(success["expectedBytes"] as? Int, 100)
+        XCTAssertEqual(success["duplicateBytes"] as? Int, 20)
+        XCTAssertEqual(success["retryCount"] as? Int, 1)
+        XCTAssertEqual(success["protocols"] as? [String], ["h3"])
+        XCTAssertEqual(success["finalIntegrity"] as? Bool, true)
+        XCTAssertNotNil(success["thermalState"] as? String)
+    }
+}

--- a/Tests/VocelloiOSUITests/VocelloiOSModelDownloadUITests.swift
+++ b/Tests/VocelloiOSUITests/VocelloiOSModelDownloadUITests.swift
@@ -1,0 +1,80 @@
+import Foundation
+@preconcurrency import XCTest
+
+/// Explicit, opt-in physical-device proof for background model delivery. This method is selected
+/// directly by `scripts/ui_test.sh ios model-download`; smoke, benchmarks, CI, and release never
+/// execute it. All actions use genuine visible Settings controls.
+@MainActor
+final class VocelloiOSModelDownloadUITests: VocelloiOSUITestCase {
+    private let isolatedSupportRoot = "model-download-acceptance"
+    private let modelID = "pro_custom"
+
+    func testIsolatedBackgroundDownloadAdoptionAndCleanup() {
+        let environment = ["QVOICE_APP_SUPPORT_DIR": isolatedSupportRoot]
+        beginSession(additionalEnvironment: environment)
+        defer { endSession() }
+
+        select(tab: .settings)
+        removePriorIsolatedModelIfNeeded()
+
+        let install = element("iosModelDownload_\(modelID)")
+        XCTAssertTrue(VocelloUIWait.exists(install, timeout: 60))
+        XCTAssertTrue(VocelloUIPrimaryAction.perform(on: install, timeout: 20))
+
+        let progress = element("iosModelProgress_\(modelID)")
+        XCTAssertTrue(VocelloUIWait.exists(progress, timeout: 120))
+        XCTAssertTrue(VocelloUIWait.condition("model download to make measurable progress", timeout: 600) {
+            self.progressFraction(progress) > 0
+        })
+        let beforeRelaunch = progressFraction(progress)
+        VocelloUIScreenshot.attach(app, named: "ios-model-download-before-relaunch")
+
+        XCUIDevice.shared.press(.home)
+        XCTAssertTrue(VocelloUIWait.condition("Vocello to enter the background", timeout: 30) {
+            self.app.state == .runningBackground || self.app.state == .runningBackgroundSuspended
+        })
+        app.terminate()
+        launchApp(additionalEnvironment: environment)
+        select(tab: .settings)
+
+        let installed = element("iosModelDelete_\(modelID)")
+        let restoredProgress = element("iosModelProgress_\(modelID)")
+        XCTAssertTrue(VocelloUIWait.condition("adopted download progress or completed install", timeout: 120) {
+            if installed.exists { return true }
+            guard restoredProgress.exists else { return false }
+            return self.progressFraction(restoredProgress) >= beforeRelaunch
+        })
+        XCTAssertTrue(VocelloUIWait.exists(installed, timeout: 3_600))
+        VocelloUIScreenshot.attach(app, named: "ios-model-download-installed")
+
+        XCTAssertTrue(VocelloUIPrimaryAction.perform(on: installed, timeout: 20))
+        let confirmDelete = element("deleteModelSheet_confirm")
+        XCTAssertTrue(VocelloUIWait.exists(confirmDelete, timeout: 20))
+        XCTAssertTrue(VocelloUIPrimaryAction.perform(on: confirmDelete, timeout: 20))
+        XCTAssertTrue(VocelloUIWait.exists(element("iosModelDownload_\(modelID)"), timeout: 120))
+        VocelloUIScreenshot.attach(app, named: "ios-model-download-isolated-cleanup")
+    }
+
+    private func removePriorIsolatedModelIfNeeded() {
+        let installed = element("iosModelDelete_\(modelID)")
+        guard installed.exists else { return }
+        XCTAssertTrue(VocelloUIPrimaryAction.perform(on: installed, timeout: 20))
+        let confirmDelete = element("deleteModelSheet_confirm")
+        XCTAssertTrue(VocelloUIWait.exists(confirmDelete, timeout: 20))
+        XCTAssertTrue(VocelloUIPrimaryAction.perform(on: confirmDelete, timeout: 20))
+        XCTAssertTrue(VocelloUIWait.exists(element("iosModelDownload_\(modelID)"), timeout: 120))
+    }
+
+    private func progressFraction(_ element: XCUIElement) -> Double {
+        guard element.exists else { return 0 }
+        if let number = element.value as? NSNumber {
+            return number.doubleValue
+        }
+        guard let value = element.value as? String else { return 0 }
+        let numeric = value
+            .replacingOccurrences(of: "%", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let parsed = Double(numeric) else { return 0 }
+        return value.contains("%") ? parsed / 100 : parsed
+    }
+}

--- a/Tests/VocelloiOSUITests/VocelloiOSUITestCase.swift
+++ b/Tests/VocelloiOSUITests/VocelloiOSUITestCase.swift
@@ -20,11 +20,11 @@ class VocelloiOSUITestCase: XCTestCase {
 
     var app: XCUIApplication { session.app }
 
-    func beginSession() {
+    func beginSession(additionalEnvironment: [String: String] = [:]) {
         continueAfterFailure = false
         pendingAutoplayPreferenceRestore = nil
         session = VocelloUIApplicationSession()
-        launchApp()
+        launchApp(additionalEnvironment: additionalEnvironment)
     }
 
     func endSession() {

--- a/config/documentation-contract.json
+++ b/config/documentation-contract.json
@@ -28,7 +28,7 @@
       "authority": "derived from source, project.yml, scripts, and machine-readable contracts",
       "audience": "maintainers",
       "reviewTriggers": ["target or scheme changes", "runtime topology", "telemetry schema", "test workflow"],
-      "paths": ["docs/ARCHITECTURE.md", "docs/development-progress.md", "docs/project-map.html", "docs/qwen_tone.md", "docs/reference/*.md", "Sources/Resources/voice-previews/README.md"]
+      "paths": ["docs/ARCHITECTURE.md", "docs/decisions/*.md", "docs/development-progress.md", "docs/project-map.html", "docs/qwen_tone.md", "docs/reference/*.md", "Sources/Resources/voice-previews/README.md"]
     },
     {
       "id": "benchmarking",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,7 +109,7 @@ graph.)
 | `VocelloCoreTests` | bundle.unit-test | macOS | `VocelloCoreTests` | `com.qwenvoice.core.tests` | Core semantics, typed telemetry compatibility, and atomic/readable output contracts. |
 | `VocelloEngineIntegrationTests` | bundle.unit-test | macOS | `VocelloEngineIntegrationTests` | `com.qwenvoice.engine-integration.tests` | Injectable XPC client/transport lifecycle and correlation contracts; never launches frontend UI. |
 | `VocelloMacUITests` | bundle.ui-testing | macOS | `VocelloMacUITests` | `com.qwenvoice.app.uitests` | Explicit native-app smoke and benchmark XCUITest lanes. |
-| `VocelloiOSUITests` | bundle.ui-testing | iOS | `VocelloiOSUITests` | `com.patricedery.vocello.uitests` | Explicit paired-physical-iPhone smoke and benchmark XCUITest lanes; never Simulator. |
+| `VocelloiOSUITests` | bundle.ui-testing | iOS | `VocelloiOSUITests` | `com.patricedery.vocello.uitests` | Explicit paired-physical-iPhone smoke/benchmark lanes plus the isolated opt-in model-delivery lifecycle proof; never Simulator. |
 
 ### Testing lanes (see [`docs/reference/testing-runbook.md`](reference/testing-runbook.md))
 
@@ -118,6 +118,7 @@ graph.)
 | **Deterministic verification** | Core + XPC integration + `Qwen3RuntimeTests` + app build | Project-input checks + physical-device SDK compile | Required by ordinary CI; sufficient for commit, push, pull request, and merge |
 | **Platform runtime gate** | `macos_test.sh gate` | `ios_device.sh gate` | Deterministic/device diagnostics; independent of XCUITest |
 | **UI regression** | `ui_test.sh macos smoke\|benchmark` XCUITest | `ui_test.sh ios smoke\|benchmark` XCUITest on a paired physical iPhone | Explicit frontend QA only; never required for publishing or packaging |
+| **Model-delivery lifecycle** | Isolated CLI install | `ui_test.sh ios model-download` on a paired physical iPhone | Opt-in diagnostic only; never part of smoke, benchmark, CI, or release |
 | **Headless engine** | `vocello bench`, `lang-bench` | `bench`, `lang-bench` device diagnostics | Explicit performance/release QA |
 | **UI evidence** | Named XCTest attachments from the native app | Named XCTest attachments from the physical iPhone | Independent explicit-acceptance artifacts |
 
@@ -679,12 +680,19 @@ served at `bundle://vocello/ios/catalog/v1/models.json` via
 `Info.plist … QVoiceModelCatalogURL`) and `voice-previews/` (24 kHz mono Int16
 WAVs named by speaker id, played by `IOSVoicePreviewPlayer`).
 
-**Download** (`Sources/QwenVoiceCore/HuggingFaceDownloader.swift`, SwiftHuggingFace):
-list files at the pinned revision → stage under `.qwenvoice-downloads/` → verify
-each file's size + **CryptoKit SHA-256** → atomic move → persist a
-`ModelAssetIntegrityManifest.json`. Downloads come from Hugging Face over HTTPS;
-**no cloud inference**. iOS catalog validation: `scripts/check_ios_catalog.sh`.
-Headless install: `vocello models install <id>` (CLI) or the app Settings UI.
+**Download** (`Sources/QwenVoiceCore/HuggingFaceDownloader.swift`): list files at the pinned
+revision, stage, verify exact size plus **CryptoKit SHA-256**, atomically swap the directory, and
+persist `ModelAssetIntegrityManifest.json`. A verified-artifact receipt avoids a second full-file
+hash in the same process; a relaunch rehashes staged data once before reuse. macOS and CLI own
+terminal foreground-session teardown. iPhone owns one bundle-aware background session for the app
+lifetime, an atomic schema-v2 ledger, exact task adoption, durable delegate staging, and UIKit
+completion deferral until postprocessing is durable. Explicit Cancel discards staging; Retry keeps
+verified files. Typed transient retries cover connection loss and HTTP 408/429/5xx, while permanent
+TLS/filesystem/configuration errors fail without retry. Compact local diagnostics are capped at 20
+records and 5 MB and contain no raw URLs or absolute paths. Downloads come from Hugging Face over
+HTTPS; **no cloud inference**. iOS catalog validation: `scripts/check_ios_catalog.sh`. Headless
+install: `vocello models install <id>` (CLI) or the app Settings UI. Full lifecycle and storage
+contract: [`reference/model-delivery.md`](reference/model-delivery.md).
 
 **macOS test fixtures:** UI smoke and bench lanes with `QWENVOICE_DEBUG=1` read
 `QwenVoice-Debug/models`; the test driver symlinks that path to the canonical

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -36,6 +36,7 @@ Review when: target or scheme changes; runtime topology; telemetry schema; test 
 
 - [`Sources/Resources/voice-previews/README.md`](../Sources/Resources/voice-previews/README.md)
 - [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md)
+- [`docs/decisions/model-delivery-background-assets.md`](../docs/decisions/model-delivery-background-assets.md)
 - [`docs/development-progress.md`](../docs/development-progress.md)
 - [`docs/project-map.html`](../docs/project-map.html)
 - [`docs/qwen_tone.md`](../docs/qwen_tone.md)
@@ -56,6 +57,7 @@ Review when: target or scheme changes; runtime topology; telemetry schema; test 
 - [`docs/reference/mimi-codec-guide.md`](../docs/reference/mimi-codec-guide.md)
 - [`docs/reference/mlx-audio-swift-patching.md`](../docs/reference/mlx-audio-swift-patching.md)
 - [`docs/reference/mlx-guide.md`](../docs/reference/mlx-guide.md)
+- [`docs/reference/model-delivery.md`](../docs/reference/model-delivery.md)
 - [`docs/reference/privacy-storage.md`](../docs/reference/privacy-storage.md)
 - [`docs/reference/prosody-qa-research.md`](../docs/reference/prosody-qa-research.md)
 - [`docs/reference/qwen3-tts-guide.md`](../docs/reference/qwen3-tts-guide.md)

--- a/docs/decisions/model-delivery-background-assets.md
+++ b/docs/decisions/model-delivery-background-assets.md
@@ -1,0 +1,31 @@
+# ADR: retain background URLSession model delivery
+
+- Status: accepted
+- Date: 2026-07-14
+- Decision owner: iOS and backend
+
+## Context
+
+Vocello downloads multi-gigabyte, revision-pinned Qwen model packages from Hugging Face. iPhone must
+survive backgrounding and process relaunch while preserving SHA-256 verification, atomic install,
+App Group storage, user-controlled deletion, and the repository's no-bundled-weights posture.
+
+## Options considered
+
+| Option | Advantages | Costs and constraints |
+| --- | --- | --- |
+| Repaired background `URLSession` | Works with current Hugging Face hosting and catalog; supports App Store/TestFlight; preserves current App Group, integrity, retry, cancellation, and cleanup contracts | The app owns durable task reconciliation, ledger migration, and background completion |
+| Unmanaged Background Assets with existing hosting | System-managed scheduling and storage may improve large-download lifecycle | Requires a Background Assets extension and a second delivery lifecycle; entitlement, App Store behavior, host behavior, update cadence, migration, and deletion semantics require separate validation |
+| Apple-hosted on-demand Background Assets | Strong system integration and Apple-hosted delivery | Requires redistribution of model payloads, hosted-asset operations and cost, licensing confirmation for every model, App Store asset cadence, and migration away from direct pinned Hugging Face revisions |
+
+## Decision
+
+Use the repaired single background `URLSession` route for production. Do not add a Background Assets
+target, extension, entitlement, hosted payload, or parallel downloader in this change.
+
+## Revisit criteria
+
+Reconsider only through a separate product decision after confirming App Store/TestFlight support,
+Hugging Face and model redistribution rights, asset-hosting cost, update cadence, extension and App
+Group migration, deletion/storage behavior, and a measured lifecycle or transfer advantage over the
+current implementation.

--- a/docs/development-progress.md
+++ b/docs/development-progress.md
@@ -16,6 +16,16 @@
   transcript-backed Voice Design reference; a Custom Voice output is not an acceptable substitute.
 - No preview/browser-mirror route, invisible accessibility state marker, alternate UI driver,
   coordinate bridge, or hidden UI bootstrap belongs in the shippable app.
+- Model delivery uses one shared integrity/atomic-install implementation. iPhone now owns one
+  bundle-aware app-lifetime background session plus an atomic schema-v2 request ledger, exact task
+  adoption, cancellation barriers, durable delegate staging, and bounded privacy-safe diagnostics.
+  macOS and CLI retain foreground delivery with terminal session teardown. Cancel discards staging;
+  Retry reuses verified files. The isolated `scripts/ui_test.sh ios model-download` lifecycle proof
+  is explicit QA and never joins smoke, benchmark, CI, packaging, or release gates. The 2026-07-14
+  isolated Custom Speed proofs passed on both canonical platforms: macOS verified and removed its
+  temporary 2.31 GB install, while the physical-iPhone test preserved monotonic progress across
+  backgrounding, termination, and relaunch, installed with exact wire bytes and no retry, then
+  deleted the isolated model through visible Settings. No connection or chunking default changed.
 - Benchmark evidence now uses collision-resistant run IDs, atomic run-scoped manifests, and a
   privacy-safe PASS-only registry. `benchmarks/HISTORY.md` is generated from canonical JSON records;
   raw telemetry, audio, screenshots, traces, and `.xcresult` bundles remain untracked.

--- a/docs/project-map.html
+++ b/docs/project-map.html
@@ -1694,7 +1694,7 @@ scripts/macos_test.sh test
     {
       "label":"Library",
       "title":"Saved Voices · History · Models",
-      "body":"Record or import references, optionally transcribe locally, cache prepared clone prompts, replay/export generations, and manage per-mode model packages. iOS background-session reattachment is not the same as the macOS repair affordance.",
+      "body":"Record or import references, optionally transcribe locally, cache prepared clone prompts, replay/export generations, and manage per-mode model packages. iOS uses one durable ledger and app-lifetime background session; macOS uses terminally invalidated foreground sessions.",
       "chips":[
         {"t":"PreparedVoice","c":""},
         {"t":"LocalDocumentIO","c":""},
@@ -1839,8 +1839,8 @@ scripts/macos_test.sh test
     },
     {
       "title":"Model install",
-      "steps":["Read the model contract or iOS catalog","List the pinned Hugging Face revision","Download into .qwenvoice-downloads staging","Verify required paths, sizes, and integrity metadata","Atomically move into models/ and refresh inventory"],
-      "note":"macOS exposes repair for incomplete installs. iOS reattaches background URLSession transfers and treats explicit cancel as discard."
+      "steps":["Read the model contract or iOS catalog","Reconcile the durable request ledger with existing background tasks","Download into platform-owned staging","Verify exact size and SHA-256 once per process generation","Atomically move into models/ and refresh inventory"],
+      "note":"macOS and CLI tear down foreground sessions on terminal paths. iOS uses one app-lifetime bundle-aware background session, adopts only exact task identities, defers UIKit completion until durable postprocessing, preserves verified files for Retry, and treats explicit Cancel as discard."
     },
     {
       "title":"Persistence and playback",
@@ -2134,7 +2134,7 @@ scripts/macos_test.sh test
   "storage": [
     {"title":"macOS release","root":"~/Library/Application Support/QwenVoice/","items":["models/ and .qwenvoice-downloads/","outputs/{mode}/","voices/ and prepared artifacts","history.sqlite","cache/{prepared_audio,imported_references,native_mlx,stream_sessions}/","diagnostics/ when telemetry is enabled"]},
     {"title":"macOS debug","root":"~/Library/Application Support/QwenVoice-Debug/","items":["Same logical layout as release","Model fixtures may symlink to the canonical store","Raw diagnostics remain gitignored"]},
-    {"title":"iOS App Group","root":"group.com.patricedery.vocello.shared/Vocello/","items":["Speed model packages and staging","App Group history database and outputs","Saved voices and reference material","Pullable diagnostics mirror for device gates","Increased-memory-limit entitlement required"]},
+    {"title":"iOS App Group","root":"group.com.patricedery.vocello.shared/Vocello/","items":["Speed model packages","One downloads/staging tree plus the atomic model-delivery ledger","Bounded privacy-safe model-download diagnostics","App Group history database and outputs","Saved voices and reference material","Pullable diagnostics mirror for device gates","Increased-memory-limit entitlement required"]},
     {"title":"Privacy boundary","root":"local-first runtime","items":["No cloud TTS or bundled model weights","Recording, transcription, generation, playback, and History stay local","Network use is model download, release/CI, and website delivery","Production telemetry is disabled by default"]}
   ],
   "invariants": [

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -153,7 +153,10 @@ vocello models install <id> [--verbose]    # headless download into the shared m
 Shows each model's install state, on-disk size, and (for `status`) any missing required files.
 `install` uses the same `HuggingFaceDownloader` as the macOS app — a CLI-installed model is
 immediately usable in the app, and vice versa. Variant-scoped ids (`pro_custom_speed`, `…_quality`)
-are what `generate --variant` selects.
+are what `generate --variant` selects. Foreground sessions are invalidated on every terminal path;
+transient retries preserve valid staging, explicit cancellation discards it, and compact local
+metrics are bounded under `diagnostics/model-downloads/`. See
+[`model-delivery.md`](model-delivery.md).
 
 For test/bench lanes with `QWENVOICE_DEBUG=1`, weights live under `QwenVoice-Debug/`; the test
 driver symlinks `QwenVoice-Debug/models` → the canonical store (see

--- a/docs/reference/ios-app-guide.md
+++ b/docs/reference/ios-app-guide.md
@@ -145,14 +145,23 @@ comes from `qwenvoice_ios_model_catalog.json`.
 | State | Visible control | What it means |
 |---|---|---|
 | Not installed | `iosModelDownload_<id>` ("Install") | Default; nothing staged |
-| Downloading | `iosModelCancel_<id>` ("Cancel") + progress bar | Active download |
-| Paused | `iosModelResume_<id>` ("Resume") | Reached by the runtime when a download stalls; not a user-facing pause button |
-| Failed/incomplete | `iosModelRetry_<id>` ("Retry") / `iosModelRepair_<id>` ("Repair") | Error or interrupted |
+| Queued / waiting / downloading / retrying | `iosModelCancel_<id>` ("Cancel") plus phase/progress detail | Durable request awaiting its turn or connectivity, actively transferring, or applying a typed retry |
+| Verifying / installing / cancelling | Progress indicator | Hash/receipt validation, atomic install, or the cancellation barrier is in progress |
+| Failed/incomplete | `iosModelRetry_<id>` ("Retry") / `iosModelRepair_<id>` ("Repair") | Retry preserves verified files; Repair revalidates an incomplete installed package |
 | Installed | `iosModelDelete_<id>` (trash) | Ready to generate |
 
-Cancel opens a confirmation dialog: `iosModelCancelDownloadConfirmButton` (cancel, deletes data).
-There is no user-facing pause button; paused state is reached by the runtime. Download progress
-`iosModelProgress_<id>` (downloading / resuming / paused states).
+Cancel opens a confirmation dialog: `iosModelCancelDownloadConfirmButton` (cancel, deletes staged
+data). There is no paused state or Resume control. Waiting for connectivity comes from URLSession;
+an active task separately reports no progress after 20 seconds. `iosModelProgress_<id>` exposes
+download/retry progress, while the visible detail reports bytes, smoothed speed, ETA, retry reason,
+and verified-file reuse.
+
+One bundle-aware background URLSession lives for the app lifetime. On launch, the atomic v2 ledger
+and current catalog adopt exactly matching tasks, cancel stale/unknown/duplicate tasks, and create
+only missing tasks. Progress remains monotonic through backgrounding, process relaunch, and retry.
+Delegate files move into durable App Group staging before the callback returns, and UIKit's
+background completion waits for durable install/failure postprocessing. Full contract:
+[`model-delivery.md`](model-delivery.md).
 
 ### The Studio gates generation on the installed model
 
@@ -174,8 +183,9 @@ Generate rather than Install. Destructive install/cancel/delete actions are outs
 - **Install:** Settings → `iosModelDownload_<id>`.tap() → (wait for complete → `iosModelDelete_<id>`).
 - **Cancel:** `iosModelDownload_<id>`.tap() → `iosModelCancel_<id>`.tap() →
   `waitForConfirmationButton("iosModelCancelDownloadConfirmButton")` → tap it → Install reappears.
-- **Pause/resume/cancel:** The runtime may pause a download (showing `iosModelResume_<id>`). Tap
-  Resume, then tap Cancel and confirm with `iosModelCancelDownloadConfirmButton`.
+- **Retry/cancel:** Retry a failed request with `iosModelRetry_<id>` to reuse verified files. Cancel
+  an active request with `iosModelCancel_<id>`, then confirm `iosModelCancelDownloadConfirmButton`;
+  staging is removed only after URLSession cancellation callbacks and tasks are terminal.
 - **Delete:** `iosModelDelete_<id>`.tap() → `deleteModelSheet_confirm`.tap() → Install reappears.
 
 ---
@@ -252,8 +262,9 @@ Gotchas:
 2. Dismiss the keyboard before Generate when it obscures the button.
 3. Wait for cold model loading rather than repeating a click.
 4. Attach named screenshots at important semantic states and failures.
-5. Recording and destructive model lifecycle actions require attended setup and are outside the
-   smoke and benchmark lanes.
+5. Recording and destructive model lifecycle actions are outside smoke and benchmark. The isolated
+   physical-device model-delivery proof is selected explicitly with
+   `scripts/ui_test.sh ios model-download` and cleans up through visible Settings controls.
 
 ---
 

--- a/docs/reference/ios-device-testing.md
+++ b/docs/reference/ios-device-testing.md
@@ -26,6 +26,8 @@ also checks signing plus the existing app-build and dSYM readiness. `device-stat
 reachability as its only blocker. The XCUITest runner independently rejects a phone that
 CoreDevice reports as locked before invoking `xcodebuild`. Install or repair iOS models through the
 visible Settings → Model Downloads UI; neither device scripts nor normal UI tests install them.
+The sole exception is the separately selected `scripts/ui_test.sh ios model-download` lifecycle
+diagnostic, which uses an isolated app-support root and is never part of smoke or benchmark.
 
 ## Explicit XCUITest lanes
 
@@ -34,6 +36,9 @@ scripts/ui_test.sh ios smoke
 scripts/ui_test.sh ios benchmark
 # Filtered benchmark example:
 scripts/ui_test.sh ios benchmark --modes custom --lengths short --warm 1 --label "focused"
+
+# Explicit isolated background-transfer lifecycle proof, not a normal UI lane:
+scripts/ui_test.sh ios model-download
 ```
 
 The iPhone matrix keeps the shared short/medium/long ordering, but its long script is exactly the
@@ -44,6 +49,7 @@ the iPhone lane never bypasses its user-facing script limit.
 | --- | --- |
 | Smoke | Exact app launch, Studio mode and tab navigation, visible model and clone-reference readiness, one real Custom generation, completed player, and History |
 | Benchmark | Ordered, configurable Studio matrix with pulled telemetry, readable audio, audio QC, thermal and timing evidence; the default is exactly 29 takes |
+| Model delivery | One isolated Custom Speed install; background/process relaunch adoption, monotonic progress, integrity, and visible cleanup |
 
 Every lane uses the paired physical-device destination. Tests use stable accessibility identifiers,
 condition-based waits, XCTest activities, screenshots, and failure attachments. Coordinate tables,

--- a/docs/reference/macos-app-guide.md
+++ b/docs/reference/macos-app-guide.md
@@ -128,6 +128,12 @@ macOS has **both Speed (4-bit) and Quality (8-bit)** variants (unlike iOS Speed-
 Settings → Voice Models shows per-mode packages. Download via `settings_download_<id>`;
 cancel via `settings_cancel_<id>`; repair via `settings_repair_<id>`.
 
+The shared foreground downloader distinguishes queued, waiting for connectivity, downloading,
+retrying, verifying, installing, and cancelling. Active transfer shows bytes, smoothed speed, ETA,
+and a separate 20-second no-progress indication. Transient failures retry up to three times; Retry
+preserves verified files, while explicit Cancel discards that package's staged data. Every terminal
+foreground path invalidates its URLSession. Details: [`model-delivery.md`](model-delivery.md).
+
 The Studio's Generate CTA (`textInput_generateButton`) appears only when the mode's model
 is installed — otherwise the app prompts to download from Settings.
 

--- a/docs/reference/model-delivery.md
+++ b/docs/reference/model-delivery.md
@@ -1,0 +1,106 @@
+# Model delivery
+
+Vocello uses one shared native downloader, `HuggingFaceDownloader`, for pinned Hugging Face model
+artifacts. macOS and the CLI use foreground `URLSession` instances. iPhone uses one bundle-aware
+background session for the app lifetime. There is no second downloader, cloud synthesis path, or
+ordinary-CI model fetch.
+
+## Integrity and installation
+
+Every file is matched to the model contract or the bundled iOS catalog, downloaded into staging,
+checked against its exact byte count and SHA-256, and installed by an atomic directory swap. A
+newly assembled file is hashed once. A same-process verified-artifact receipt permits finalization
+without reading the complete file again; after a relaunch the staged file is hashed once before a
+new receipt is trusted. Installed models retain the existing integrity-manifest format.
+
+macOS and CLI staging remains next to the model store under `.qwenvoice-downloads/`. iPhone has one
+layout under the app-support root:
+
+```text
+downloads/
+  ios_model_delivery_state.json
+  staging/
+    delegate-files/
+    <model-id>/{files,partials,resume-data}/
+diagnostics/model-downloads/
+models/
+```
+
+The iOS ledger is atomically written, versioned, and contains only privacy-safe identifiers and
+relative paths. It records the logical request, model and artifact version, expected and verified
+files, retries, monotonic received bytes, and terminal state. A one-time migration cancels the old
+per-model sessions, waits for their cancellation callbacks, moves recoverable staging into the v2
+layout, and removes the old document only when those sessions are empty. Installed models are not
+touched.
+
+## iPhone restoration and ownership
+
+At launch, the coordinator asks the single background session for all tasks. Valid tasks whose
+encoded model/artifact/file identity exactly matches the ledger and current catalog are adopted.
+Unknown, stale, or duplicate tasks are cancelled, and only missing files receive new tasks.
+Delegate temporary files are synchronously moved into durable app-group staging before the callback
+returns. UIKit's background-session completion handler is released only after all delegate events
+and durable install/failure postprocessing finish.
+
+iPhone runs one model request at a time. macOS keeps its existing foreground concurrency. Both
+platforms keep per-file range chunking disabled by default.
+
+## States, cancellation, and retry
+
+Visible states are: queued, waiting for connectivity, downloading, retrying, verifying, installing,
+cancelling, installed, failed, deleting, and deleted. Speed and ETA are shown only during active
+transfer. A separate no-progress message appears after 20 seconds of an actively running task;
+waiting-for-connectivity comes from the URLSession delegate.
+
+Explicit **Cancel** is a discard operation. The coordinator first persists `cancelRequested`, stops
+new task registration, awaits all resume-data cancellation callbacks and terminal tasks, and only
+then removes staging. **Retry** preserves already verified files and reconstructs progress from the
+ledger, staged partials, and adopted task byte counts.
+
+Transient connection failures and HTTP 408, 429, and 5xx responses retry up to three times. A
+`Retry-After` value is honored up to five minutes. One integrity mismatch receives one clean retry.
+Cancellation, disk exhaustion, local filesystem errors, TLS trust failures, configuration errors,
+and permanent 4xx responses do not retry.
+
+## Diagnostics and acceptance
+
+Local diagnostic summaries retain at most 20 records and 5 MB. Their allowlisted fields cover
+timing, protocol, redirect/reuse and constrained/expensive-network flags, transferred bytes, and a
+sanitized failure class. A successful attempt also records expected and wire bytes, duplicate bytes,
+retry count, protocol set, thermal state, phase timings, and final-integrity status. Task completion
+waits for URLSession's terminal callback so the success summary cannot overtake final task metrics.
+They never contain a raw URL, absolute path, device identity, or user data.
+
+Deterministic tests are model-free and Simulator-free. Live delivery is an explicit diagnostic:
+
+```sh
+# isolated macOS/CLI data root
+./build/vocello models install pro_custom_speed \
+  --data-dir build/scratch/transient/model-download-acceptance/ --verbose
+
+# paired physical iPhone; isolated app-support root, visible Settings controls
+scripts/ui_test.sh ios model-download
+```
+
+The iPhone proof backgrounds and terminates the app during transfer, relaunches it, requires
+non-regressing adopted progress, waits for exact verified installation, and deletes the isolated
+model through the visible UI. It is not part of smoke, benchmark, CI, release, or packaging.
+Crash-delta snapshots retain hashes rather than duplicating the device's historical diagnostics;
+the lane pulls only its bounded model-download summaries into the local untracked result artifact.
+
+The 2026-07-14 isolated Custom Speed acceptance passed on the Mac mini M2 8 GB and physical iPhone
+17 Pro. Both transfers moved the exact 2,312,057,897 expected bytes without retry or duplicate
+payload. Control-plane traffic such as the macOS catalog response is recorded separately and is
+never classified as duplicate model payload. The iPhone XCUITest completed its
+background/relaunch/install/visible-delete lifecycle in
+81.6 seconds and reported HTTP/2 plus HTTP/1.1 with fair thermal state. This is lifecycle evidence,
+not a performance baseline, and did not change concurrency or range-chunking defaults.
+
+## Tuning policy
+
+One live transfer is a lifecycle proof, not a concurrency experiment. Connection counts or chunking
+defaults may change only after a controlled comparison improves total transfer time by at least 15%
+without more retries, duplicate bytes, thermal regression, or restoration failure.
+
+Background Assets was evaluated and not adopted in this change. See
+[`../decisions/model-delivery-background-assets.md`](../decisions/model-delivery-background-assets.md).

--- a/docs/reference/privacy-storage.md
+++ b/docs/reference/privacy-storage.md
@@ -26,6 +26,7 @@ Maintained macOS subtrees and preferences:
 
 - `models/` stores installed Hugging Face model files. Speed and Quality folders for the same generation mode can coexist on macOS.
 - `.qwenvoice-downloads/` stores staged model downloads, partial files, resume data, and download-state metadata while a download is in progress.
+- `diagnostics/model-downloads/` stores allowlisted transfer/failure summaries, capped at 20 records and 5 MB; raw URLs and absolute paths are excluded.
 - `outputs/CustomVoice/`, `outputs/VoiceDesign/`, and `outputs/Clones/` store generated audio unless the user chooses a different output directory. If a user-chosen directory becomes missing or unwritable, new audio falls back to these default folders and Settings shows a warning — a generation is never lost to a vanished folder.
 - `voices/` stores saved voice reference assets (the reference WAV plus an optional `.txt` transcript sidecar).
 - Reference-clip **recording** (macOS, 2026-06) uses two short-lived directories under the system temporary directory: `voice-clone-references/` holds the in-progress capture and `voice-enroll/` holds a stable copy during enrollment. Both are deleted as part of enrollment/cancel; the kept copy is the one in `voices/`.
@@ -57,7 +58,9 @@ QVOICE_APP_SUPPORT_DIR=/path/to/custom/app-support
 Maintained iPhone subtrees:
 
 - `models/` stores verified installed model files.
-- `downloads/` stores in-progress model delivery state; `downloads/staging/` holds staged partials.
+- `downloads/ios_model_delivery_state.json` is the atomic schema-v2 delivery ledger. It stores only privacy-safe identifiers, relative paths, receipts, retry counts, byte progress, and terminal state.
+- `downloads/staging/` is the only iPhone delivery staging tree; it holds durable delegate files plus per-model verified files, partials, and resume data.
+- `diagnostics/model-downloads/` stores allowlisted local transfer/failure summaries, capped at 20 records and 5 MB. It excludes raw URLs, absolute paths, device identity, and user data.
 - `outputs/` stores generated audio. The user can optionally also copy each new clip to an external Files/iCloud folder via Settings → "Saved outputs" (a user-granted security-scoped bookmark; no new entitlement). The internal copy here is always kept and is what History plays from.
 - `voices/` stores saved voice reference assets.
 - `cache/imported_references/` stores app-owned materializations of WAV, MP3, AIFF, or M4A files

--- a/docs/reference/testing-runbook.md
+++ b/docs/reference/testing-runbook.md
@@ -46,11 +46,19 @@ scripts/ui_test.sh ios smoke
 scripts/ui_test.sh ios benchmark
 # Filtered benchmark example
 scripts/ui_test.sh ios benchmark --modes custom --lengths short --warm 1 --label "focused"
+
+# Opt-in ~2.3 GB background-session restoration proof; isolated data, genuine Settings controls
+scripts/ui_test.sh ios model-download
 ```
 
 Both benchmark commands accept `--modes`, `--lengths`, `--warm`, and `--label`. Without filters,
 each runs the canonical 29-take matrix. Filtered runs are targeted diagnostics, not substitutes for
 the full matrix when full frontend benchmark acceptance is explicitly requested.
+
+`ios model-download` is not a third routine UI lane. It selects one isolated physical-device test
+directly, backgrounds and relaunches the app during transfer, checks adopted progress, verifies the
+install, and deletes the isolated model through Settings. It never runs in ordinary CI or release.
+See [`model-delivery.md`](model-delivery.md).
 
 ## Model readiness
 

--- a/project.yml
+++ b/project.yml
@@ -426,7 +426,8 @@ targets:
       - package: SwiftHuggingFace
         product: HuggingFace
 
-  # Pure logic unit tests for QwenVoiceCore language semantics (no models, no XPC).
+  # Pure logic unit tests for QwenVoiceCore language and model-delivery lifecycle semantics
+  # (no models, no network, no Simulator, no XPC).
   # Run: scripts/macos_test.sh core-test
   VocelloCoreTests:
     type: bundle.unit-test

--- a/scripts/ui_test.sh
+++ b/scripts/ui_test.sh
@@ -37,8 +37,10 @@ Usage:
   scripts/ui_test.sh macos benchmark [--modes custom,design,clone] [--lengths short,medium,long] [--warm 3] [--label RUN_ID]
   scripts/ui_test.sh ios smoke
   scripts/ui_test.sh ios benchmark [--modes custom,design,clone] [--lengths short,medium,long] [--warm 3] [--label RUN_ID]
+  scripts/ui_test.sh ios model-download
 
 The iOS destination is the paired physical iPhone only. Simulator destinations are unsupported.
+`model-download` is an opt-in isolated lifecycle proof and never runs in smoke, benchmark, CI, or release.
 No lane retries automatically. A failed run keeps its log, xcresult, screenshots, and diagnostics.
 RUN_ID is an opaque 1-96 character identifier using letters, digits, dot, underscore, or hyphen.
 EOF
@@ -50,7 +52,8 @@ platform="$1"
 lane="$2"
 shift 2
 [[ "$platform" == "macos" || "$platform" == "ios" ]] || usage
-[[ "$lane" == "smoke" || "$lane" == "benchmark" ]] || usage
+[[ "$lane" == "smoke" || "$lane" == "benchmark" || "$lane" == "model-download" ]] || usage
+[[ "$lane" != "model-download" || "$platform" == "ios" ]] || usage
 
 modes="custom,design,clone"
 lengths="short,medium,long"
@@ -72,7 +75,7 @@ while [[ $# -gt 0 ]]; do
 done
 validate_benchmark_label "$label"
 
-if [[ "$lane" == "smoke" && ( "$modes" != "custom,design,clone" || "$lengths" != "short,medium,long" || "$warm" != 3 || -n "$label" ) ]]; then
+if [[ "$lane" != "benchmark" && ( "$modes" != "custom,design,clone" || "$lengths" != "short,medium,long" || "$warm" != 3 || -n "$label" ) ]]; then
   die "benchmark flags are accepted only by the benchmark lane"
 fi
 
@@ -314,6 +317,79 @@ snapshot_ios_crashes() {
     printf '%s  %s\n' "$hash" "$relative"
   done < <(find "$destination/pull" -type f -path '*/crashes/*' -print0 2>/dev/null) \
     | sort >"$destination/hashes.txt"
+  # Crash gating needs the stable hashes, not another copy of the device's complete historical
+  # diagnostics tree. Exact payload retrieval remains available through ios_device.sh crashes.
+  rm -rf "$destination/pull"
+}
+
+pull_ios_model_download_diagnostics() {
+  local device="$1" destination="$2"
+  rm -rf "$destination"
+  mkdir -p "$destination"
+  xcrun devicectl device copy from --device "$device" \
+    --domain-type appDataContainer --domain-identifier "$BUNDLE_ID_IOS" \
+    --source "Library/Application Support/Q-Voice/model-download-acceptance/diagnostics/model-downloads" \
+    --destination "$destination" >"$out/model-download-diagnostics-pull.log" 2>&1 \
+    || return 1
+  python3 - "$destination" <<'PY'
+import json, pathlib, sys
+
+root = pathlib.Path(sys.argv[1])
+files = sorted(root.glob("*.json"))
+if not files or len(files) > 20:
+    raise SystemExit(f"expected 1-20 compact diagnostic records, found {len(files)}")
+if sum(path.stat().st_size for path in files) > 5 * 1024 * 1024:
+    raise SystemExit("model-download diagnostics exceed the 5 MiB retention contract")
+records = [json.loads(path.read_text(encoding="utf-8")) for path in files]
+successes = [
+    record for record in records
+    if record.get("kind") == "success" and record.get("finalIntegrity") is True
+]
+if not successes:
+    raise SystemExit("missing final-integrity success summary")
+latest = max(successes, key=lambda value: value.get("capturedAtUTC", ""))
+latest_time = latest.get("capturedAtUTC", "")
+prior_terminal_times = sorted(
+    record.get("capturedAtUTC", "") for record in records
+    if record.get("kind") in {"success", "failure"}
+    and record.get("capturedAtUTC", "") < latest_time
+)
+lower_bound = prior_terminal_times[-1] if prior_terminal_times else ""
+current = [
+    record for record in records
+    if lower_bound < record.get("capturedAtUTC", "") <= latest_time
+]
+metrics = [
+    record for record in current
+    if record.get("kind") == "task-metrics" and record.get("relativePath")
+]
+expected = max(
+    (record.get("totalBytes", 0) for record in current if record.get("kind") == "phase"),
+    default=latest.get("expectedBytes", 0),
+)
+wire = sum(max(0, record.get("transferredBytes", 0)) for record in metrics)
+protocols = sorted({record.get("protocolName") for record in metrics if record.get("protocolName")})
+if expected <= 0 or wire < expected or not protocols:
+    raise SystemExit("selected success is missing complete transfer metrics")
+summary = {
+    "schemaVersion": 1,
+    "capturedAtUTC": latest_time,
+    "finalIntegrity": True,
+    "expectedBytes": expected,
+    "wireBytes": wire,
+    "duplicateBytes": wire - expected,
+    "retryCount": latest.get("retryCount", 0),
+    "protocols": protocols,
+    "thermalState": latest.get("thermalState"),
+    "networkSeconds": latest.get("networkSeconds"),
+    "verificationSeconds": latest.get("verificationSeconds"),
+    "installationSeconds": latest.get("installationSeconds"),
+}
+(root.parent / "validated-summary.json").write_text(
+    json.dumps(summary, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+PY
 }
 
 run_xcodebuild() {
@@ -450,13 +526,15 @@ else
 
   if [[ "$lane" == "smoke" ]]; then
     only_test="VocelloiOSUITests/VocelloiOSSmokeUITests/testPhysicalDeviceSmokeJourney"
-  else
+  elif [[ "$lane" == "benchmark" ]]; then
     only_test="VocelloiOSUITests/VocelloiOSBenchmarkUITests/testOrderedConfigurableMatrix"
     export TEST_RUNNER_QVOICE_IOS_BENCH_RUN_ID="$run_id"
     export TEST_RUNNER_QVOICE_IOS_BENCH_MODES="$modes"
     export TEST_RUNNER_QVOICE_IOS_BENCH_LENGTHS="$lengths"
     export TEST_RUNNER_QVOICE_IOS_BENCH_WARM="$warm"
     export TEST_RUNNER_QVOICE_IOS_BENCH_LABEL="${label:-$run_id}"
+  else
+    only_test="VocelloiOSUITests/VocelloiOSModelDownloadUITests/testIsolatedBackgroundDownloadAdoptionAndCleanup"
   fi
 
   note "physical-iPhone XCUITest $lane on $device → $out"
@@ -472,6 +550,11 @@ else
     ARCHS=arm64 ONLY_ACTIVE_ARCH=YES \
     SWIFT_OPTIMIZATION_LEVEL=-O \
     || die "physical-iPhone XCUITest failed (see $out/xcodebuild.log)"
+
+  if [[ "$lane" == "model-download" ]]; then
+    pull_ios_model_download_diagnostics "$device" "$out/model-download-diagnostics" \
+      || die "could not collect or validate compact model-download diagnostics (see $out/model-download-diagnostics-pull.log)"
+  fi
 
   snapshot_ios_crashes "$out/crashes-after" \
     || die "could not establish the post-run iPhone crash snapshot"


### PR DESCRIPTION
## Summary

- repair iOS background URLSession restoration with one app-lifetime session, a durable schema-v2 ledger, exact task adoption, cancellation barriers, and one-time legacy migration
- unify integrity verification and atomic installation across macOS, CLI, and iOS while avoiding duplicate full-file hashing
- add typed retry/connectivity phases, monotonic progress, speed and ETA, bounded privacy-safe task metrics, and accurate control-plane versus payload accounting
- simplify the visible model-manager states and add an opt-in physical-iPhone lifecycle XCUITest lane
- document the delivery contract and the decision to defer Background Assets

## Root cause

The prior iOS implementation created per-model background sessions without durable task adoption, allowed cancellation and delegate callbacks to race with staging cleanup, repeated large-file verification, and exposed UI states that did not correspond to implemented lifecycle behavior. Foreground sessions also lacked explicit terminal teardown and diagnostics did not separate catalog traffic from model payload.

## Validation

- `git diff --check`
- `python3 scripts/documentation_contract.py`
- `python3 scripts/build_output_policy.py validate`
- `./scripts/check_project_inputs.sh` (359 tests)
- `scripts/macos_test.sh core-test`
- `scripts/macos_test.sh test`
- `./scripts/build.sh build`
- `./scripts/build_foundation_targets.sh ios`
- isolated macOS Custom Speed download: exact integrity, temporary payload removed
- physical-iPhone Custom Speed lifecycle: background, terminate, relaunch, adopted monotonic progress, exact install, visible delete; no retry or duplicate payload

Raw model payloads, telemetry details, and `.xcresult` evidence remain local and untracked.