### PR TITLE
Restore complete Swift CodeQL analysis

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -134,9 +134,10 @@ jobs:
       - name: Prepare Swift CodeQL build inputs
         if: matrix.language == 'swift'
         run: |
-          # Project generation, deterministic contracts, and dependency
-          # resolution do not need extraction. Finish them before CodeQL starts
-          # tracing so the traced phase contains one compilation only.
+          # Prebuild the full graph natively so Xcode 26's optional Metal
+          # compiler materializes MLX shader outputs before CodeQL's translated
+          # tracing shell starts. The traced command below invalidates only
+          # repository-owned Swift sources.
           ./scripts/build.sh codeql-prepare
 
       - name: Initialize CodeQL
@@ -149,9 +150,9 @@ jobs:
         if: matrix.language == 'swift'
         run: |
           # CodeQL's tracing shell currently runs through Rosetta on the ARM
-          # macos-26 image. Keep compilation inside that shell so the Swift
-          # extractor sees it, while build.sh selects generic macOS and emits
-          # only arm64 products through ARCHS=arm64.
+          # macos-26 image. Keep the owned-Swift rebuild inside that shell so
+          # the extractor sees it, while reusing native Metal/dependency outputs
+          # and emitting only arm64 products through ARCHS=arm64.
           ./scripts/build.sh codeql
 
       - name: Analyze

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -114,12 +114,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
-        with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
-
       - name: Select and validate native toolchain
         if: matrix.language == 'swift'
         run: |
@@ -130,15 +124,28 @@ jobs:
           arch -arm64 /opt/homebrew/bin/brew install xcodegen xcbeautify ripgrep shellcheck
           python3 scripts/supply_chain_contract.py --installed native
 
+      - name: Prepare Swift CodeQL build inputs
+        if: matrix.language == 'swift'
+        run: |
+          # Project generation, deterministic contracts, and dependency
+          # resolution do not need extraction. Finish them before CodeQL starts
+          # tracing so the traced phase contains one compilation only.
+          ./scripts/build.sh codeql-prepare
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
       - name: Build Swift targets for CodeQL
         if: matrix.language == 'swift'
         run: |
-          # The CodeQL tracing shell is x86_64 even on the ARM macos-26
-          # runner. Start the authoritative build through an ARM bash so
-          # xcodebuild can select the repository's arm64-only destination.
-          # build.sh owns regeneration; invoking it separately would run the
-          # full project-input suite twice before compilation.
-          arch -arm64 /bin/bash ./scripts/build.sh build
+          # CodeQL's tracing shell currently runs through Rosetta on the ARM
+          # macos-26 image. Keep compilation inside that shell so the Swift
+          # extractor sees it, while build.sh selects generic macOS and emits
+          # only arm64 products through ARCHS=arm64.
+          ./scripts/build.sh codeql
 
       - name: Analyze
         uses: github/codeql-action/analyze@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.30.5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -122,6 +122,13 @@ jobs:
           # macos-26 image. Invoke the ARM Homebrew binary explicitly so its
           # architecture guard does not reject the otherwise native runner.
           arch -arm64 /opt/homebrew/bin/brew install xcodegen xcbeautify ripgrep shellcheck
+          # Xcode 26 ships Metal as an optional component, and GitHub's fresh
+          # macos-26 images do not consistently include it. MLX compiles Metal
+          # sources, so install the component before CodeQL starts tracing.
+          if ! xcrun metal --version >/dev/null 2>&1; then
+            xcodebuild -downloadComponent metalToolchain
+          fi
+          xcrun metal --version
           python3 scripts/supply_chain_contract.py --installed native
 
       - name: Prepare Swift CodeQL build inputs

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -135,8 +135,9 @@ jobs:
         if: matrix.language == 'swift'
         run: |
           # Prebuild the full graph natively so Xcode 26's optional Metal
-          # compiler materializes MLX shader outputs before CodeQL's translated
-          # tracing shell starts. The traced command below invalidates only
+          # compiler materializes and validates MLX shader outputs in managed
+          # CI scratch before CodeQL's translated tracing shell starts. The
+          # traced command below reuses that scratch graph and invalidates only
           # repository-owned Swift sources.
           ./scripts/build.sh codeql-prepare
 
@@ -152,7 +153,10 @@ jobs:
           # CodeQL's tracing shell currently runs through Rosetta on the ARM
           # macos-26 image. Keep the owned-Swift rebuild inside that shell so
           # the extractor sees it, while reusing native Metal/dependency outputs
-          # and emitting only arm64 products through ARCHS=arm64.
+          # and emitting only arm64 products through ARCHS=arm64. The traced
+          # scratch product is analysis-only because Xcode removes the excluded
+          # Metal resource; codeql-prepare already validated the complete app in
+          # the same isolated scratch root. Neither command stages public output.
           ./scripts/build.sh codeql
 
       - name: Analyze

--- a/docs/project-health.md
+++ b/docs/project-health.md
@@ -5,7 +5,7 @@
 
 - Current source identity and dirty state: local JSON report only (kept out of the tracked snapshot to avoid self-referential drift)
 - Swift tests: 232 cases in 39 files
-- Python tests: 534 cases in 40 files
+- Python tests: 535 cases in 40 files
 - Required-step assurance: 55 steps across 12 workflows, all covered by forced-failure fixtures
 - Unsafe-concurrency annotations: 50 (50 registered with owner and invariant; contract complete)
 
@@ -28,7 +28,7 @@
 | xpc-transport | macos | 3 | 2 / 12 | macos: fresh |
 | benchmark-validation | release-qa | 6 | 4 / 111 | macos: fresh, ios: fresh |
 | orchestration-assurance | release-qa | 3 | 1 / 12 | not hardware-gated |
-| release-supply-chain | release-qa | 6 | 3 / 46 | macos: stale |
+| release-supply-chain | release-qa | 6 | 3 / 47 | macos: stale |
 | persistence-privacy | platform-release-qa | 4 | 2 / 7 | not hardware-gated |
 | runtime-hardening | backend-release-qa | 5 | 2 / 10 | not hardware-gated |
 

--- a/docs/project-health.md
+++ b/docs/project-health.md
@@ -5,7 +5,7 @@
 
 - Current source identity and dirty state: local JSON report only (kept out of the tracked snapshot to avoid self-referential drift)
 - Swift tests: 232 cases in 39 files
-- Python tests: 537 cases in 40 files
+- Python tests: 539 cases in 40 files
 - Required-step assurance: 55 steps across 12 workflows, all covered by forced-failure fixtures
 - Unsafe-concurrency annotations: 50 (50 registered with owner and invariant; contract complete)
 
@@ -28,7 +28,7 @@
 | xpc-transport | macos | 3 | 2 / 12 | macos: fresh |
 | benchmark-validation | release-qa | 6 | 4 / 111 | macos: fresh, ios: fresh |
 | orchestration-assurance | release-qa | 3 | 1 / 12 | not hardware-gated |
-| release-supply-chain | release-qa | 6 | 3 / 49 | macos: stale |
+| release-supply-chain | release-qa | 6 | 3 / 51 | macos: stale |
 | persistence-privacy | platform-release-qa | 4 | 2 / 7 | not hardware-gated |
 | runtime-hardening | backend-release-qa | 5 | 2 / 10 | not hardware-gated |
 

--- a/docs/project-health.md
+++ b/docs/project-health.md
@@ -5,7 +5,7 @@
 
 - Current source identity and dirty state: local JSON report only (kept out of the tracked snapshot to avoid self-referential drift)
 - Swift tests: 232 cases in 39 files
-- Python tests: 535 cases in 40 files
+- Python tests: 537 cases in 40 files
 - Required-step assurance: 55 steps across 12 workflows, all covered by forced-failure fixtures
 - Unsafe-concurrency annotations: 50 (50 registered with owner and invariant; contract complete)
 
@@ -28,7 +28,7 @@
 | xpc-transport | macos | 3 | 2 / 12 | macos: fresh |
 | benchmark-validation | release-qa | 6 | 4 / 111 | macos: fresh, ios: fresh |
 | orchestration-assurance | release-qa | 3 | 1 / 12 | not hardware-gated |
-| release-supply-chain | release-qa | 6 | 3 / 47 | macos: stale |
+| release-supply-chain | release-qa | 6 | 3 / 49 | macos: stale |
 | persistence-privacy | platform-release-qa | 4 | 2 / 7 | not hardware-gated |
 | runtime-hardening | backend-release-qa | 5 | 2 / 10 | not hardware-gated |
 

--- a/docs/project-health.md
+++ b/docs/project-health.md
@@ -5,7 +5,7 @@
 
 - Current source identity and dirty state: local JSON report only (kept out of the tracked snapshot to avoid self-referential drift)
 - Swift tests: 232 cases in 39 files
