### PR TITLE
Repair post-merge security workflows

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -124,7 +124,10 @@ jobs:
         if: matrix.language == 'swift'
         run: |
           sudo xcode-select -s /Applications/Xcode_26.6.app
-          brew install xcodegen xcbeautify ripgrep shellcheck
+          # CodeQL's tracing shell currently runs through Rosetta on the ARM
+          # macos-26 image. Invoke the ARM Homebrew binary explicitly so its
+          # architecture guard does not reject the otherwise native runner.
+          arch -arm64 /opt/homebrew/bin/brew install xcodegen xcbeautify ripgrep shellcheck
           python3 scripts/supply_chain_contract.py --installed native
 
       - name: Build Swift targets for CodeQL

--- a/docs/project-health.md
+++ b/docs/project-health.md
@@ -5,7 +5,7 @@
 
 - Current source identity and dirty state: local JSON report only (kept out of the tracked snapshot to avoid self-referential drift)
 - Swift tests: 232 cases in 39 files
-- Python tests: 524 cases in 40 files
+- Python tests: 526 cases in 40 files
 - Required-step assurance: 55 steps across 12 workflows, all covered by forced-failure fixtures
 - Unsafe-concurrency annotations: 50 (50 registered with owner and invariant; contract complete)
 
@@ -28,7 +28,7 @@
 | xpc-transport | macos | 3 | 2 / 12 | macos: fresh |
 | benchmark-validation | release-qa | 6 | 4 / 111 | macos: fresh, ios: fresh |
 | orchestration-assurance | release-qa | 3 | 1 / 12 | not hardware-gated |
-| release-supply-chain | release-qa | 6 | 3 / 36 | macos: stale |
+| release-supply-chain | release-qa | 6 | 3 / 38 | macos: stale |
 | persistence-privacy | platform-release-qa | 4 | 2 / 7 | not hardware-gated |
 | runtime-hardening | backend-release-qa | 5 | 2 / 10 | not hardware-gated |
 

--- a/scripts/supply_chain_contract.py
+++ b/scripts/supply_chain_contract.py
@@ -171,6 +171,15 @@ def validate(root: Path, installed: str | None = None) -> list[str]:
         if "npm --prefix website audit --package-lock-only --audit-level=high" not in npm_audit:
             errors.append("npm advisory audit must inspect the committed website lock at high severity")
 
+    codeql = _workflow_job(security, "codeql")
+    if not codeql:
+        errors.append("security workflow is missing CodeQL")
+    else:
+        if "runner: macos-26" not in codeql:
+            errors.append("Swift CodeQL must retain the macos-26 ARM runner")
+        if "arch -arm64 /opt/homebrew/bin/brew install xcodegen xcbeautify ripgrep shellcheck" not in codeql:
+            errors.append("Swift CodeQL tooling must invoke ARM Homebrew explicitly on the macos-26 runner")
+
     snapshot_path = root / "scripts/swift_dependency_snapshot.py"
     snapshot_source = snapshot_path.read_text(encoding="utf-8") if snapshot_path.is_file() else ""
     for lock_path in (

--- a/scripts/swift_dependency_snapshot.py
+++ b/scripts/swift_dependency_snapshot.py
@@ -249,8 +249,8 @@ def build_snapshot(
             "name": DETECTOR_NAME,
             "version": DETECTOR_VERSION,
             "url": DETECTOR_URL,
-            "metadata": {"format": "swift-package-resolved-v3", "manifest_count": len(manifests)},
         },
+        "metadata": {"format": "swift-package-resolved-v3", "manifest_count": len(manifests)},
         "scanned": _validated_scanned(scanned),
         "manifests": manifests,
     }

--- a/scripts/tests/test_supply_chain_contract.py
+++ b/scripts/tests/test_supply_chain_contract.py
@@ -54,6 +54,10 @@ jobs:
       contents: read
     steps:
       - run: npm --prefix website audit --package-lock-only --audit-level=high
