### PR TITLE
Run Swift CodeQL build natively

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -133,8 +133,12 @@ jobs:
       - name: Build Swift targets for CodeQL
         if: matrix.language == 'swift'
         run: |
-          ./scripts/regenerate_project.sh
-          ./scripts/build.sh build
+          # The CodeQL tracing shell is x86_64 even on the ARM macos-26
+          # runner. Start the authoritative build through an ARM bash so
+          # xcodebuild can select the repository's arm64-only destination.
+          # build.sh owns regeneration; invoking it separately would run the
+          # full project-input suite twice before compilation.
+          arch -arm64 /bin/bash ./scripts/build.sh build
 
       - name: Analyze
         uses: github/codeql-action/analyze@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5

--- a/docs/project-health.md
+++ b/docs/project-health.md
@@ -5,7 +5,7 @@
 
 - Current source identity and dirty state: local JSON report only (kept out of the tracked snapshot to avoid self-referential drift)
 - Swift tests: 232 cases in 39 files
-- Python tests: 526 cases in 40 files
+- Python tests: 527 cases in 40 files
 - Required-step assurance: 55 steps across 12 workflows, all covered by forced-failure fixtures
 - Unsafe-concurrency annotations: 50 (50 registered with owner and invariant; contract complete)
 
@@ -28,7 +28,7 @@
 | xpc-transport | macos | 3 | 2 / 12 | macos: fresh |
 | benchmark-validation | release-qa | 6 | 4 / 111 | macos: fresh, ios: fresh |
 | orchestration-assurance | release-qa | 3 | 1 / 12 | not hardware-gated |
-| release-supply-chain | release-qa | 6 | 3 / 38 | macos: stale |
+| release-supply-chain | release-qa | 6 | 3 / 39 | macos: stale |
 | persistence-privacy | platform-release-qa | 4 | 2 / 7 | not hardware-gated |
 | runtime-hardening | backend-release-qa | 5 | 2 / 10 | not hardware-gated |
 

--- a/scripts/supply_chain_contract.py
+++ b/scripts/supply_chain_contract.py
@@ -179,6 +179,10 @@ def validate(root: Path, installed: str | None = None) -> list[str]:
             errors.append("Swift CodeQL must retain the macos-26 ARM runner")
         if "arch -arm64 /opt/homebrew/bin/brew install xcodegen xcbeautify ripgrep shellcheck" not in codeql:
             errors.append("Swift CodeQL tooling must invoke ARM Homebrew explicitly on the macos-26 runner")
+        if "arch -arm64 /bin/bash ./scripts/build.sh build" not in codeql:
+            errors.append("Swift CodeQL must invoke the authoritative macOS build through an ARM bash")
+        if "./scripts/regenerate_project.sh" in codeql:
+            errors.append("Swift CodeQL must let build.sh own project regeneration")
 
     snapshot_path = root / "scripts/swift_dependency_snapshot.py"
     snapshot_source = snapshot_path.read_text(encoding="utf-8") if snapshot_path.is_file() else ""

--- a/scripts/tests/test_supply_chain_contract.py
+++ b/scripts/tests/test_supply_chain_contract.py
@@ -58,6 +58,7 @@ jobs:
     runner: macos-26
     steps:
       - run: arch -arm64 /opt/homebrew/bin/brew install xcodegen xcbeautify ripgrep shellcheck
+      - run: arch -arm64 /bin/bash ./scripts/build.sh build
 """ % self.sha
         (self.root / ".github/workflows/security.yml").write_text(security, encoding="utf-8")
         (self.root / ".github/dependabot.yml").write_text(
@@ -205,6 +206,30 @@ jobs:
         self.assertTrue(any("ARM Homebrew" in value for value in module.validate(self.root)))
         path.write_text(text.replace("runner: macos-26", "runner: macos-15"), encoding="utf-8")
         self.assertTrue(any("macos-26 ARM runner" in value for value in module.validate(self.root)))
+
+    def test_swift_codeql_build_must_run_natively_without_duplicate_regeneration(self) -> None:
+        path = self.root / ".github/workflows/security.yml"
+        text = path.read_text(encoding="utf-8")
+        path.write_text(
+            text.replace(
+                "arch -arm64 /bin/bash ./scripts/build.sh build",
+                "./scripts/build.sh build",
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any(
+            "authoritative macOS build through an ARM bash" in value
+            for value in module.validate(self.root)
+        ))
+
+        path.write_text(
+            text.replace(
+                "arch -arm64 /bin/bash ./scripts/build.sh build",
+                "./scripts/regenerate_project.sh\n      - run: arch -arm64 /bin/bash ./scripts/build.sh build",
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("build.sh own project regeneration" in value for value in module.validate(self.root)))
 
     def test_swift_dependency_snapshot_must_cover_both_tracked_locks(self) -> None:
         path = self.root / "scripts/swift_dependency_snapshot.py"


### PR DESCRIPTION
## Summary

- force the CodeQL-traced macOS build through an ARM bash so Xcode exposes the repository's arm64 destination
- remove the redundant standalone project regeneration that ran all project-input fixtures twice
- enforce both invariants in the supply-chain contract and add regression coverage
- refresh the generated project-health inventory

## Root cause

GitHub's macos-26 runner and CodeQL bundle are ARM-native, but CodeQL's tracing shell is translated. The previous workflow invoked xcodebuild from that x86_64 shell, so Xcode advertised only an x86_64 My Mac destination while build.sh correctly requested macOS arm64, then exited 70.

## Verification

- python3 -m unittest -v scripts.tests.test_supply_chain_contract
- python3 scripts/supply_chain_contract.py
- python3 scripts/project_health.py validate
- ./scripts/check_project_inputs.sh (461 tests)
- git diff --check
- arch -arm64 /bin/bash -c 'uname -m' => arm64

No model, device, UI, benchmark, or release lane was used.