### PR TITLE
docs: state public throughput as N× realtime instead of bare RTF

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ Every number below comes from a tracked, privacy-safe benchmark record in this r
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/charts/rtf-by-mode-dark.svg">
-  <img alt="Grouped bar chart: warm real-time factors for Custom Voice (1.68 to 1.83), Voice Design (1.78 to 1.94), and Voice Cloning (1.49 to 1.84), all beyond the realtime line at 1.0" src="docs/charts/rtf-by-mode-light.svg">
+  <img alt="Grouped bar chart: warm generation speed for Custom Voice (1.68× to 1.83× realtime), Voice Design (1.78× to 1.94×), and Voice Cloning (1.49× to 1.84×), all beyond the realtime line at 1.0×" src="docs/charts/rtf-by-mode-light.svg">
 </picture>
 
 Vocello 2.2 also changed how the app behaves *while* it generates: translucent interface surfaces temporarily render as solid fills so the compositor stops competing with the engine. Same machine, same take, about a third faster:
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/charts/gate-delta-dark.svg">
-  <img alt="Paired bar chart: the same warm Custom take at real-time factor 1.37 before the generation performance gate and 1.83 with it, a 33 percent improvement" src="docs/charts/gate-delta-light.svg">
+  <img alt="Paired bar chart: the same warm Custom take at 1.37× realtime before the generation performance gate and 1.83× with it, a 33 percent improvement" src="docs/charts/gate-delta-light.svg">
 </picture>
 
 The full methodology, hardware profiles, and every published record live in [`benchmarks/HISTORY.md`](benchmarks/HISTORY.md) and [`docs/reference/benchmarking-procedure.md`](docs/reference/benchmarking-procedure.md); the charts above regenerate deterministically from the named records via `scripts/generate_readme_charts.py`.
@@ -229,7 +229,7 @@ echo "Hello there." | build/vocello generate --variant speed --stream --json
 
 The CLI supports single generation, mode shortcuts, batches, saved voices, speaker and model discovery, model installation, and benchmark matrices. Standard output is machine-readable; progress is written to standard error. See [`docs/reference/cli.md`](docs/reference/cli.md).
 
-> **Reproducing the benchmark numbers:** `./scripts/build.sh cli` produces an unoptimized development build that lands around RTF 1.0. The published figures come from the optimized Release path, and the two build topologies are not comparable; see the like-for-like rules in [`docs/reference/benchmarking-procedure.md`](docs/reference/benchmarking-procedure.md).
+> **Reproducing the benchmark numbers:** `./scripts/build.sh cli` produces an unoptimized development build that lands around 1.0× realtime. The published figures come from the optimized Release path, and the two build topologies are not comparable; see the like-for-like rules in [`docs/reference/benchmarking-procedure.md`](docs/reference/benchmarking-procedure.md).
 
 ## Contributing
 

--- a/docs/charts/gate-delta-dark.svg
+++ b/docs/charts/gate-delta-dark.svg
@@ -7,10 +7,10 @@
 <text x="400.0" y="62.0" fill="#9198a1" font-size="10" font-weight="normal" text-anchor="middle">realtime</text>
 <text x="202.0" y="91.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="end">before the gate (2.1 pipeline)</text>
 <path d="M210.0 78.0 h257.2 a4 4 0 0 1 4 4 v10.0 a4 4 0 0 1 -4 4 h-257.2 z" fill="#484f58"/>
-<text x="477.2" y="91.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.37</text>
+<text x="477.2" y="91.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.37×</text>
 <text x="202.0" y="123.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="end">with the gate (2.2)</text>
 <path d="M210.0 110.0 h343.6 a4 4 0 0 1 4 4 v10.0 a4 4 0 0 1 -4 4 h-343.6 z" fill="#BE8A24"/>
-<text x="563.6" y="123.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.83</text>
+<text x="563.6" y="123.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.83×</text>
 <text x="704.0" y="182.0" fill="#9198a1" font-size="10" font-weight="normal" text-anchor="end">records 9b6f267b → d02005ae</text>
 </g>
 </svg>

--- a/docs/charts/gate-delta-light.svg
+++ b/docs/charts/gate-delta-light.svg
@@ -7,10 +7,10 @@
 <text x="400.0" y="62.0" fill="#656d76" font-size="10" font-weight="normal" text-anchor="middle">realtime</text>
 <text x="202.0" y="91.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="end">before the gate (2.1 pipeline)</text>
 <path d="M210.0 78.0 h257.2 a4 4 0 0 1 4 4 v10.0 a4 4 0 0 1 -4 4 h-257.2 z" fill="#afb8c1"/>
