### PR TITLE
docs(readme): add live lifetime-downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 <p align="center">
   <a href="https://vocello.vercel.app/"><img src="https://img.shields.io/badge/Website-vocello.vercel.app-7b61ff?style=flat-square&logo=vercel" alt="Website"></a>
   <a href="https://github.com/PowerBeef/Vocello/releases/tag/v2.2.2"><img src="https://img.shields.io/badge/Vocello-2.2.2-7b61ff?style=flat-square" alt="Vocello 2.2.2"></a>
+  <a href="https://github.com/PowerBeef/Vocello/releases"><img src="https://img.shields.io/github/downloads/PowerBeef/Vocello/total?style=flat-square&label=downloads&color=7b61ff&logo=github&logoColor=white" alt="Lifetime downloads across all GitHub releases"></a>
   <img src="https://img.shields.io/badge/macOS-26%2B-111827?style=flat-square&logo=apple" alt="macOS 26 or newer">
   <a href="https://testflight.apple.com/join/Cvp6yCv7"><img src="https://img.shields.io/badge/iPhone-TestFlight%20beta-7b61ff?style=flat-square&logo=apple" alt="iPhone TestFlight beta"></a>
   <img src="https://img.shields.io/badge/Apple%20Silicon-required-111827?style=flat-square&logo=apple" alt="Apple Silicon required">


### PR DESCRIPTION
## Summary

Adds a live lifetime-downloads badge to the README badge row. The badge uses the shields.io GitHub downloads endpoint (`github/downloads/PowerBeef/Vocello/total`), so it automatically tracks and displays the cumulative download count across all release assets (every published DMG, past and future) with no maintenance required. It links to the releases page and matches the existing flat-square brand styling (`7b61ff`, white GitHub logo).

Note the count covers GitHub release assets only — TestFlight installs are not exposed by any public API and cannot be included.

## Verification

- [x] Relevant deterministic repository checks pass. The T1 quick-gate checks were run in this environment: all pass except `project_health.py rebuild-summary --check`, which is irreproducible in this Linux/shallow-clone container regardless of this change (it fails identically on the untouched tree, since the tracked snapshot is generated on macOS). Every other contract, wiring, privacy, and link check passes; this is a README-only change, so the path-aware CI router applies its docs-only handling by design.
- [x] Generated project or indexes were regenerated and checked when their inputs changed — no generated inputs changed (single README badge line).
- [x] Model-, device-, and UI-dependent QA is listed separately and is not treated as a publishing prerequisite — none applicable.

## Documentation impact

- [x] Active docs and role guidance still match source, `project.yml`, scripts, and machine-readable contracts — no doc semantics changed.
- [x] Vendor-runtime changes update `VENDOR_MANIFEST.json`, `PATCHES.json`, tests, and current guidance as applicable — not applicable.
- [x] Telemetry or benchmark schema changes received backend, affected-platform, and release/QA review — not applicable.
- [x] Public product claims were checked against `config/public-product-facts.json`, the model contract, hardware profiles, and tracked benchmark evidence — the badge renders GitHub's own release-asset download data live; no static claim is added.
- [x] Historical snapshots remain clearly labelled and were not rewritten as active runbooks — not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016BS6yBaQmTo5T6RDuTx86i

---
_Generated by [Claude Code](https://claude.ai/code/session_016BS6yBaQmTo5T6RDuTx86i)_