### PR TITLE
Record merged runtime convergence checkpoint

### DIFF
--- a/docs/development-progress.md
+++ b/docs/development-progress.md
@@ -10,7 +10,10 @@ This checkpoint covers runtime source commit
 the physical iPhone. “Implementation complete” below means source authority has changed and the
 named focused proof has passed; it does not mean the full convergence program or overall runtime
 promotion has passed. `config/runtime-refactor-contract.json` is the machine-readable status
-record.
+record. The checkpoint was delivered to protected `main` by [PR #78](https://github.com/PowerBeef/QwenVoice/pull/78)
+as merge commit `d39b9a6f2f2cedd4c02a1114c7a127e645029cb7`; all nine GitHub checks passed. The
+follow-up NumPy toolchain pin in that pull request fixes fresh-runner prosody-test setup and does not
+change runtime or promotion evidence.
 
 | Plan phase | Current state |
 | --- | --- |
@@ -51,22 +54,22 @@ controls or a full canonical matrix.
 
 ### Next convergence checkpoint
 
-Proceed in this order so later performance evidence is not recorded against transitional
-telemetry or an incompletely qualified sampling contract:
+The Phase 1–4 checkpoint is now on protected `main`. Proceed in this order so later performance
+evidence is not recorded against transitional telemetry or an incompletely qualified sampling
+contract:
 
-1. Merge the Phase 1–4 checkpoint into protected `main` after deterministic CI passes.
-2. Close Phase 5 evidence: require sampling algorithm v2 and planned/observed seed agreement,
+1. Close Phase 5 evidence: require sampling algorithm v2 and planned/observed seed agreement,
    publish the privacy-safe take seed and WAV digest, add fail-closed missing/mismatch fixtures,
    and define versioned domain-separated sub-seed derivation for later long-form and candidate
    work.
-3. Run fixed-seed repeat pairs for Custom, Design, and Clone on the macOS CLI and physical-iPhone
+2. Run fixed-seed repeat pairs for Custom, Design, and Clone on the macOS CLI and physical-iPhone
    headless lane. Equal seeds must preserve token/chunk/PCM identity; changed seeds must diverge
    while retaining QC, memory, and crash safety.
-4. Complete Phase 6 telemetry v9 writer, merger, validators, and PASS-only publication, then run
+3. Complete Phase 6 telemetry v9 writer, merger, validators, and PASS-only publication, then run
    focused v9 UI pilots on both platforms.
-5. Finish Phase 0 characterization with at least three clean control sessions and, for each
+4. Finish Phase 0 characterization with at least three clean control sessions and, for each
    applicable promoted cell, at least ten warm and three cold observations.
-6. Only then run fresh full 29-take macOS and physical-iPhone matrices. Running them before the
+5. Only then run fresh full 29-take macOS and physical-iPhone matrices. Running them before the
    Phase 5/6 closures would create transitional schema-v8 evidence that must be repeated.
 
 Shipping long-form sub-seed execution remains Phase 11, candidate retry remains Phase 12, and


### PR DESCRIPTION
## Summary
- record PR #78 and its merge commit as the delivered Phase 1-4 checkpoint
- remove the now-completed merge step from the active convergence sequence
- keep Phase 5 sampling evidence and Phase 6 telemetry publication as the next authoritative work

## Verification
- git diff --check
- python3 scripts/documentation_contract.py
- ./scripts/check_project_inputs.sh