### PR TITLE
chore(deps): bump swift-transformers 1.1.9 → 1.3.3 with the full pin contract set

### DIFF
--- a/Packages/VocelloQwen3Core/COMPATIBILITY.json
+++ b/Packages/VocelloQwen3Core/COMPATIBILITY.json
@@ -25,7 +25,7 @@
       "mlx-swift": "0.31.6",
       "mlx-swift-lm": "3.31.4",
       "swift-huggingface": "0.9.0",
-      "swift-transformers": "1.1.9"
+      "swift-transformers": "1.3.3"
     },
     "benchmarkNeutralResolvedDependencies": {
       "swift-nio": "Transitive EventSource transport primitives do not participate in prepared Qwen model loading, tokenization, or synthesis; lockstep, security-baseline, and deterministic build checks still apply."

--- a/Packages/VocelloQwen3Core/CURRENT_INVENTORY.json
+++ b/Packages/VocelloQwen3Core/CURRENT_INVENTORY.json
@@ -208,7 +208,7 @@
     },
     {
       "path": "Package.swift",
-      "sha256": "75f7a2abb7007e54d93016d73aa13a613d2c1f8b0b05d8cbae0816ab294958e7",
+      "sha256": "16c54187348f033034ad5b662dd0f058fbd29410c689bbe7fc88a839cb695c57",
       "upstreamStatus": "modified"
     },
     {

--- a/Packages/VocelloQwen3Core/Package.resolved
+++ b/Packages/VocelloQwen3Core/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "75f7a2abb7007e54d93016d73aa13a613d2c1f8b0b05d8cbae0816ab294958e7",
+  "originHash" : "3417e662590be3aa1bcf8c0ce19fdc627848c6bf4ad76d087b19ecd9f3d17461",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
-        "version" : "1.1.9"
+        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
+        "version" : "1.3.3"
       }
     },
     {

--- a/Packages/VocelloQwen3Core/Package.swift
+++ b/Packages/VocelloQwen3Core/Package.swift
@@ -30,9 +30,12 @@ let package = Package(
         .package(url: "https://github.com/ml-explore/mlx-swift-lm.git", exact: "3.31.4"),
         .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.9.0"),
         // mlx-swift-lm 3.x dropped its swift-transformers dependency; the app now brings the
-        // concrete Hub/Tokenizers implementation. Pinned to the exact version the 2.30.6 graph
-        // resolved so tokenizer behavior stays identical across the pin-bump A/B.
-        .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "1.1.9")
+        // concrete Hub/Tokenizers implementation. Exact-pinned because tokenizer behavior is
+        // engine behavior: 1.3.3 (from 1.1.9, 2026-08-05) deliberately changes BPE/Unigram
+        // tokenization (Unicode-scalar merges, NFD fixes) and speeds up encode 5-25x, so the
+        // bump carried the benchmark battery instead of the byte-identity A/B; see
+        // benchmarks/HISTORY.md and the pin-bump procedure in docs/reference/mlx-guide.md §9.
+        .package(url: "https://github.com/huggingface/swift-transformers.git", exact: "1.3.3")
     ],
     targets: [
         // MARK: - VocelloQwen3Core

--- a/QwenVoice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/QwenVoice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
-        "version" : "1.1.9"
+        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
+        "version" : "1.3.3"
       }
     },
     {

--- a/scripts/tests/test_vendor_runtime_contract.py
+++ b/scripts/tests/test_vendor_runtime_contract.py
@@ -434,16 +434,23 @@ public func stableFacadeEntryPoint() -> Bool { true }
         record = records["macos-xcui-benchmark-20260801-182943-b0b5a448"]
         git_blob = MODULE.git_blob
 
+        # Tree-independence: synthesize the "historical" package manifest and
+        # lockfile from the CURRENT tree so the only difference is the injected
+        # neutral drift. Reading them from the record's real commit made the
+        # test break on every legitimate non-neutral pin bump (first hit:
+        # swift-transformers 1.3.3), which is the contract working — not the
+        # property under test here.
         def blob_with_neutral_drift(repo_root: Path, commit: str, path: Path) -> bytes | None:
-            blob = git_blob(repo_root, commit, path)
-            if path.name == "Package.resolved" and blob is not None:
-                payload = json.loads(blob)
+            if path.name == "Package.swift":
+                return (runtime / "Package.swift").read_bytes()
+            if path.name == "Package.resolved":
+                payload = json.loads((runtime / "Package.resolved").read_bytes())
                 for pin in payload["pins"]:
                     if pin["identity"] == "swift-nio":
                         pin["state"] = {"revision": "0" * 40, "version": "2.99.0"}
                         break
                 return json.dumps(payload, sort_keys=True).encode("utf-8")
-            return blob
+            return git_blob(repo_root, commit, path)
 
         with mock.patch.object(MODULE, "git_blob", side_effect=blob_with_neutral_drift):
             self.assertTrue(
@@ -471,15 +478,17 @@ public func stableFacadeEntryPoint() -> Bool { true }
                     commit: str,
                     path: Path,
                 ) -> bytes | None:
-                    blob = git_blob(repo_root, commit, path)
-                    if path.name == "Package.resolved" and blob is not None:
-                        payload = json.loads(blob)
+                    # Same tree-independence as the neutral-drift test above.
+                    if path.name == "Package.swift":
+                        return (runtime / "Package.swift").read_bytes()
+                    if path.name == "Package.resolved":
+                        payload = json.loads((runtime / "Package.resolved").read_bytes())
                         for pin in payload["pins"]:
                             if pin["identity"] == "swift-nio":
                                 pin[field] = value
                                 break
                         return json.dumps(payload, sort_keys=True).encode("utf-8")
-                    return blob
+                    return git_blob(repo_root, commit, path)
 
                 with mock.patch.object(MODULE, "git_blob", side_effect=blob_with_source_drift):
                     self.assertFalse(


### PR DESCRIPTION
Supersedes #93 (dependabot), which could not carry the pin contract (COMPATIBILITY.json, CURRENT_INVENTORY, workspace lockfile).

## What
- `Packages/VocelloQwen3Core/Package.swift`: exact pin 1.1.9 → 1.3.3, comment corrected to state the real rationale and evidence basis.
- Both `Package.resolved` files: revision `2fa33e1f` **verified against the upstream 1.3.3 tag** via the GitHub API.
- `COMPATIBILITY.json` + rebuilt `CURRENT_INVENTORY`.
- `swift-huggingface` stays at exact 0.9.0 (1.3.3 requires ≥0.8.1); mlx pair untouched.

## Why
1.3.2/1.3.3 fix real tokenization correctness (Unicode-scalar BPE merges, NFD, Japanese kana) and speed up encode substantially (Unigram ~15–25×, BPE merge 5–12×). The 1.2.0 Hub downloader swap is unused here — our only `HubApi` use parses local tokenizer configs; the fail-closed catalog owns downloads.

## Evidence (pin-bump procedure, mlx-guide §9.3)
- Full deterministic suite PASS, including owned-runtime tokenizer contracts; macOS build + iOS device-SDK compile PASS.
- Fixed-seed clone bench vs clean `release-QA-2.4.0`: **RTF improved** at every length (0.904/1.106/1.215 vs 0.947/1.142/1.238), **peak footprint improved** (2616/2876/3131 MB vs 2740/3520/3549), **audio QC pass** on all takes. TTFC ~75 ms higher (noted; outside the keep-criteria triple).
- macOS language quick hint gate **PASS 7/7** including JA/ZH cells (the paths the tokenizer fixes touch).
- Byte-identity A/B deliberately not claimed: the upstream changes alter tokenization by design; the quality battery replaces it. Branch-minted records dropped — the canonical bench record mints on main post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKEyjULPhcNEtmtt3M4AMJ