### PR TITLE
docs: gloss RTF direction in benchmark history and historical release notes

### DIFF
--- a/benchmarks/HISTORY.md
+++ b/benchmarks/HISTORY.md
@@ -6,6 +6,10 @@ result bundles, and traces remain untracked. Earlier manual results are preserve
 [`LEGACY_HISTORY.md`](LEGACY_HISTORY.md) and are not treated as structured evidence.
 Schema-v1 records remain readable but are marked memory-contract-incomplete and are excluded
 from schema-v2 memory trends.
+RTF here is audio seconds ÷ wall-clock seconds (`audioSecondsPerWallSecond`): higher is
+faster, 1.1 ≈ 1.1× realtime, and a positive RTF trend is an improvement. Much of the TTS
+ecosystem defines RTF as the inverse (wall-clock ÷ audio, lower is better); convert before
+cross-project comparisons.
 
 ## engine-generation / ios / iphone-17-pro / config `3abbfd2f50ea`
 

--- a/docs/releases/v2.1.0.md
+++ b/docs/releases/v2.1.0.md
@@ -17,6 +17,11 @@ Released **2026-06-12**. Vocello 2.1.0 is a quality-and-performance release for 
 ## Headline themes
 
 - **8 GB Macs now generate faster than realtime** with Speed models (RTF past 1.0 on the floor-tier baseline).
+
+  > **Editor's note (2026-07-30):** RTF in these notes is audio seconds ÷ wall-clock seconds
+  > (higher is faster): RTF 1.1 ≈ 1.1× realtime. Much of the TTS ecosystem defines RTF as the
+  > inverse (wall-clock ÷ audio, lower is better) — convert before cross-project comparisons.
+  > Current releases state throughput as "N× realtime" instead.
 - **Voice library grew up** — record references with the Mac microphone, on-device transcription in all 10 languages, language-aware picker recommendations.
 - **Delivery and language accuracy** — preset rewrites, sampler-order fix, Latin-script auto-language fix, clone first-word fix.
 - **Reproducible generations** — variation control (Expressive / Balanced / Consistent), deterministic seeds, shared seed across batch lines.

--- a/docs/releases/v2.2.0.md
+++ b/docs/releases/v2.2.0.md
@@ -75,6 +75,10 @@ locally on Apple Silicon; no audio leaves the Mac unless you export it.
 
 Recorded per the standing release-candidate procedure (`docs/reference/macos-release-qa.md`):
 
+> **Editor's note (2026-07-30):** RTF below is audio seconds ÷ wall-clock seconds (higher is
+> faster): RTF 1.80 ≈ 1.80× realtime. Much of the TTS ecosystem defines RTF as the inverse
+> (lower is better) — convert before cross-project comparisons.
+
 - **macOS smoke lane:** `macos-xcui-smoke-20260725-062451-8f15c1fd` — PASS, all seven
   journeys, including the scaled long-form run below.
 - **Engine regression bench:** label `release-QA-2.2.0`

--- a/scripts/benchmark_history.py
+++ b/scripts/benchmark_history.py
@@ -2586,6 +2586,10 @@ def render_history(records: list[tuple[Path, dict[str, Any]]]) -> str:
         "[`LEGACY_HISTORY.md`](LEGACY_HISTORY.md) and are not treated as structured evidence.",
         "Schema-v1 records remain readable but are marked memory-contract-incomplete and are excluded",
         "from schema-v2 memory trends.",
+        "RTF here is audio seconds ÷ wall-clock seconds (`audioSecondsPerWallSecond`): higher is",
+        "faster, 1.1 ≈ 1.1× realtime, and a positive RTF trend is an improvement. Much of the TTS",
+        "ecosystem defines RTF as the inverse (wall-clock ÷ audio, lower is better); convert before",
+        "cross-project comparisons.",
         "",
     ]
     if not grouped:


### PR DESCRIPTION
## Summary

Follow-up to #89, closing the two residual RTF-ambiguity surfaces:

- **`benchmarks/HISTORY.md`** (via `scripts/benchmark_history.py`): the generated header now carries a legend defining RTF as audio seconds ÷ wall-clock seconds (`audioSecondsPerWallSecond`, higher is faster, positive trend = improvement) and warning that much of the TTS ecosystem uses the inverse convention.
- **`docs/releases/v2.1.0.md` and `docs/releases/v2.2.0.md`**: dated editor's notes beside the RTF figures with the same conversion guidance. The original historical wording is unchanged — the notes are additions, following the repo's existing editor's-note precedent for historical documents.

## Verification

- [x] Relevant deterministic repository checks pass: `benchmark_history.py validate --all` (118 records PASS) and `rebuild-index` succeed; `test_benchmark_history` has no header-text assertions, and its only local errors are the macOS-toolchain-absent (`swift`/`xcrun`) environment class, pre-existing on this Linux worker.
- [x] Generated project or indexes were regenerated and checked when their inputs changed: `benchmarks/HISTORY.md` regenerated from the updated renderer in the same change.
- [x] Model-, device-, and UI-dependent QA is listed separately and is not treated as a publishing prerequisite: none applicable; docs/generator-text only.

## Documentation impact

- [x] Active docs and role guidance still match source, `project.yml`, scripts, and machine-readable contracts: no contract or schema changes.
- [x] Vendor-runtime changes update `VENDOR_MANIFEST.json`, `PATCHES.json`, tests, and current guidance as applicable: no vendor-runtime changes.
- [x] Telemetry or benchmark schema changes received backend, affected-platform, and release/QA review: record schemas and fields untouched; only the generated index's prose header changed.
- [x] Public product claims were checked against `config/public-product-facts.json`, the model contract, hardware profiles, and tracked benchmark evidence: no figures changed; only definitions were added beside existing ones.
- [x] Historical snapshots remain clearly labelled and were not rewritten as active runbooks: the release notes keep their original text verbatim; the additions are dated editor's notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rpcLH9KAtErfC7JwsdYJf

---
_Generated by [Claude Code](https://claude.ai/code/session_012rpcLH9KAtErfC7JwsdYJf)_