-- Python tests: 527 cases in 40 files
+- Python tests: 533 cases in 40 files
 - Required-step assurance: 55 steps across 12 workflows, all covered by forced-failure fixtures
 - Unsafe-concurrency annotations: 50 (50 registered with owner and invariant; contract complete)
 
@@ -28,7 +28,7 @@
 | xpc-transport | macos | 3 | 2 / 12 | macos: fresh |
 | benchmark-validation | release-qa | 6 | 4 / 111 | macos: fresh, ios: fresh |
 | orchestration-assurance | release-qa | 3 | 1 / 12 | not hardware-gated |
-| release-supply-chain | release-qa | 6 | 3 / 39 | macos: stale |
+| release-supply-chain | release-qa | 6 | 3 / 45 | macos: stale |
 | persistence-privacy | platform-release-qa | 4 | 2 / 7 | not hardware-gated |
 | runtime-hardening | backend-release-qa | 5 | 2 / 10 | not hardware-gated |
 

--- a/docs/project-health.md
+++ b/docs/project-health.md
@@ -5,7 +5,7 @@
 
 - Current source identity and dirty state: local JSON report only (kept out of the tracked snapshot to avoid self-referential drift)
 - Swift tests: 232 cases in 39 files
-- Python tests: 533 cases in 40 files
+- Python tests: 534 cases in 40 files
 - Required-step assurance: 55 steps across 12 workflows, all covered by forced-failure fixtures
 - Unsafe-concurrency annotations: 50 (50 registered with owner and invariant; contract complete)
 
@@ -28,7 +28,7 @@
 | xpc-transport | macos | 3 | 2 / 12 | macos: fresh |
 | benchmark-validation | release-qa | 6 | 4 / 111 | macos: fresh, ios: fresh |
 | orchestration-assurance | release-qa | 3 | 1 / 12 | not hardware-gated |
-| release-supply-chain | release-qa | 6 | 3 / 45 | macos: stale |
+| release-supply-chain | release-qa | 6 | 3 / 46 | macos: stale |
 | persistence-privacy | platform-release-qa | 4 | 2 / 7 | not hardware-gated |
 | runtime-hardening | backend-release-qa | 5 | 2 / 10 | not hardware-gated |
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,8 +12,8 @@
 #
 # usage:
 #   scripts/build.sh build            # fast local build, no launch (alias: debug)
-#   scripts/build.sh codeql-prepare   # CI-only: prepare generated inputs/packages before tracing
-#   scripts/build.sh codeql           # CI-only: traced generic-destination arm64 build
+#   scripts/build.sh codeql-prepare   # CI-only: native dependency/Metal prebuild before tracing
+#   scripts/build.sh codeql           # CI-only: traced owned-Swift arm64 rebuild
 #   scripts/build.sh run [--logs|--telemetry|--verify|--debug]
 #   scripts/build.sh release [release.sh args...]
 #   scripts/build.sh clean
@@ -52,8 +52,8 @@ usage: scripts/build.sh <command> [options]
 
 commands:
   build                 Fast local build (-Onone). No launch. (alias: debug)
-  codeql-prepare        CI-only: prepare generated inputs and packages before CodeQL init.
-  codeql                CI-only: build arm64 through CodeQL's traced shell.
+  codeql-prepare        CI-only: prebuild dependencies and Metal before CodeQL init.
+  codeql                CI-only: rebuild owned Swift as arm64 through CodeQL's traced shell.
   run [--logs|--telemetry|--verify|--debug]
                         Build, then launch $APP_NAME.app.
   release [args...]     Run scripts/release.sh (optimized DMG) with the shared regen/SPM cache.
@@ -148,11 +148,32 @@ build_app() {
 
 cmd_codeql_prepare() {
     DESTINATION="$CODEQL_DESTINATION"
-    prepare_build_inputs
+    build_app "scripts/build.sh codeql-prepare"
+}
+
+touch_codeql_sources() {
+    local source_count
+    source_count="$(find \
+        "$ROOT_DIR/Sources" \
+        "$ROOT_DIR/Packages/VocelloQwen3Core/Sources" \
+        -type f -name '*.swift' -print | wc -l | tr -d ' ')"
+    [[ "$source_count" =~ ^[1-9][0-9]*$ ]] || {
+        echo "error: CodeQL found no owned Swift sources to rebuild" >&2
+        return 1
+    }
+    find \
+        "$ROOT_DIR/Sources" \
+        "$ROOT_DIR/Packages/VocelloQwen3Core/Sources" \
+        -type f -name '*.swift' -exec touch {} +
+    echo "==> Marked $source_count owned Swift sources for traced recompilation"
 }
 
 cmd_codeql() {
     DESTINATION="$CODEQL_DESTINATION"
+    # The native prebuild materializes MLX's Metal outputs. Only owned Swift
+    # needs to be newer for the translated CodeQL shell, whose tracer cannot
+    # execute Xcode 26's optional Metal compiler.
+    touch_codeql_sources
     build_app "scripts/build.sh codeql"
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,6 +12,8 @@
 #
 # usage:
 #   scripts/build.sh build            # fast local build, no launch (alias: debug)
+#   scripts/build.sh codeql-prepare   # CI-only: prepare generated inputs/packages before tracing
+#   scripts/build.sh codeql           # CI-only: traced generic-destination arm64 build
 #   scripts/build.sh run [--logs|--telemetry|--verify|--debug]
 #   scripts/build.sh release [release.sh args...]
 #   scripts/build.sh clean
@@ -29,6 +31,7 @@ APP_NAME="Vocello"
 SCHEME_NAME="QwenVoice"
 BUNDLE_ID="com.qwenvoice.app"
 DESTINATION="platform=macOS,arch=arm64"
+CODEQL_DESTINATION="generic/platform=macOS"
 
 BUILD_DIR="$QVOICE_BUILD_ROOT"
 DERIVED_DATA="$QVOICE_XCODE_MACOS_DERIVED"
@@ -49,6 +52,8 @@ usage: scripts/build.sh <command> [options]
 
 commands:
   build                 Fast local build (-Onone). No launch. (alias: debug)
+  codeql-prepare        CI-only: prepare generated inputs and packages before CodeQL init.
+  codeql                CI-only: build arm64 through CodeQL's traced shell.
   run [--logs|--telemetry|--verify|--debug]
                         Build, then launch $APP_NAME.app.
   release [args...]     Run scripts/release.sh (optimized DMG) with the shared regen/SPM cache.
@@ -63,10 +68,15 @@ Set QWENVOICE_DEBUG=1 to launch with the runtime debug toggle on.
 EOF
 }
 
-build_app() {
+prepare_build_inputs() {
     ensure_project_regenerated
     ensure_spm_resolved "$QVOICE_SCRATCH_PACKAGE_RESOLUTION" "$SOURCE_PACKAGES_DIR" \
         dev QwenVoice Release "$DESTINATION"
+}
+
+build_app() {
+    local command_identity="${1:-scripts/build.sh build}"
+    prepare_build_inputs
 
     # Stable dev signing: a real Apple Development identity keeps the app's
     # designated requirement constant across rebuilds, so TCC grants
@@ -127,13 +137,23 @@ build_app() {
     local signing_class="apple-development"
     [[ "$signing_identity" != "-" ]] || signing_class="ad-hoc"
     write_build_provenance "$DERIVED_DATA/last-build.json" \
-        "scripts/build.sh build" "$SCHEME_NAME" Release "$DESTINATION" arm64 \
+        "$command_identity" "$SCHEME_NAME" Release "$DESTINATION" arm64 \
         Onone "$signing_class" "$DERIVED_DATA" "$SOURCE_PACKAGES_DIR"
     write_build_provenance "$QVOICE_SYMBOLS_MACOS/last-build.json" \
-        "scripts/build.sh build" "$SCHEME_NAME" Release "$DESTINATION" arm64 \
+        "$command_identity" "$SCHEME_NAME" Release "$DESTINATION" arm64 \
         Onone "$signing_class" "$DERIVED_DATA" "$SOURCE_PACKAGES_DIR"
     echo "==> Build ready: $APP_BUNDLE"
     prune_stale_builds
+}
+
+cmd_codeql_prepare() {
+    DESTINATION="$CODEQL_DESTINATION"
+    prepare_build_inputs
+}
+
+cmd_codeql() {
+    DESTINATION="$CODEQL_DESTINATION"
+    build_app "scripts/build.sh codeql"
 }
 
 # Preserve this build's dSYMs (app + XPC service + any others) so
@@ -287,6 +307,12 @@ main() {
     case "$command" in
         build|debug)
             build_app
+            ;;
+        codeql-prepare)
+            cmd_codeql_prepare
+            ;;
+        codeql)
+            cmd_codeql
             ;;
         run)
             cmd_run "$@"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,7 +32,8 @@ SCHEME_NAME="QwenVoice"
 BUNDLE_ID="com.qwenvoice.app"
 DESTINATION="platform=macOS,arch=arm64"
 CODEQL_DESTINATION="generic/platform=macOS"
-CODEQL_EXCLUDE_METAL_SOURCES=0
+CODEQL_DERIVED_DATA="$QVOICE_SCRATCH_CI/codeql-macos"
+CODEQL_BUILD_PHASE="none"
 
 BUILD_DIR="$QVOICE_BUILD_ROOT"
 DERIVED_DATA="$QVOICE_XCODE_MACOS_DERIVED"
@@ -90,10 +91,17 @@ assert_mlx_metallibs() {
 
 build_app() {
     local command_identity="${1:-scripts/build.sh build}"
+    case "$CODEQL_BUILD_PHASE" in
+        none|prepare|trace) ;;
+        *)
+            echo "error: unsupported CodeQL build phase: $CODEQL_BUILD_PHASE" >&2
+            return 1
+            ;;
+    esac
     # Keep this array non-empty: macOS /bin/bash 3.2 treats expansion of an
     # empty array as an unbound variable under `set -u`.
     local -a build_tail=(build)
-    if [ "$CODEQL_EXCLUDE_METAL_SOURCES" = "1" ]; then
+    if [ "$CODEQL_BUILD_PHASE" = "trace" ]; then
         # CodeQL's translated tracing shell cannot execute Xcode 26's Metal
         # compiler. codeql-prepare has already built the exact native Metal
         # products in this DerivedData; exclude only their source files while