-<text x="477.2" y="91.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.37</text>
+<text x="477.2" y="91.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.37×</text>
 <text x="202.0" y="123.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="end">with the gate (2.2)</text>
 <path d="M210.0 110.0 h343.6 a4 4 0 0 1 4 4 v10.0 a4 4 0 0 1 -4 4 h-343.6 z" fill="#8A6410"/>
-<text x="563.6" y="123.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.83</text>
+<text x="563.6" y="123.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.83×</text>
 <text x="704.0" y="182.0" fill="#656d76" font-size="10" font-weight="normal" text-anchor="end">records 9b6f267b → d02005ae</text>
 </g>
 </svg>

--- a/docs/charts/rtf-by-mode-dark.svg
+++ b/docs/charts/rtf-by-mode-dark.svg
@@ -1,46 +1,46 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="720" height="428" viewBox="0 0 720 428" role="img">
 <g font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif">
 <text x="16.0" y="28.0" fill="#e6edf3" font-size="16" font-weight="600" text-anchor="start">Faster than playback in every mode</text>
-<text x="16.0" y="47.0" fill="#9198a1" font-size="12" font-weight="normal" text-anchor="start">Warm real-time factor (RTF, higher is better) · Mac mini M2, 8 GB</text>
+<text x="16.0" y="47.0" fill="#9198a1" font-size="12" font-weight="normal" text-anchor="start">Warm generation speed, multiples of realtime (higher is faster) · Mac mini M2, 8 GB</text>
 <line x1="241.5" y1="64.0" x2="241.5" y2="388" stroke="#30363d" stroke-width="1" stroke-dasharray="3 3"/>
-<text x="241.5" y="406.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="middle">0.5</text>
+<text x="241.5" y="406.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="middle">0.5×</text>
 <line x1="373.0" y1="64.0" x2="373.0" y2="388" stroke="#9198a1" stroke-width="1"/>
-<text x="373.0" y="406.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="middle">1.0 · realtime</text>
+<text x="373.0" y="406.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="middle">1.0× · realtime</text>
 <line x1="504.5" y1="64.0" x2="504.5" y2="388" stroke="#30363d" stroke-width="1" stroke-dasharray="3 3"/>
-<text x="504.5" y="406.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="middle">1.5</text>
+<text x="504.5" y="406.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="middle">1.5×</text>
 <circle cx="22" cy="80.0" r="5" fill="#BE8A24"/>
 <text x="32.0" y="84.0" fill="#e6edf3" font-size="13" font-weight="600" text-anchor="start">Custom Voice</text>
 <text x="102.0" y="106.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="end">short</text>
 <path d="M110.0 94.0 h438.9 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-438.9 z" fill="#BE8A24"/>
-<text x="558.9" y="106.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.68</text>
+<text x="558.9" y="106.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.68×</text>
 <text x="102.0" y="128.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="end">medium</text>
 <path d="M110.0 116.0 h473.6 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-473.6 z" fill="#BE8A24"/>
-<text x="593.6" y="128.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.82</text>
+<text x="593.6" y="128.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.82×</text>
 <text x="102.0" y="150.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="end">long</text>
 <path d="M110.0 138.0 h477.1 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-477.1 z" fill="#BE8A24"/>
-<text x="597.1" y="150.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.83</text>
+<text x="597.1" y="150.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.83×</text>
 <circle cx="22" cy="182.0" r="5" fill="#9070E6"/>
 <text x="32.0" y="186.0" fill="#e6edf3" font-size="13" font-weight="600" text-anchor="start">Voice Design</text>
 <text x="102.0" y="208.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="end">short</text>
 <path d="M110.0 196.0 h465.2 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-465.2 z" fill="#9070E6"/>
-<text x="585.2" y="208.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.78</text>
+<text x="585.2" y="208.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.78×</text>
 <text x="102.0" y="230.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="end">medium</text>
 <path d="M110.0 218.0 h497.1 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-497.1 z" fill="#9070E6"/>
-<text x="617.1" y="230.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.91</text>
+<text x="617.1" y="230.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.91×</text>
 <text x="102.0" y="252.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="end">long</text>
 <path d="M110.0 240.0 h505.3 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-505.3 z" fill="#9070E6"/>