+  codeql:
+    runner: macos-26
+    steps:
+      - run: arch -arm64 /opt/homebrew/bin/brew install xcodegen xcbeautify ripgrep shellcheck
 """ % self.sha
         (self.root / ".github/workflows/security.yml").write_text(security, encoding="utf-8")
         (self.root / ".github/dependabot.yml").write_text(
@@ -187,6 +191,20 @@ jobs:
             encoding="utf-8",
         )
         self.assertTrue(any("audit must run only" in value for value in module.validate(self.root)))
+
+    def test_swift_codeql_tooling_must_run_homebrew_natively(self) -> None:
+        path = self.root / ".github/workflows/security.yml"
+        text = path.read_text(encoding="utf-8")
+        path.write_text(
+            text.replace(
+                "arch -arm64 /opt/homebrew/bin/brew install xcodegen xcbeautify ripgrep shellcheck",
+                "brew install xcodegen xcbeautify ripgrep shellcheck",
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("ARM Homebrew" in value for value in module.validate(self.root)))
+        path.write_text(text.replace("runner: macos-26", "runner: macos-15"), encoding="utf-8")
+        self.assertTrue(any("macos-26 ARM runner" in value for value in module.validate(self.root)))
 
     def test_swift_dependency_snapshot_must_cover_both_tracked_locks(self) -> None:
         path = self.root / "scripts/swift_dependency_snapshot.py"

--- a/scripts/tests/test_swift_dependency_snapshot.py
+++ b/scripts/tests/test_swift_dependency_snapshot.py
@@ -103,6 +103,28 @@ let package = Package(
         )
         self.assertEqual(first["scanned"], "2026-07-17T00:00:00Z")
 
+    def test_detector_uses_only_api_permitted_properties(self) -> None:
+        snapshot = self.snapshot()
+        self.assertEqual(
+            set(snapshot),
+            {"version", "sha", "ref", "job", "detector", "metadata", "scanned", "manifests"},
+        )
+        self.assertEqual(
+            snapshot["detector"],
+            {
+                "name": module.DETECTOR_NAME,
+                "version": module.DETECTOR_VERSION,
+                "url": module.DETECTOR_URL,
+            },
+        )
+        self.assertEqual(
+            snapshot["metadata"],
+            {"format": "swift-package-resolved-v3", "manifest_count": 2},
+        )
+        root = snapshot["manifests"]["qwenvoice-root-xcode-workspace-v1"]
+        self.assertEqual(root["metadata"]["lockfile_version"], 3)
+        self.assertEqual(root["resolved"]["swift-nio"]["metadata"], {"revision": "c" * 40})
+
     def test_direct_relationships_are_derived_from_each_declaration(self) -> None:
         manifests = self.snapshot()["manifests"]
         root = manifests["qwenvoice-root-xcode-workspace-v1"]["resolved"]
@@ -165,6 +187,7 @@ let package = Package(
         self.assertEqual(payload["version"], 0)
         self.assertEqual(payload["sha"], "e" * 40)
         self.assertEqual(len(payload["manifests"]), 2)
+        self.assertNotIn("metadata", payload["detector"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- move custom Swift dependency-snapshot metadata to the API-supported top-level field
- keep detector identity limited to the closed `name`, `version`, and `url` shape
- run Homebrew natively on the ARM `macos-26` Swift CodeQL runner
- enforce both contracts with deterministic negative fixtures
- refresh the generated project-health test inventory

## Root cause

The first post-merge run for #74 exposed two deterministic workflow issues. GitHub rejected `detector.metadata` with HTTP 422 because custom metadata is a sibling snapshot field, and Swift CodeQL invoked the ARM Homebrew installation through a Rosetta tracing shell. The CodeQL issue predated #74; the dependency-submission issue was the new route's first live API execution.

## Verification

- `python3 -m unittest -v scripts.tests.test_swift_dependency_snapshot scripts.tests.test_supply_chain_contract`
- `python3 scripts/supply_chain_contract.py`
- `./scripts/check_project_inputs.sh` (460 tests)
- `git diff --check`

No model, UI, benchmark, Simulator, or physical-device operation was required.