@@ -115,7 +123,9 @@ build_app() {
     else
         echo "==> Code signing identity: $signing_identity"
     fi
-    sync_dev_signing_cache "$signing_identity" "$XCODEBUILD_APP" "$APP_BUNDLE"
+    if [ "$CODEQL_BUILD_PHASE" = "none" ]; then
+        sync_dev_signing_cache "$signing_identity" "$XCODEBUILD_APP" "$APP_BUNDLE"
+    fi
 
     echo "==> Building $SCHEME_NAME (single config, -Onone dev build, $DESTINATION)..."
     xcb_run \
@@ -142,10 +152,23 @@ build_app() {
         echo "error: built app bundle not found at $XCODEBUILD_APP" >&2
         exit 1
     fi
+    if [ "$CODEQL_BUILD_PHASE" = "trace" ]; then
+        # This product intentionally excludes Metal sources so CodeQL's
+        # translated shell can trace Swift. Xcode removes the corresponding
+        # metallib as stale. It lives only in managed CI scratch, and the
+        # complete scratch app was already validated by codeql-prepare.
+        assert_macos_bundle_arm64_only "$XCODEBUILD_APP"
+        echo "==> CodeQL traced Swift build completed (analysis-only product)"
+        return 0
+    fi
     assert_mlx_metallibs "$XCODEBUILD_APP"
     assert_macos_bundle_arm64_only "$XCODEBUILD_APP"
     assert_signing_identity "$XCODEBUILD_APP" "$signing_identity"
     assert_signing_identity "$XCODEBUILD_APP/Contents/XPCServices/QwenVoiceEngineService.xpc" "$signing_identity"
+    if [ "$CODEQL_BUILD_PHASE" = "prepare" ]; then
+        echo "==> CodeQL native preparation completed (validated scratch product)"
+        return 0
+    fi
     if [ -e "$APP_BUNDLE" ] || [ -L "$APP_BUNDLE" ]; then
         quit_app_if_running
         rm -rf "$APP_BUNDLE"
@@ -171,8 +194,15 @@ build_app() {
     prune_stale_builds
 }
 
-cmd_codeql_prepare() {
+configure_codeql_build() {
+    CODEQL_BUILD_PHASE="$1"
     DESTINATION="$CODEQL_DESTINATION"
+    DERIVED_DATA="$CODEQL_DERIVED_DATA"
+    XCODEBUILD_APP="$DERIVED_DATA/Build/Products/Release/$APP_NAME.app"
+}
+
+cmd_codeql_prepare() {
+    configure_codeql_build prepare
     build_app "scripts/build.sh codeql-prepare"
 }
 
@@ -194,8 +224,7 @@ touch_codeql_sources() {
 }
 
 cmd_codeql() {
-    DESTINATION="$CODEQL_DESTINATION"
-    CODEQL_EXCLUDE_METAL_SOURCES=1
+    configure_codeql_build trace
     # The native prebuild materializes MLX's Metal outputs. Only owned Swift
     # needs to be newer for the translated CodeQL shell, whose tracer cannot
     # execute Xcode 26's optional Metal compiler.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,6 +32,7 @@ SCHEME_NAME="QwenVoice"
 BUNDLE_ID="com.qwenvoice.app"
 DESTINATION="platform=macOS,arch=arm64"
 CODEQL_DESTINATION="generic/platform=macOS"
+CODEQL_EXCLUDE_METAL_SOURCES=0
 
 BUILD_DIR="$QVOICE_BUILD_ROOT"
 DERIVED_DATA="$QVOICE_XCODE_MACOS_DERIVED"
@@ -74,8 +75,31 @@ prepare_build_inputs() {
         dev QwenVoice Release "$DESTINATION"
 }
 
+assert_mlx_metallibs() {
+    local app_bundle="$1"
+    local relative_path
+    for relative_path in \
+        "Contents/Resources/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib" \
+        "Contents/XPCServices/QwenVoiceEngineService.xpc/Contents/Resources/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib"; do
+        if [ ! -s "$app_bundle/$relative_path" ]; then
+            echo "error: required native MLX Metal library is missing or empty: $app_bundle/$relative_path" >&2
+            return 1
+        fi
+    done
+}
+
 build_app() {
     local command_identity="${1:-scripts/build.sh build}"
+    # Keep this array non-empty: macOS /bin/bash 3.2 treats expansion of an
+    # empty array as an unbound variable under `set -u`.
+    local -a build_tail=(build)
+    if [ "$CODEQL_EXCLUDE_METAL_SOURCES" = "1" ]; then
+        # CodeQL's translated tracing shell cannot execute Xcode 26's Metal
+        # compiler. codeql-prepare has already built the exact native Metal
+        # products in this DerivedData; exclude only their source files while
+        # the tracing shell recompiles repository-owned Swift.
+        build_tail=('EXCLUDED_SOURCE_FILE_NAMES=*.metal' build)
+    fi
     prepare_build_inputs
 
     # Stable dev signing: a real Apple Development identity keeps the app's
@@ -112,12 +136,13 @@ build_app() {
         SWIFT_OPTIMIZATION_LEVEL="-Onone" \
         SWIFT_COMPILATION_MODE="incremental" \
         GCC_OPTIMIZATION_LEVEL="0" \
-        build
+        "${build_tail[@]}"
 
     if [ ! -d "$XCODEBUILD_APP" ]; then
         echo "error: built app bundle not found at $XCODEBUILD_APP" >&2
         exit 1
     fi
+    assert_mlx_metallibs "$XCODEBUILD_APP"
     assert_macos_bundle_arm64_only "$XCODEBUILD_APP"
     assert_signing_identity "$XCODEBUILD_APP" "$signing_identity"
     assert_signing_identity "$XCODEBUILD_APP/Contents/XPCServices/QwenVoiceEngineService.xpc" "$signing_identity"
@@ -170,6 +195,7 @@ touch_codeql_sources() {
 
 cmd_codeql() {
     DESTINATION="$CODEQL_DESTINATION"
+    CODEQL_EXCLUDE_METAL_SOURCES=1
     # The native prebuild materializes MLX's Metal outputs. Only owned Swift
     # needs to be newer for the translated CodeQL shell, whose tracer cannot
     # execute Xcode 26's optional Metal compiler.

--- a/scripts/supply_chain_contract.py
+++ b/scripts/supply_chain_contract.py
@@ -233,12 +233,17 @@ def validate(root: Path, installed: str | None = None) -> list[str]:
             errors.append(message)
     codeql_prepare_function = _shell_function(build_source, "cmd_codeql_prepare")
     if 'DESTINATION="$CODEQL_DESTINATION"' not in codeql_prepare_function \
-            or "prepare_build_inputs" not in codeql_prepare_function:
-        errors.append("CodeQL preparation must select the generic destination and prepare build inputs")
+            or 'build_app "scripts/build.sh codeql-prepare"' not in codeql_prepare_function:
+        errors.append("CodeQL preparation must select the generic destination and prebuild the app natively")
     codeql_build_function = _shell_function(build_source, "cmd_codeql")
     if 'DESTINATION="$CODEQL_DESTINATION"' not in codeql_build_function \
+            or "touch_codeql_sources" not in codeql_build_function \
             or 'build_app "scripts/build.sh codeql"' not in codeql_build_function:
-        errors.append("CodeQL build must select the generic destination and reuse the authoritative app build")
+        errors.append("CodeQL build must touch owned Swift and reuse the authoritative generic-destination app build")
+    touch_function = _shell_function(build_source, "touch_codeql_sources")
+    for source_root in ("$ROOT_DIR/Sources", "$ROOT_DIR/Packages/VocelloQwen3Core/Sources"):
+        if source_root not in touch_function:
+            errors.append(f"CodeQL traced rebuild does not cover owned Swift root: {source_root}")
 
     snapshot_path = root / "scripts/swift_dependency_snapshot.py"
     snapshot_source = snapshot_path.read_text(encoding="utf-8") if snapshot_path.is_file() else ""

--- a/scripts/supply_chain_contract.py
+++ b/scripts/supply_chain_contract.py
@@ -225,34 +225,103 @@ def validate(root: Path, installed: str | None = None) -> list[str]:
     for token, message in (
         ('DESTINATION="platform=macOS,arch=arm64"', "The ordinary macOS build destination must remain explicit"),
         ('CODEQL_DESTINATION="generic/platform=macOS"', "CodeQL must use the generic macOS destination"),
-        ("CODEQL_EXCLUDE_METAL_SOURCES=0", "Ordinary macOS builds must compile Metal sources"),
+        ('CODEQL_DERIVED_DATA="$QVOICE_SCRATCH_CI/codeql-macos"', "CodeQL must use managed CI scratch"),
+        ('CODEQL_BUILD_PHASE="none"', "Ordinary macOS builds must publish complete runnable products"),
         ("ARCHS=arm64", "CodeQL must emit arm64 products"),
         ("codeql-prepare)", "build.sh is missing the CodeQL preparation command"),
         ("codeql)", "build.sh is missing the traced CodeQL build command"),
     ):
         if token not in build_source:
             errors.append(message)
+    configure_function = _shell_function(build_source, "configure_codeql_build")
+    for token in (
+        'CODEQL_BUILD_PHASE="$1"',
+        'DESTINATION="$CODEQL_DESTINATION"',
+        'DERIVED_DATA="$CODEQL_DERIVED_DATA"',
+        'XCODEBUILD_APP="$DERIVED_DATA/Build/Products/Release/$APP_NAME.app"',
+    ):
+        if token not in configure_function:
+            errors.append(f"CodeQL scratch configuration is missing: {token}")
     codeql_prepare_function = _shell_function(build_source, "cmd_codeql_prepare")
-    if 'DESTINATION="$CODEQL_DESTINATION"' not in codeql_prepare_function \
+    if "configure_codeql_build prepare" not in codeql_prepare_function \
+            or "configure_codeql_build trace" in codeql_prepare_function \
             or 'build_app "scripts/build.sh codeql-prepare"' not in codeql_prepare_function:
-        errors.append("CodeQL preparation must select the generic destination and prebuild the app natively")
+        errors.append("CodeQL preparation must build and validate the complete app in managed scratch")
     codeql_build_function = _shell_function(build_source, "cmd_codeql")
-    if 'DESTINATION="$CODEQL_DESTINATION"' not in codeql_build_function \
-            or "CODEQL_EXCLUDE_METAL_SOURCES=1" not in codeql_build_function \
+    if "configure_codeql_build trace" not in codeql_build_function \
             or "touch_codeql_sources" not in codeql_build_function \
             or 'build_app "scripts/build.sh codeql"' not in codeql_build_function:
         errors.append(
-            "CodeQL build must exclude Metal sources, touch owned Swift, and reuse the authoritative "
-            "generic-destination app build"
+            "CodeQL build must select the isolated trace phase, touch owned Swift, and reuse managed scratch"
         )
     build_app_function = _shell_function(build_source, "build_app")
-    if 'if [ "$CODEQL_EXCLUDE_METAL_SOURCES" = "1" ]; then' not in build_app_function \
-            or "local -a build_tail=(build)" not in build_app_function \
-            or "build_tail=('EXCLUDED_SOURCE_FILE_NAMES=*.metal' build)" not in build_app_function \
+    build_tail_position = build_app_function.find("local -a build_tail=(build)")
+    sync_condition = 'if [ "$CODEQL_BUILD_PHASE" = "none" ]; then'
+    sync_position = build_app_function.find(sync_condition)
+    build_tail_block = build_app_function[build_tail_position:sync_position]
+    if build_tail_position < 0 or sync_position < 0 \
+            or 'if [ "$CODEQL_BUILD_PHASE" = "trace" ]; then' not in build_tail_block \
+            or "build_tail=('EXCLUDED_SOURCE_FILE_NAMES=*.metal' build)" not in build_tail_block \
             or '"${build_tail[@]}"' not in build_app_function:
         errors.append("CodeQL Metal exclusion must remain scoped to the dedicated traced build")
+    sync_call_position = build_app_function.find('sync_dev_signing_cache "$signing_identity" "$XCODEBUILD_APP" "$APP_BUNDLE"')
+    build_position = build_app_function.find('"${build_tail[@]}"')
+    sync_guard_match = re.search(
+        re.escape(sync_condition) + r"\s*\n(?P<body>.*?)(?m:^\s*fi\s*$)",
+        build_app_function[sync_position:build_position],
+        re.DOTALL,
+    )
+    if not (
+        0 <= sync_position < sync_call_position < build_position
+        and sync_guard_match is not None
+        and 'sync_dev_signing_cache "$signing_identity" "$XCODEBUILD_APP" "$APP_BUNDLE"'
+        in sync_guard_match.group("body")
+    ):
+        errors.append("CodeQL scratch phases must not synchronize or remove the public app product")
+
+    product_position = build_app_function.find('if [ ! -d "$XCODEBUILD_APP" ]; then', build_position)
+    trace_condition = 'if [ "$CODEQL_BUILD_PHASE" = "trace" ]; then'
+    trace_position = build_app_function.find(trace_condition, product_position)
+    metallib_position = build_app_function.find('assert_mlx_metallibs "$XCODEBUILD_APP"', trace_position)
+    trace_block = build_app_function[trace_position:metallib_position]
+    if not (
+        0 <= build_position < product_position < trace_position < metallib_position
+        and 'assert_macos_bundle_arm64_only "$XCODEBUILD_APP"' in trace_block
+        and "return 0" in trace_block
+    ):
+        errors.append("CodeQL trace phase must verify an arm64 product and stop only after the traced build succeeds")
+    for prohibited in (
+        "$APP_BUNDLE", "sync_dev_signing_cache", "preserve_dsyms",
+        "write_build_provenance", "record_dev_signing_identity", "ln -s", "rm -rf",
+    ):
+        if prohibited in trace_block:
+            errors.append(f"CodeQL trace phase contains a public-product mutation: {prohibited}")
+
+    normal_arch_position = build_app_function.find(
+        'assert_macos_bundle_arm64_only "$XCODEBUILD_APP"', metallib_position
+    )
+    signing_position = build_app_function.find(
+        'assert_signing_identity "$XCODEBUILD_APP" "$signing_identity"', normal_arch_position
+    )
+    prepare_condition = 'if [ "$CODEQL_BUILD_PHASE" = "prepare" ]; then'
+    prepare_position = build_app_function.find(prepare_condition, signing_position)
+    public_position = build_app_function.find('if [ -e "$APP_BUNDLE" ]', prepare_position)
+    prepare_block = build_app_function[prepare_position:public_position]
+    if not (
+        0 <= metallib_position < normal_arch_position < signing_position < prepare_position < public_position
+        and "return 0" in prepare_block
+    ):
+        errors.append(
+            "CodeQL preparation must validate Metal, arm64, and signing before stopping ahead of public staging"
+        )
+    for prohibited in (
+        "quit_app_if_running", "preserve_dsyms", "write_build_provenance",
+        "record_dev_signing_identity", "ln -s", "rm -rf",
+    ):
+        if prohibited in prepare_block:
+            errors.append(f"CodeQL preparation contains a public-product mutation: {prohibited}")
     if 'assert_mlx_metallibs "$XCODEBUILD_APP"' not in build_app_function:
-        errors.append("Every macOS app build must verify the required app and XPC MLX Metal libraries")
+        errors.append("Every runnable macOS app build must verify the required app and XPC MLX Metal libraries")
     metallib_function = _shell_function(build_source, "assert_mlx_metallibs")
     if 'if [ ! -s "$app_bundle/$relative_path" ]; then' not in metallib_function:
         errors.append("MLX Metal verification must fail closed for missing or empty libraries")

--- a/scripts/supply_chain_contract.py
+++ b/scripts/supply_chain_contract.py
@@ -225,6 +225,7 @@ def validate(root: Path, installed: str | None = None) -> list[str]:
     for token, message in (
         ('DESTINATION="platform=macOS,arch=arm64"', "The ordinary macOS build destination must remain explicit"),
         ('CODEQL_DESTINATION="generic/platform=macOS"', "CodeQL must use the generic macOS destination"),
+        ("CODEQL_EXCLUDE_METAL_SOURCES=0", "Ordinary macOS builds must compile Metal sources"),
         ("ARCHS=arm64", "CodeQL must emit arm64 products"),
         ("codeql-prepare)", "build.sh is missing the CodeQL preparation command"),
         ("codeql)", "build.sh is missing the traced CodeQL build command"),
@@ -237,9 +238,30 @@ def validate(root: Path, installed: str | None = None) -> list[str]:
         errors.append("CodeQL preparation must select the generic destination and prebuild the app natively")
     codeql_build_function = _shell_function(build_source, "cmd_codeql")
     if 'DESTINATION="$CODEQL_DESTINATION"' not in codeql_build_function \
+            or "CODEQL_EXCLUDE_METAL_SOURCES=1" not in codeql_build_function \
             or "touch_codeql_sources" not in codeql_build_function \
             or 'build_app "scripts/build.sh codeql"' not in codeql_build_function:
-        errors.append("CodeQL build must touch owned Swift and reuse the authoritative generic-destination app build")
+        errors.append(
+            "CodeQL build must exclude Metal sources, touch owned Swift, and reuse the authoritative "
+            "generic-destination app build"
+        )
+    build_app_function = _shell_function(build_source, "build_app")
+    if 'if [ "$CODEQL_EXCLUDE_METAL_SOURCES" = "1" ]; then' not in build_app_function \
+            or "local -a build_tail=(build)" not in build_app_function \
+            or "build_tail=('EXCLUDED_SOURCE_FILE_NAMES=*.metal' build)" not in build_app_function \
+            or '"${build_tail[@]}"' not in build_app_function:
+        errors.append("CodeQL Metal exclusion must remain scoped to the dedicated traced build")
+    if 'assert_mlx_metallibs "$XCODEBUILD_APP"' not in build_app_function:
+        errors.append("Every macOS app build must verify the required app and XPC MLX Metal libraries")
+    metallib_function = _shell_function(build_source, "assert_mlx_metallibs")
+    if 'if [ ! -s "$app_bundle/$relative_path" ]; then' not in metallib_function:
+        errors.append("MLX Metal verification must fail closed for missing or empty libraries")
+    for required_path in (
+        "Contents/Resources/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib",
+        "Contents/XPCServices/QwenVoiceEngineService.xpc/Contents/Resources/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib",
+    ):
+        if required_path not in metallib_function:
+            errors.append(f"MLX Metal verification is missing required bundle path: {required_path}")
     touch_function = _shell_function(build_source, "touch_codeql_sources")
     for source_root in ("$ROOT_DIR/Sources", "$ROOT_DIR/Packages/VocelloQwen3Core/Sources"):
         if source_root not in touch_function:

--- a/scripts/supply_chain_contract.py
+++ b/scripts/supply_chain_contract.py
@@ -187,6 +187,10 @@ def validate(root: Path, installed: str | None = None) -> list[str]:
             errors.append("Swift CodeQL must retain the macos-26 ARM runner")
         if "arch -arm64 /opt/homebrew/bin/brew install xcodegen xcbeautify ripgrep shellcheck" not in codeql:
             errors.append("Swift CodeQL tooling must invoke ARM Homebrew explicitly on the macos-26 runner")
+        if "xcodebuild -downloadComponent metalToolchain" not in codeql:
+            errors.append("Swift CodeQL must install Xcode 26's optional Metal Toolchain when absent")
+        if "xcrun metal --version" not in codeql:
+            errors.append("Swift CodeQL must verify the Metal compiler before initialization")
         if not re.search(r"(?m)^\s*(?:run:\s*)?\./scripts/build\.sh codeql-prepare\s*$", codeql):
             errors.append("Swift CodeQL must prepare generated inputs and packages before tracing")
         if not re.search(r"(?m)^\s*(?:run:\s*)?\./scripts/build\.sh codeql\s*$", codeql):

--- a/scripts/supply_chain_contract.py
+++ b/scripts/supply_chain_contract.py
@@ -33,6 +33,14 @@ def _job_permissions(job: str) -> list[str]:
     return [line.strip() for line in match.group(1).splitlines() if line.strip()]
 
 
+def _shell_function(text: str, name: str) -> str:
+    match = re.search(rf"(?m)^{re.escape(name)}\(\)\s*\{{\s*$", text)
+    if not match:
+        return ""
+    end = re.search(r"(?m)^}\s*$", text[match.end():])
+    return text[match.start():match.end() + end.end()] if end else ""
+
+
 def _tool_output(command: list[str]) -> str:
     try:
         return subprocess.check_output(command, stderr=subprocess.STDOUT, text=True)
@@ -179,10 +187,54 @@ def validate(root: Path, installed: str | None = None) -> list[str]:
             errors.append("Swift CodeQL must retain the macos-26 ARM runner")
         if "arch -arm64 /opt/homebrew/bin/brew install xcodegen xcbeautify ripgrep shellcheck" not in codeql:
             errors.append("Swift CodeQL tooling must invoke ARM Homebrew explicitly on the macos-26 runner")
-        if "arch -arm64 /bin/bash ./scripts/build.sh build" not in codeql:
-            errors.append("Swift CodeQL must invoke the authoritative macOS build through an ARM bash")
+        if not re.search(r"(?m)^\s*(?:run:\s*)?\./scripts/build\.sh codeql-prepare\s*$", codeql):
+            errors.append("Swift CodeQL must prepare generated inputs and packages before tracing")
+        if not re.search(r"(?m)^\s*(?:run:\s*)?\./scripts/build\.sh codeql\s*$", codeql):
+            errors.append("Swift CodeQL must invoke the authoritative traced build command")
+        if re.search(r"(?m)^\s*(?:run:\s*)?\./scripts/build\.sh build\s*$", codeql):
+            errors.append("Swift CodeQL must not substitute the ordinary local build command")
         if "./scripts/regenerate_project.sh" in codeql:
             errors.append("Swift CodeQL must let build.sh own project regeneration")
+        if "arch -arm64 /bin/bash ./scripts/build.sh" in codeql:
+            errors.append("Swift CodeQL compilation must remain inside the CodeQL tracing shell")
+        for step_name in ("Prepare Swift CodeQL build inputs", "Build Swift targets for CodeQL"):
+            if not re.search(
+                rf"(?m)^\s*- name: {re.escape(step_name)}\s*$\n\s+if: matrix\.language == 'swift'\s*$",
+                codeql,
+            ):
+                errors.append(f"{step_name} must remain Swift-only")
+        codeql_order = [
+            "Select and validate native toolchain",
+            "Prepare Swift CodeQL build inputs",
+            "Initialize CodeQL",
+            "Build Swift targets for CodeQL",
+            "Analyze",
+        ]
+        codeql_positions = [codeql.find(value) for value in codeql_order]
+        if any(value < 0 for value in codeql_positions) or codeql_positions != sorted(codeql_positions):
+            errors.append(
+                "Swift CodeQL must preserve toolchain -> prepare -> initialize -> traced build -> analyze ordering"
+            )
+
+    build_path = root / "scripts/build.sh"
+    build_source = build_path.read_text(encoding="utf-8") if build_path.is_file() else ""
+    for token, message in (
+        ('DESTINATION="platform=macOS,arch=arm64"', "The ordinary macOS build destination must remain explicit"),
+        ('CODEQL_DESTINATION="generic/platform=macOS"', "CodeQL must use the generic macOS destination"),
+        ("ARCHS=arm64", "CodeQL must emit arm64 products"),
+        ("codeql-prepare)", "build.sh is missing the CodeQL preparation command"),
+        ("codeql)", "build.sh is missing the traced CodeQL build command"),
+    ):
+        if token not in build_source:
+            errors.append(message)
+    codeql_prepare_function = _shell_function(build_source, "cmd_codeql_prepare")
+    if 'DESTINATION="$CODEQL_DESTINATION"' not in codeql_prepare_function \
+            or "prepare_build_inputs" not in codeql_prepare_function:
+        errors.append("CodeQL preparation must select the generic destination and prepare build inputs")
+    codeql_build_function = _shell_function(build_source, "cmd_codeql")
+    if 'DESTINATION="$CODEQL_DESTINATION"' not in codeql_build_function \
+            or 'build_app "scripts/build.sh codeql"' not in codeql_build_function:
+        errors.append("CodeQL build must select the generic destination and reuse the authoritative app build")
 
     snapshot_path = root / "scripts/swift_dependency_snapshot.py"
     snapshot_source = snapshot_path.read_text(encoding="utf-8") if snapshot_path.is_file() else ""

--- a/scripts/tests/test_supply_chain_contract.py
+++ b/scripts/tests/test_supply_chain_contract.py
@@ -82,10 +82,14 @@ jobs:
                 'ARCHS=arm64',
                 'cmd_codeql_prepare() {',
                 '  DESTINATION="$CODEQL_DESTINATION"',
-                '  prepare_build_inputs',
+                '  build_app "scripts/build.sh codeql-prepare"',
+                '}',
+                'touch_codeql_sources() {',
+                '  find "$ROOT_DIR/Sources" "$ROOT_DIR/Packages/VocelloQwen3Core/Sources" -name "*.swift" -exec touch {} +',
                 '}',
                 'cmd_codeql() {',
                 '  DESTINATION="$CODEQL_DESTINATION"',
+                '  touch_codeql_sources',
                 '  build_app "scripts/build.sh codeql"',
                 '}',
                 'case "${1:-}" in',
@@ -320,7 +324,22 @@ jobs:
             ),
             encoding="utf-8",
         )
-        self.assertTrue(any("CodeQL build must select" in value for value in module.validate(self.root)))
+        self.assertTrue(any("CodeQL build must touch" in value for value in module.validate(self.root)))
+
+    def test_swift_codeql_traced_build_must_invalidate_all_owned_swift(self) -> None:
+        path = self.root / "scripts/build.sh"
+        text = path.read_text(encoding="utf-8")
+        path.write_text(
+            text.replace('  touch_codeql_sources\n  build_app "scripts/build.sh codeql"', '  build_app "scripts/build.sh codeql"'),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("touch owned Swift" in value for value in module.validate(self.root)))
+
+        path.write_text(
+            text.replace('"$ROOT_DIR/Packages/VocelloQwen3Core/Sources"', '"$ROOT_DIR/Packages/Other/Sources"'),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("VocelloQwen3Core/Sources" in value for value in module.validate(self.root)))
 
     def test_swift_codeql_special_steps_must_remain_swift_only(self) -> None:
         path = self.root / ".github/workflows/security.yml"

--- a/scripts/tests/test_supply_chain_contract.py
+++ b/scripts/tests/test_supply_chain_contract.py
@@ -58,7 +58,12 @@ jobs:
     runner: macos-26
     steps:
       - name: Select and validate native toolchain
-        run: arch -arm64 /opt/homebrew/bin/brew install xcodegen xcbeautify ripgrep shellcheck
+        run: |
+          arch -arm64 /opt/homebrew/bin/brew install xcodegen xcbeautify ripgrep shellcheck
+          if ! xcrun metal --version >/dev/null 2>&1; then
+            xcodebuild -downloadComponent metalToolchain
+          fi
+          xcrun metal --version
       - name: Prepare Swift CodeQL build inputs
         if: matrix.language == 'swift'
         run: ./scripts/build.sh codeql-prepare
@@ -235,6 +240,18 @@ jobs:
         self.assertTrue(any("ARM Homebrew" in value for value in module.validate(self.root)))
         path.write_text(text.replace("runner: macos-26", "runner: macos-15"), encoding="utf-8")
         self.assertTrue(any("macos-26 ARM runner" in value for value in module.validate(self.root)))
+
+    def test_swift_codeql_requires_the_optional_metal_toolchain(self) -> None:
+        path = self.root / ".github/workflows/security.yml"
+        text = path.read_text(encoding="utf-8")
+        path.write_text(
+            text.replace("xcodebuild -downloadComponent metalToolchain", "echo skip-metal-download"),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("optional Metal Toolchain" in value for value in module.validate(self.root)))
+
+        path.write_text(text.replace("xcrun metal --version", "true"), encoding="utf-8")
+        self.assertTrue(any("verify the Metal compiler" in value for value in module.validate(self.root)))
 
     def test_swift_codeql_build_must_remain_inside_tracing_shell(self) -> None:
         path = self.root / ".github/workflows/security.yml"

--- a/scripts/tests/test_supply_chain_contract.py
+++ b/scripts/tests/test_supply_chain_contract.py
@@ -57,10 +57,39 @@ jobs:
   codeql:
     runner: macos-26
     steps:
-      - run: arch -arm64 /opt/homebrew/bin/brew install xcodegen xcbeautify ripgrep shellcheck
-      - run: arch -arm64 /bin/bash ./scripts/build.sh build
+      - name: Select and validate native toolchain
+        run: arch -arm64 /opt/homebrew/bin/brew install xcodegen xcbeautify ripgrep shellcheck
+      - name: Prepare Swift CodeQL build inputs
+        if: matrix.language == 'swift'
+        run: ./scripts/build.sh codeql-prepare
+      - name: Initialize CodeQL
+      - name: Build Swift targets for CodeQL
+        if: matrix.language == 'swift'
+        run: ./scripts/build.sh codeql
+      - name: Analyze
 """ % self.sha
         (self.root / ".github/workflows/security.yml").write_text(security, encoding="utf-8")
+        (self.root / "scripts/build.sh").write_text(
+            '\n'.join((
+                '#!/usr/bin/env bash',
+                'DESTINATION="platform=macOS,arch=arm64"',
+                'CODEQL_DESTINATION="generic/platform=macOS"',
+                'ARCHS=arm64',
+                'cmd_codeql_prepare() {',
+                '  DESTINATION="$CODEQL_DESTINATION"',
+                '  prepare_build_inputs',
+                '}',
+                'cmd_codeql() {',
+                '  DESTINATION="$CODEQL_DESTINATION"',
+                '  build_app "scripts/build.sh codeql"',
+                '}',
+                'case "${1:-}" in',
+                '  codeql-prepare) ;;',
+                '  codeql) ;;',
+                'esac',
+            )),
+            encoding="utf-8",
+        )
         (self.root / ".github/dependabot.yml").write_text(
             '\n'.join(f'package-ecosystem: "{value}"' for value in ("github-actions", "npm", "swift")),
             encoding="utf-8",
@@ -207,25 +236,94 @@ jobs:
         path.write_text(text.replace("runner: macos-26", "runner: macos-15"), encoding="utf-8")
         self.assertTrue(any("macos-26 ARM runner" in value for value in module.validate(self.root)))
 
-    def test_swift_codeql_build_must_run_natively_without_duplicate_regeneration(self) -> None:
+    def test_swift_codeql_build_must_remain_inside_tracing_shell(self) -> None:
         path = self.root / ".github/workflows/security.yml"
         text = path.read_text(encoding="utf-8")
         path.write_text(
             text.replace(
-                "arch -arm64 /bin/bash ./scripts/build.sh build",
-                "./scripts/build.sh build",
+                "run: ./scripts/build.sh codeql\n",
+                "run: arch -arm64 /bin/bash ./scripts/build.sh codeql\n",
             ),
             encoding="utf-8",
         )
         self.assertTrue(any(
-            "authoritative macOS build through an ARM bash" in value
+            "inside the CodeQL tracing shell" in value
             for value in module.validate(self.root)
         ))
 
+    def test_swift_codeql_preparation_is_required_before_initialization(self) -> None:
+        path = self.root / ".github/workflows/security.yml"
+        text = path.read_text(encoding="utf-8")
+        prepare = (
+            "      - name: Prepare Swift CodeQL build inputs\n"
+            "        if: matrix.language == 'swift'\n"
+            "        run: ./scripts/build.sh codeql-prepare\n"
+        )
+        initialize = "      - name: Initialize CodeQL\n"
+        path.write_text(text.replace(prepare + initialize, initialize + prepare), encoding="utf-8")
+        self.assertTrue(any("toolchain -> prepare -> initialize" in value for value in module.validate(self.root)))
+
+    def test_swift_codeql_must_use_dedicated_traced_build_command(self) -> None:
+        path = self.root / ".github/workflows/security.yml"
+        text = path.read_text(encoding="utf-8")
+        path.write_text(
+            text.replace("run: ./scripts/build.sh codeql\n", "run: ./scripts/build.sh build\n"),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("authoritative traced build" in value for value in module.validate(self.root)))
+
+    def test_swift_codeql_must_use_generic_arm64_build_contract(self) -> None:
+        path = self.root / "scripts/build.sh"
+        text = path.read_text(encoding="utf-8")
+        path.write_text(
+            text.replace('CODEQL_DESTINATION="generic/platform=macOS"', 'CODEQL_DESTINATION="platform=macOS,arch=arm64"'),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("generic macOS destination" in value for value in module.validate(self.root)))
+
+        path.write_text(text.replace("ARCHS=arm64", "ARCHS=x86_64"), encoding="utf-8")
+        self.assertTrue(any("emit arm64 products" in value for value in module.validate(self.root)))
+
+    def test_swift_codeql_commands_must_each_select_the_generic_destination(self) -> None:
+        path = self.root / "scripts/build.sh"
+        text = path.read_text(encoding="utf-8")
         path.write_text(
             text.replace(
-                "arch -arm64 /bin/bash ./scripts/build.sh build",
-                "./scripts/regenerate_project.sh\n      - run: arch -arm64 /bin/bash ./scripts/build.sh build",
+                'cmd_codeql_prepare() {\n  DESTINATION="$CODEQL_DESTINATION"',
+                'cmd_codeql_prepare() {\n  DESTINATION="$DESTINATION"',
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("CodeQL preparation must select" in value for value in module.validate(self.root)))
+
+        path.write_text(
+            text.replace(
+                'cmd_codeql() {\n  DESTINATION="$CODEQL_DESTINATION"',
+                'cmd_codeql() {\n  DESTINATION="$DESTINATION"',
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("CodeQL build must select" in value for value in module.validate(self.root)))
+
+    def test_swift_codeql_special_steps_must_remain_swift_only(self) -> None:
+        path = self.root / ".github/workflows/security.yml"
+        text = path.read_text(encoding="utf-8")
+        path.write_text(
+            text.replace(
+                "      - name: Prepare Swift CodeQL build inputs\n        if: matrix.language == 'swift'\n",
+                "      - name: Prepare Swift CodeQL build inputs\n",
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("build inputs must remain Swift-only" in value for value in module.validate(self.root)))
+
+    def test_swift_codeql_must_not_duplicate_project_regeneration(self) -> None:
+        path = self.root / ".github/workflows/security.yml"
+        text = path.read_text(encoding="utf-8")
+        path.write_text(
+            text.replace(
+                "run: ./scripts/build.sh codeql-prepare",
+                "run: ./scripts/regenerate_project.sh\n      - run: ./scripts/build.sh codeql-prepare",
             ),
             encoding="utf-8",
         )

--- a/scripts/tests/test_supply_chain_contract.py
+++ b/scripts/tests/test_supply_chain_contract.py
@@ -79,7 +79,8 @@ jobs:
                 '#!/usr/bin/env bash',
                 'DESTINATION="platform=macOS,arch=arm64"',
                 'CODEQL_DESTINATION="generic/platform=macOS"',
-                'CODEQL_EXCLUDE_METAL_SOURCES=0',
+                'CODEQL_DERIVED_DATA="$QVOICE_SCRATCH_CI/codeql-macos"',
+                'CODEQL_BUILD_PHASE="none"',
                 'ARCHS=arm64',
                 'assert_mlx_metallibs() {',
                 '  local app_bundle="$1"',
@@ -92,22 +93,50 @@ jobs:
                 '}',
                 'build_app() {',
                 '  local -a build_tail=(build)',
-                '  if [ "$CODEQL_EXCLUDE_METAL_SOURCES" = "1" ]; then',
+                '  if [ "$CODEQL_BUILD_PHASE" = "trace" ]; then',
                 "    build_tail=('EXCLUDED_SOURCE_FILE_NAMES=*.metal' build)",
                 '  fi',
+                '  if [ "$CODEQL_BUILD_PHASE" = "none" ]; then',
+                '    sync_dev_signing_cache "$signing_identity" "$XCODEBUILD_APP" "$APP_BUNDLE"',
+                '  fi',
                 '  echo "${build_tail[@]}"',
+                '  if [ ! -d "$XCODEBUILD_APP" ]; then',
+                '    return 1',
+                '  fi',
+                '  if [ "$CODEQL_BUILD_PHASE" = "trace" ]; then',
+                '    assert_macos_bundle_arm64_only "$XCODEBUILD_APP"',
+                '    return 0',
+                '  fi',
                 '  assert_mlx_metallibs "$XCODEBUILD_APP"',
+                '  assert_macos_bundle_arm64_only "$XCODEBUILD_APP"',
+                '  assert_signing_identity "$XCODEBUILD_APP" "$signing_identity"',
+                '  if [ "$CODEQL_BUILD_PHASE" = "prepare" ]; then',
+                '    return 0',
+                '  fi',
+                '  if [ -e "$APP_BUNDLE" ] || [ -L "$APP_BUNDLE" ]; then',
+                '    quit_app_if_running',
+                '    rm -rf "$APP_BUNDLE"',
+                '  fi',
+                '  ln -s "$XCODEBUILD_APP" "$APP_BUNDLE"',
+                '  preserve_dsyms',
+                '  write_build_provenance',
+                '  record_dev_signing_identity',
+                '}',
+                'configure_codeql_build() {',
+                '  CODEQL_BUILD_PHASE="$1"',
+                '  DESTINATION="$CODEQL_DESTINATION"',
+                '  DERIVED_DATA="$CODEQL_DERIVED_DATA"',
+                '  XCODEBUILD_APP="$DERIVED_DATA/Build/Products/Release/$APP_NAME.app"',
                 '}',
                 'cmd_codeql_prepare() {',
-                '  DESTINATION="$CODEQL_DESTINATION"',
+                '  configure_codeql_build prepare',
                 '  build_app "scripts/build.sh codeql-prepare"',
                 '}',
                 'touch_codeql_sources() {',
                 '  find "$ROOT_DIR/Sources" "$ROOT_DIR/Packages/VocelloQwen3Core/Sources" -name "*.swift" -exec touch {} +',
                 '}',
                 'cmd_codeql() {',
-                '  DESTINATION="$CODEQL_DESTINATION"',
-                '  CODEQL_EXCLUDE_METAL_SOURCES=1',
+                '  configure_codeql_build trace',
                 '  touch_codeql_sources',
                 '  build_app "scripts/build.sh codeql"',
                 '}',
@@ -329,21 +358,23 @@ jobs:
         text = path.read_text(encoding="utf-8")
         path.write_text(
             text.replace(
-                'cmd_codeql_prepare() {\n  DESTINATION="$CODEQL_DESTINATION"',
-                'cmd_codeql_prepare() {\n  DESTINATION="$DESTINATION"',
+                "  configure_codeql_build prepare\n",
+                "  configure_codeql_build trace\n",
+                1,
             ),
             encoding="utf-8",
         )
-        self.assertTrue(any("CodeQL preparation must select" in value for value in module.validate(self.root)))
+        self.assertTrue(any("preparation must build and validate" in value for value in module.validate(self.root)))
 
         path.write_text(
             text.replace(
-                'cmd_codeql() {\n  DESTINATION="$CODEQL_DESTINATION"',
-                'cmd_codeql() {\n  DESTINATION="$DESTINATION"',
+                "  configure_codeql_build trace\n",
+                "  configure_codeql_build prepare\n",
+                1,
             ),
             encoding="utf-8",
         )
-        self.assertTrue(any("CodeQL build must" in value for value in module.validate(self.root)))
+        self.assertTrue(any("CodeQL build must select" in value for value in module.validate(self.root)))
 
     def test_swift_codeql_traced_build_must_invalidate_all_owned_swift(self) -> None:
         path = self.root / "scripts/build.sh"
@@ -364,31 +395,117 @@ jobs:
         path = self.root / "scripts/build.sh"
         text = path.read_text(encoding="utf-8")
         path.write_text(
-            text.replace("  CODEQL_EXCLUDE_METAL_SOURCES=1\n", ""),
+            text.replace("  configure_codeql_build trace\n", ""),
             encoding="utf-8",
         )
-        self.assertTrue(any("exclude Metal sources" in value for value in module.validate(self.root)))
+        self.assertTrue(any("isolated trace phase" in value for value in module.validate(self.root)))
 
         path.write_text(
             text.replace(
-                '  if [ "$CODEQL_EXCLUDE_METAL_SOURCES" = "1" ]; then',
+                '  if [ "$CODEQL_BUILD_PHASE" = "trace" ]; then',
                 '  if true; then',
+                1,
             ),
             encoding="utf-8",
         )
         self.assertTrue(any("scoped to the dedicated traced build" in value for value in module.validate(self.root)))
 
         path.write_text(
-            text.replace("CODEQL_EXCLUDE_METAL_SOURCES=0", "CODEQL_EXCLUDE_METAL_SOURCES=1"),
+            text.replace('CODEQL_BUILD_PHASE="none"', 'CODEQL_BUILD_PHASE="trace"'),
             encoding="utf-8",
         )
-        self.assertTrue(any("Ordinary macOS builds must compile Metal" in value for value in module.validate(self.root)))
+        self.assertTrue(any("complete runnable products" in value for value in module.validate(self.root)))
+
+        path.write_text(
+            text.replace(
+                'CODEQL_DERIVED_DATA="$QVOICE_SCRATCH_CI/codeql-macos"',
+                'CODEQL_DERIVED_DATA="$QVOICE_XCODE_MACOS_DERIVED"',
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("managed CI scratch" in value for value in module.validate(self.root)))
 
         path.write_text(
             text.replace("  local -a build_tail=(build)\n", "  local -a build_tail=()\n"),
             encoding="utf-8",
         )
         self.assertTrue(any("scoped to the dedicated traced build" in value for value in module.validate(self.root)))
+
+    def test_swift_codeql_scratch_phases_cannot_mutate_public_products(self) -> None:
+        path = self.root / "scripts/build.sh"
+        text = path.read_text(encoding="utf-8")
+
+        path.write_text(
+            text.replace(
+                '  if [ "$CODEQL_BUILD_PHASE" = "none" ]; then',
+                '  if true; then',
+                1,
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("must not synchronize" in value for value in module.validate(self.root)))
+
+        path.write_text(
+            text.replace(
+                '  if [ "$CODEQL_BUILD_PHASE" = "none" ]; then\n'
+                '    sync_dev_signing_cache "$signing_identity" "$XCODEBUILD_APP" "$APP_BUNDLE"\n'
+                '  fi\n',
+                '  if [ "$CODEQL_BUILD_PHASE" = "none" ]; then\n'
+                '    true\n'
+                '  fi\n'
+                '  sync_dev_signing_cache "$signing_identity" "$XCODEBUILD_APP" "$APP_BUNDLE"\n',
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("must not synchronize" in value for value in module.validate(self.root)))
+
+        path.write_text(
+            text.replace(
+                '    assert_macos_bundle_arm64_only "$XCODEBUILD_APP"\n    return 0\n',
+                '    assert_macos_bundle_arm64_only "$XCODEBUILD_APP"\n    rm -rf "$APP_BUNDLE"\n    return 0\n',
+                1,
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("trace phase contains a public-product mutation" in value for value in module.validate(self.root)))
+
+        path.write_text(
+            text.replace(
+                '  if [ "$CODEQL_BUILD_PHASE" = "prepare" ]; then\n    return 0\n',
+                '  if [ "$CODEQL_BUILD_PHASE" = "prepare" ]; then\n    preserve_dsyms\n    return 0\n',
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("preparation contains a public-product mutation" in value for value in module.validate(self.root)))
+
+    def test_swift_codeql_scratch_phases_validate_before_returning(self) -> None:
+        path = self.root / "scripts/build.sh"
+        text = path.read_text(encoding="utf-8")
+
+        path.write_text(
+            text.replace('  if [ ! -d "$XCODEBUILD_APP" ]; then\n    return 1\n  fi\n', ""),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("only after the traced build succeeds" in value for value in module.validate(self.root)))
+
+        path.write_text(
+            text.replace(
+                '    assert_macos_bundle_arm64_only "$XCODEBUILD_APP"\n',
+                "    true\n",
+                1,
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("verify an arm64 product" in value for value in module.validate(self.root)))
+
+        path.write_text(
+            text.replace(
+                '  if [ "$CODEQL_BUILD_PHASE" = "prepare" ]; then\n    return 0\n',
+                '  if [ "$CODEQL_BUILD_PHASE" = "prepare" ]; then\n    true\n',
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("preparation must validate Metal" in value for value in module.validate(self.root)))
 
     def test_swift_codeql_must_verify_prebuilt_metal_libraries(self) -> None:
         path = self.root / "scripts/build.sh"

--- a/scripts/tests/test_supply_chain_contract.py
+++ b/scripts/tests/test_supply_chain_contract.py
@@ -79,7 +79,25 @@ jobs:
                 '#!/usr/bin/env bash',
                 'DESTINATION="platform=macOS,arch=arm64"',
                 'CODEQL_DESTINATION="generic/platform=macOS"',
+                'CODEQL_EXCLUDE_METAL_SOURCES=0',
                 'ARCHS=arm64',
+                'assert_mlx_metallibs() {',
+                '  local app_bundle="$1"',
+                '  local relative_path',
+                '  for relative_path in "Contents/Resources/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib" "Contents/XPCServices/QwenVoiceEngineService.xpc/Contents/Resources/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib"; do',
+                '    if [ ! -s "$app_bundle/$relative_path" ]; then',
+                '      return 1',
+                '    fi',
+                '  done',
+                '}',
+                'build_app() {',
+                '  local -a build_tail=(build)',
+                '  if [ "$CODEQL_EXCLUDE_METAL_SOURCES" = "1" ]; then',
+                "    build_tail=('EXCLUDED_SOURCE_FILE_NAMES=*.metal' build)",
+                '  fi',
+                '  echo "${build_tail[@]}"',
+                '  assert_mlx_metallibs "$XCODEBUILD_APP"',
+                '}',
                 'cmd_codeql_prepare() {',
                 '  DESTINATION="$CODEQL_DESTINATION"',
                 '  build_app "scripts/build.sh codeql-prepare"',
@@ -89,6 +107,7 @@ jobs:
                 '}',
                 'cmd_codeql() {',
                 '  DESTINATION="$CODEQL_DESTINATION"',
+                '  CODEQL_EXCLUDE_METAL_SOURCES=1',
                 '  touch_codeql_sources',
                 '  build_app "scripts/build.sh codeql"',
                 '}',
@@ -324,7 +343,7 @@ jobs:
             ),
             encoding="utf-8",
         )
-        self.assertTrue(any("CodeQL build must touch" in value for value in module.validate(self.root)))
+        self.assertTrue(any("CodeQL build must" in value for value in module.validate(self.root)))
 
     def test_swift_codeql_traced_build_must_invalidate_all_owned_swift(self) -> None:
         path = self.root / "scripts/build.sh"
@@ -340,6 +359,60 @@ jobs:
             encoding="utf-8",
         )
         self.assertTrue(any("VocelloQwen3Core/Sources" in value for value in module.validate(self.root)))
+
+    def test_swift_codeql_metal_exclusion_is_traced_build_only(self) -> None:
+        path = self.root / "scripts/build.sh"
+        text = path.read_text(encoding="utf-8")
+        path.write_text(
+            text.replace("  CODEQL_EXCLUDE_METAL_SOURCES=1\n", ""),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("exclude Metal sources" in value for value in module.validate(self.root)))
+
+        path.write_text(
+            text.replace(
+                '  if [ "$CODEQL_EXCLUDE_METAL_SOURCES" = "1" ]; then',
+                '  if true; then',
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("scoped to the dedicated traced build" in value for value in module.validate(self.root)))
+
+        path.write_text(
+            text.replace("CODEQL_EXCLUDE_METAL_SOURCES=0", "CODEQL_EXCLUDE_METAL_SOURCES=1"),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("Ordinary macOS builds must compile Metal" in value for value in module.validate(self.root)))
+
+        path.write_text(
+            text.replace("  local -a build_tail=(build)\n", "  local -a build_tail=()\n"),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("scoped to the dedicated traced build" in value for value in module.validate(self.root)))
+
+    def test_swift_codeql_must_verify_prebuilt_metal_libraries(self) -> None:
+        path = self.root / "scripts/build.sh"
+        text = path.read_text(encoding="utf-8")
+        path.write_text(
+            text.replace('  assert_mlx_metallibs "$XCODEBUILD_APP"\n', ""),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("must verify the required" in value for value in module.validate(self.root)))
+
+        path.write_text(
+            text.replace(
+                "Contents/XPCServices/QwenVoiceEngineService.xpc/Contents/Resources/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib",
+                "Contents/XPCServices/QwenVoiceEngineService.xpc/missing.metallib",
+            ),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("XPCServices" in value for value in module.validate(self.root)))
+
+        path.write_text(
+            text.replace('if [ ! -s "$app_bundle/$relative_path" ]; then', 'if [ ! -e "$app_bundle/$relative_path" ]; then'),
+            encoding="utf-8",
+        )
+        self.assertTrue(any("fail closed" in value for value in module.validate(self.root)))
 
     def test_swift_codeql_special_steps_must_remain_swift_only(self) -> None:
         path = self.root / ".github/workflows/security.yml"


### PR DESCRIPTION
## Summary

- restore traced Swift CodeQL builds on the native macOS 26 ARM runner
- install the optional Xcode Metal toolchain and perform a native preparation build in managed scratch
- rebuild all owned Swift under CodeQL tracing while preserving native Metal outputs and leaving canonical developer products untouched
- enforce the workflow through fail-closed supply-chain contracts and regression tests

## Verification

- `./scripts/check_project_inputs.sh` — PASS (473 deterministic tests)
- `python3 -m unittest scripts.tests.test_supply_chain_contract` — PASS (27 tests)
- `python3 scripts/supply_chain_contract.py` — PASS
- branch Security workflow — PASS: https://github.com/PowerBeef/QwenVoice/actions/runs/29568947884
  - Swift CodeQL traced build and Analyze passed
  - JavaScript/TypeScript CodeQL passed
  - Swift dependency submission passed
  - npm advisory audit passed

No device, model, UI, or benchmark lane is required for this CI-only security repair.