-<text x="625.3" y="252.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.94</text>
+<text x="625.3" y="252.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.94×</text>
 <circle cx="22" cy="284.0" r="5" fill="#E26034"/>
 <text x="32.0" y="288.0" fill="#e6edf3" font-size="13" font-weight="600" text-anchor="start">Voice Cloning</text>
 <text x="102.0" y="310.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="end">short</text>
 <path d="M110.0 298.0 h387.5 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-387.5 z" fill="#E26034"/>
-<text x="507.5" y="310.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.49</text>
+<text x="507.5" y="310.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.49×</text>
 <text x="102.0" y="332.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="end">medium</text>
 <path d="M110.0 320.0 h439.7 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-439.7 z" fill="#E26034"/>
-<text x="559.7" y="332.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.69</text>
+<text x="559.7" y="332.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.69×</text>
 <text x="102.0" y="354.0" fill="#9198a1" font-size="11" font-weight="normal" text-anchor="end">long</text>
 <path d="M110.0 342.0 h478.8 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-478.8 z" fill="#E26034"/>
-<text x="598.8" y="354.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.84</text>
+<text x="598.8" y="354.0" fill="#e6edf3" font-size="11" font-weight="normal" text-anchor="start">1.84×</text>
 <text x="704.0" y="422.0" fill="#9198a1" font-size="10" font-weight="normal" text-anchor="end">record d02005ae · benchmarks/HISTORY.md</text>
 </g>
 </svg>

--- a/docs/charts/rtf-by-mode-light.svg
+++ b/docs/charts/rtf-by-mode-light.svg
@@ -1,46 +1,46 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="720" height="428" viewBox="0 0 720 428" role="img">
 <g font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif">
 <text x="16.0" y="28.0" fill="#1f2328" font-size="16" font-weight="600" text-anchor="start">Faster than playback in every mode</text>
-<text x="16.0" y="47.0" fill="#656d76" font-size="12" font-weight="normal" text-anchor="start">Warm real-time factor (RTF, higher is better) · Mac mini M2, 8 GB</text>
+<text x="16.0" y="47.0" fill="#656d76" font-size="12" font-weight="normal" text-anchor="start">Warm generation speed, multiples of realtime (higher is faster) · Mac mini M2, 8 GB</text>
 <line x1="241.5" y1="64.0" x2="241.5" y2="388" stroke="#d1d9e0" stroke-width="1" stroke-dasharray="3 3"/>
-<text x="241.5" y="406.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="middle">0.5</text>
+<text x="241.5" y="406.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="middle">0.5×</text>
 <line x1="373.0" y1="64.0" x2="373.0" y2="388" stroke="#656d76" stroke-width="1"/>
-<text x="373.0" y="406.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="middle">1.0 · realtime</text>
+<text x="373.0" y="406.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="middle">1.0× · realtime</text>
 <line x1="504.5" y1="64.0" x2="504.5" y2="388" stroke="#d1d9e0" stroke-width="1" stroke-dasharray="3 3"/>
-<text x="504.5" y="406.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="middle">1.5</text>
+<text x="504.5" y="406.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="middle">1.5×</text>
 <circle cx="22" cy="80.0" r="5" fill="#8A6410"/>
 <text x="32.0" y="84.0" fill="#1f2328" font-size="13" font-weight="600" text-anchor="start">Custom Voice</text>
 <text x="102.0" y="106.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="end">short</text>
 <path d="M110.0 94.0 h438.9 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-438.9 z" fill="#8A6410"/>
-<text x="558.9" y="106.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.68</text>
+<text x="558.9" y="106.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.68×</text>
 <text x="102.0" y="128.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="end">medium</text>
 <path d="M110.0 116.0 h473.6 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-473.6 z" fill="#8A6410"/>
-<text x="593.6" y="128.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.82</text>
+<text x="593.6" y="128.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.82×</text>
 <text x="102.0" y="150.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="end">long</text>
 <path d="M110.0 138.0 h477.1 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-477.1 z" fill="#8A6410"/>
-<text x="597.1" y="150.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.83</text>
+<text x="597.1" y="150.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.83×</text>
 <circle cx="22" cy="182.0" r="5" fill="#6C47C8"/>
 <text x="32.0" y="186.0" fill="#1f2328" font-size="13" font-weight="600" text-anchor="start">Voice Design</text>
 <text x="102.0" y="208.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="end">short</text>
 <path d="M110.0 196.0 h465.2 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-465.2 z" fill="#6C47C8"/>
-<text x="585.2" y="208.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.78</text>
+<text x="585.2" y="208.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.78×</text>
 <text x="102.0" y="230.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="end">medium</text>
 <path d="M110.0 218.0 h497.1 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-497.1 z" fill="#6C47C8"/>
-<text x="617.1" y="230.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.91</text>
+<text x="617.1" y="230.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.91×</text>
 <text x="102.0" y="252.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="end">long</text>
 <path d="M110.0 240.0 h505.3 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-505.3 z" fill="#6C47C8"/>
-<text x="625.3" y="252.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.94</text>
+<text x="625.3" y="252.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.94×</text>
 <circle cx="22" cy="284.0" r="5" fill="#B4471B"/>
 <text x="32.0" y="288.0" fill="#1f2328" font-size="13" font-weight="600" text-anchor="start">Voice Cloning</text>
 <text x="102.0" y="310.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="end">short</text>
 <path d="M110.0 298.0 h387.5 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-387.5 z" fill="#B4471B"/>
-<text x="507.5" y="310.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.49</text>
+<text x="507.5" y="310.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.49×</text>
 <text x="102.0" y="332.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="end">medium</text>
 <path d="M110.0 320.0 h439.7 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-439.7 z" fill="#B4471B"/>
-<text x="559.7" y="332.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.69</text>
+<text x="559.7" y="332.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.69×</text>
 <text x="102.0" y="354.0" fill="#656d76" font-size="11" font-weight="normal" text-anchor="end">long</text>
 <path d="M110.0 342.0 h478.8 a4 4 0 0 1 4 4 v8.0 a4 4 0 0 1 -4 4 h-478.8 z" fill="#B4471B"/>
-<text x="598.8" y="354.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.84</text>
+<text x="598.8" y="354.0" fill="#1f2328" font-size="11" font-weight="normal" text-anchor="start">1.84×</text>
 <text x="704.0" y="422.0" fill="#656d76" font-size="10" font-weight="normal" text-anchor="end">record d02005ae · benchmarks/HISTORY.md</text>
 </g>
 </svg>

--- a/docs/reference/macos-release-qa.md
+++ b/docs/reference/macos-release-qa.md
@@ -121,6 +121,18 @@ upload depend on deterministic release-readiness and artifact checks.
    within the contract's six-hour freshness window. A manually written PASS file, stale ledger,
    missing step, changed untracked source file, or mixed invocation fails before publication.
 
+## Outward-facing performance terminology
+
+Public prose — release notes in `docs/releases/`, the GitHub Release body, the README, and the
+website — states generation throughput as a **speed multiple of realtime**: "1.8× realtime",
+"past 1.0× realtime", higher is faster. Do not present a bare "RTF" number on those surfaces.
+Much of the TTS ecosystem defines RTF as wall-clock time ÷ audio duration (lower is better),
+the inverse of this repository's `audioSecondsPerWallSecond`, so an unglossed "RTF 1.1" reads
+as slower than realtime to outside readers. If "RTF" must appear in public prose, define it
+inline as audio seconds per wall-clock second. Internal surfaces are unchanged: the telemetry
+key `audioSecondsPerWallSecond`, benchmark-record `rtf` fields, `benchmarks/HISTORY.md`, and
+baseline comparisons keep the higher-is-better metric and name.
+
 ## Known-cosmetic non-bugs (do not file)
 
 - Post-retirement readiness note briefly shows "Preparing Custom Voice" (§G residual; no connection

--- a/scripts/generate_readme_charts.py
+++ b/scripts/generate_readme_charts.py
@@ -121,7 +121,7 @@ def rtf_chart(theme_name: str) -> str:
 
     parts = svg_open(width, height)
     parts.append(text(16, 28, "Faster than playback in every mode", fill=theme["ink"], size=16, weight="600"))
-    parts.append(text(16, 47, "Warm real-time factor (RTF, higher is better) · Mac mini M2, 8 GB",
+    parts.append(text(16, 47, "Warm generation speed, multiples of realtime (higher is faster) · Mac mini M2, 8 GB",
                       fill=theme["muted"], size=12))
 
     bar_h, in_gap, group_gap = 16.0, 6.0, 26.0
@@ -135,7 +135,7 @@ def rtf_chart(theme_name: str) -> str:
             f'<line x1="{gx:.1f}" y1="{top:.1f}" x2="{gx:.1f}" y2="{height - 40}" '
             f'stroke="{stroke}" stroke-width="1"{dash}/>'
         )
-        label = "1.0 · realtime" if emphasized else f"{grid_value:.1f}"
+        label = "1.0× · realtime" if emphasized else f"{grid_value:.1f}×"
         parts.append(text(gx, height - 22, label, fill=theme["muted"], size=11, anchor="middle"))
 
     for mode in MODES:
@@ -151,7 +151,7 @@ def rtf_chart(theme_name: str) -> str:
                 f'<path d="M{x0:.1f} {y:.1f} h{bw - 4:.1f} a4 4 0 0 1 4 4 v{bar_h - 8:.1f} '
                 f'a4 4 0 0 1 -4 4 h-{bw - 4:.1f} z" fill="{color}"/>'
             )
-            parts.append(text(x0 + bw + 6, y + bar_h - 4, f"{value:.2f}", fill=theme["ink"], size=11))
+            parts.append(text(x0 + bw + 6, y + bar_h - 4, f"{value:.2f}×", fill=theme["ink"], size=11))
             y += bar_h + in_gap
         y += group_gap - in_gap
     parts.append(text(width - 16, height - 6,
@@ -198,7 +198,7 @@ def gate_chart(theme_name: str) -> str:
             f'<path d="M{x0:.1f} {y:.1f} h{bw - 4:.1f} a4 4 0 0 1 4 4 v{bar_h - 8:.1f} '
             f'a4 4 0 0 1 -4 4 h-{bw - 4:.1f} z" fill="{color}"/>'
         )
-        parts.append(text(x0 + bw + 6, y + bar_h - 5, f"{value:.2f}", fill=theme["ink"], size=11))
+        parts.append(text(x0 + bw + 6, y + bar_h - 5, f"{value:.2f}×", fill=theme["ink"], size=11))
         y += bar_h + 14.0
     parts.append(text(width - 16, height - 8,
                       f"records {RECORDS['pre'][-8:]} → {RECORDS['post'][-8:]}",

--- a/website/src/sections/Performance.jsx
+++ b/website/src/sections/Performance.jsx
@@ -47,7 +47,7 @@ const RtfChart = () => {
             d={`M${x0} ${y} h${bw - 4} a4 4 0 0 1 4 4 v${barH - 8} a4 4 0 0 1 -4 4 h-${bw - 4} z`}
             fill={mode.tone}
           />
-          <text x={x0 + bw + 7} y={y + barH - 3} className="perf-value">{value.toFixed(2)}</text>
+          <text x={x0 + bw + 7} y={y + barH - 3} className="perf-value">{`${value.toFixed(2)}×`}</text>
         </g>
       );
       y += barH + inGap;
@@ -64,7 +64,7 @@ const RtfChart = () => {
         strokeDasharray={v === 1.0 ? "" : "3 3"}
       />
       <text x={xFor(v)} y={plotBottom + 18} textAnchor="middle" className="perf-tick">
-        {v === 1.0 ? "1.0 · realtime" : v.toFixed(1)}
+        {v === 1.0 ? "1.0× · realtime" : `${v.toFixed(1)}×`}
       </text>
     </g>
   ));
@@ -73,7 +73,7 @@ const RtfChart = () => {
       className="perf-chart"
       viewBox={`0 0 ${width} ${plotBottom + 30}`}
       role="img"
-      aria-label="Warm real-time factors by mode and script length. Custom Voice 1.68 to 1.83, Voice Design 1.78 to 1.94, Voice Cloning 1.49 to 1.84. Every bar passes the realtime line at 1.0."
+      aria-label="Warm generation speed by mode and script length, as a multiple of realtime. Custom Voice 1.68× to 1.83×, Voice Design 1.78× to 1.94×, Voice Cloning 1.49× to 1.84×. Every bar passes the realtime line at 1.0×."
     >
       {gridlines}
       {rows}
@@ -96,7 +96,7 @@ const GateBars = () => {
       className="perf-chart perf-chart--gate"
       viewBox={`0 0 ${width} 96`}
       role="img"
-      aria-label="The same warm Custom take: real-time factor 1.37 on Vocello 2.1 and 1.83 on 2.2."
+      aria-label="The same warm Custom take: 1.37× realtime on Vocello 2.1 and 1.83× on 2.2."
     >
       <line x1={xFor(1.0)} y1={6} x2={xFor(1.0)} y2={78} stroke="var(--fg-tertiary)" strokeWidth="1" />
       <text x={xFor(1.0)} y={94} textAnchor="middle" className="perf-tick">realtime</text>
@@ -110,7 +110,7 @@ const GateBars = () => {
               d={`M${x0} ${y} h${bw - 4} a4 4 0 0 1 4 4 v${barH - 8} a4 4 0 0 1 -4 4 h-${bw - 4} z`}
               fill={row.tone}
             />
-            <text x={x0 + bw + 7} y={y + barH - 3} className="perf-value">{row.value.toFixed(2)}</text>
+            <text x={x0 + bw + 7} y={y + barH - 3} className="perf-value">{`${row.value.toFixed(2)}×`}</text>
           </g>
         );
       })}
@@ -126,8 +126,8 @@ export const Performance = () => (
         <h2 id="perf-title" className="section-title">Generation outpaces playback on the minimum Mac.</h2>
         <p className="section-sub">
           Vocello is benchmarked on its own support floor, a Mac mini M2 with 8 GB.
-          A real-time factor above 1.0 means audio generates faster than it plays,
-          and every number here traces to a tracked record in the open repository.
+          Speeds are multiples of realtime: past 1.0×, audio generates faster than
+          it plays, and every number here traces to a tracked record in the open repository.
         </p>
       </header>
 


### PR DESCRIPTION
## Summary

Vocello's RTF (`audioSecondsPerWallSecond`, higher is faster) is the inverse of the wall-clock ÷ audio-duration convention most of the TTS ecosystem uses (lower is faster), so bare "RTF 1.1" claims on public surfaces read as *slower than realtime* to outside readers comparing against Kokoro, Chatterbox, and similar projects. This change keeps the internal metric untouched and relabels the public surfaces to the unambiguous "N× realtime" phrasing:

- **README**: chart alt text and the CLI benchmark-reproduction note now say "1.68× to 1.83× realtime" / "around 1.0× realtime" instead of bare RTF numbers.
- **README charts** (`scripts/generate_readme_charts.py` + regenerated `docs/charts/*.svg`): subtitle now reads "Warm generation speed, multiples of realtime (higher is faster)"; bar values and axis ticks carry the "×" suffix.
- **Website** (`website/src/sections/Performance.jsx`): section copy, bar value labels, axis ticks, and both SVG aria-labels use the "N×" phrasing ("Speeds are multiples of realtime: past 1.0×, audio generates faster than it plays").
- **`docs/reference/macos-release-qa.md`**: new "Outward-facing performance terminology" section records the rule for future release notes, the GitHub Release body, the README, and the website, and explicitly leaves internal telemetry keys, benchmark-record `rtf` fields, and history unchanged.

## Verification

- [x] Relevant deterministic repository checks pass: website `lint` + `test` (7/7) + production build pass; `scripts/tests/test_generate_readme_charts.py` passes (4/4); `python3 scripts/refresh_derived_artifacts.py status` reports readme-charts, documentation-index, and model-catalog fresh. The macOS-only script self-tests could not run on this Linux worker (no `swift` toolchain); CI's full suite on macos-26 is the backstop.
- [x] Generated project or indexes were regenerated and checked when their inputs changed: `docs/charts/*.svg` regenerated from the updated generator against the same tracked benchmark records.
- [x] Model-, device-, and UI-dependent QA is listed separately and is not treated as a publishing prerequisite: none required; this is a docs/labels-only change with no runtime effect.

## Documentation impact

- [x] Active docs and role guidance still match source, `project.yml`, scripts, and machine-readable contracts: the terminology rule is documented in `macos-release-qa.md`; no contract changes.
- [x] Vendor-runtime changes update `VENDOR_MANIFEST.json`, `PATCHES.json`, tests, and current guidance as applicable: no vendor-runtime changes.
- [x] Telemetry or benchmark schema changes received backend, affected-platform, and release/QA review: no schema changes; `audioSecondsPerWallSecond`, record `rtf` fields, and `benchmarks/HISTORY.md` are untouched.
- [x] Public product claims were checked against `config/public-product-facts.json`, the model contract, hardware profiles, and tracked benchmark evidence: all figures remain the medians from tracked records `d02005ae` and `9b6f267b`; only their presentation changed.
- [x] Historical snapshots remain clearly labelled and were not rewritten as active runbooks: published release notes in `docs/releases/` and research snapshots were deliberately left verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rpcLH9KAtErfC7JwsdYJf

---
_Generated by [Claude Code](https://claude.ai/code/session_012rpcLH9KAtErfC7JwsdYJf)_